### PR TITLE
Add doctor upgrade coverage

### DIFF
--- a/profiles/doctor-upgrade.json
+++ b/profiles/doctor-upgrade.json
@@ -1,0 +1,51 @@
+{
+  "id": "doctor-upgrade",
+  "title": "Doctor Upgrade Matrix",
+  "objective": "Focused OpenClaw upgrade coverage for Doctor repair across old, meaningful config profiles tied to known breaking-change boundaries.",
+  "targetKinds": [
+    "local-build"
+  ],
+  "entries": [
+    {
+      "scenario": "doctor-repair-upgrade",
+      "state": "legacy-core-config-doctor-2026-4-24",
+      "timeoutMs": 300000
+    },
+    {
+      "scenario": "doctor-repair-upgrade",
+      "state": "legacy-plugin-config-doctor-2026-5-22",
+      "timeoutMs": 300000
+    },
+    {
+      "scenario": "doctor-repair-upgrade",
+      "state": "legacy-provider-config-doctor-2026-5-7",
+      "timeoutMs": 300000
+    },
+    {
+      "scenario": "doctor-repair-upgrade",
+      "state": "legacy-channel-config-doctor-2026-5-7",
+      "timeoutMs": 300000
+    },
+    {
+      "scenario": "doctor-repair-upgrade",
+      "state": "legacy-runtime-pin-doctor-2026-5-8",
+      "timeoutMs": 300000
+    }
+  ],
+  "purpose": "upgrade",
+  "gate": {
+    "id": "doctor-upgrade-gate",
+    "blocking": [
+      {
+        "scenario": "doctor-repair-upgrade"
+      }
+    ],
+    "coverage": {
+      "requirements": {
+        "blocking": [
+          "upgrade-existing-user:doctor-repair"
+        ]
+      }
+    }
+  }
+}

--- a/profiles/doctor-upgrade.json
+++ b/profiles/doctor-upgrade.json
@@ -35,11 +35,6 @@
   "purpose": "upgrade",
   "gate": {
     "id": "doctor-upgrade-gate",
-    "blocking": [
-      {
-        "scenario": "doctor-repair-upgrade"
-      }
-    ],
     "coverage": {
       "requirements": {
         "blocking": [

--- a/scenarios/doctor-repair-upgrade.json
+++ b/scenarios/doctor-repair-upgrade.json
@@ -1,0 +1,121 @@
+{
+  "id": "doctor-repair-upgrade",
+  "surface": "upgrade-existing-user",
+  "title": "Doctor Repair Upgrade",
+  "objective": "Clone a disposable old-version-shaped OpenClaw env, apply a legacy config fixture from a known breaking-change boundary, upgrade to the target runtime, run Doctor repair, and verify the repaired env keeps status, plugin, provider, and gateway health usable.",
+  "tags": [
+    "existing-user",
+    "upgrade",
+    "doctor",
+    "config",
+    "migration"
+  ],
+  "targetKinds": [
+    "local-build",
+    "release",
+    "runtime",
+    "npm"
+  ],
+  "auth": {
+    "mode": "skip"
+  },
+  "timeoutMs": 300000,
+  "thresholds": {
+    "upgradeMs": 180000,
+    "doctorFixMs": 60000,
+    "gatewayReadyMs": 60000,
+    "statusMs": 10000,
+    "pluginsListMs": 10000,
+    "modelsListMs": 20000,
+    "missingDependencyErrors": 0,
+    "pluginLoadFailures": 0
+  },
+  "phases": [
+    {
+      "id": "clone",
+      "title": "Clone Existing Env",
+      "intent": "Clone a durable existing env into a disposable Kova env before applying legacy config or upgrade actions.",
+      "commands": [
+        "ocm env clone {sourceEnv} {env} --json"
+      ],
+      "evidence": [
+        "clone result",
+        "source env",
+        "clone root"
+      ],
+      "healthScope": "none"
+    },
+    {
+      "id": "upgrade",
+      "title": "Upgrade To Target",
+      "intent": "Run the real target upgrade path through OCM after the legacy config state has been applied.",
+      "commands": [
+        "ocm upgrade {env} {upgradeSelector} --json"
+      ],
+      "evidence": [
+        "target upgrade JSON",
+        "snapshot id",
+        "doctor/update output",
+        "rollback status"
+      ],
+      "healthScope": "readiness"
+    },
+    {
+      "id": "doctor-repair",
+      "title": "Doctor Repair",
+      "intent": "Run Doctor repair and then run non-interactive Doctor again to prove repairable config validation errors are gone.",
+      "commands": [
+        "ocm @{env} -- doctor --fix --non-interactive",
+        "ocm @{env} -- doctor --non-interactive"
+      ],
+      "evidence": [
+        "doctor fix output",
+        "doctor clean output",
+        "no repairable config validation errors after fix"
+      ],
+      "healthScope": "post-ready"
+    },
+    {
+      "id": "post-repair-health",
+      "title": "Post-Repair Health",
+      "intent": "Verify the repaired env still supports core status, plugin discovery, model discovery, service health, and clean gateway logs.",
+      "commands": [
+        "ocm @{env} -- status",
+        "ocm @{env} -- plugins list",
+        "ocm @{env} -- models list"
+      ],
+      "evidence": [
+        "gateway state",
+        "OpenClaw status output",
+        "plugins list output",
+        "models list output",
+        "gateway logs without config validation loops, missing dependencies, or plugin load failures"
+      ],
+      "healthScope": "post-ready",
+      "collectionIntent": "post-ready-health"
+    }
+  ],
+  "evidenceContract": {
+    "snapshots": [
+      {
+        "id": "legacy-config-state",
+        "afterPhase": "clone",
+        "label": "Legacy config state after fixture setup",
+        "summary": "Captures the old config profile and Kova evidence marker before target upgrade.",
+        "required": true,
+        "maxFileBytes": 65536
+      },
+      {
+        "id": "post-doctor-config-state",
+        "afterPhase": "doctor-repair",
+        "label": "Post-Doctor config state",
+        "summary": "Captures the repaired config state after doctor --fix and doctor --non-interactive.",
+        "required": true,
+        "maxFileBytes": 65536
+      }
+    ]
+  },
+  "proves": [
+    "doctor-repair"
+  ]
+}

--- a/src/collectors/openclaw-state.mjs
+++ b/src/collectors/openclaw-state.mjs
@@ -27,6 +27,7 @@ const EXCLUDED_DIRS = new Set([
 ]);
 
 const KNOWN_FILES = [
+  ".openclaw/openclaw.json",
   "config.json",
   "settings.json",
   "providers.json",
@@ -37,6 +38,7 @@ const KNOWN_FILES = [
   "config/providers.json",
   "config/models.json",
   "config/auth.json",
+  "config/kova-doctor-upgrade-evidence.json",
   "config/version.json",
   "config/kova-source-release.json",
   "plugins/legacy-index.json",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -649,6 +649,7 @@ export async function runSelfCheck(flags = {}) {
     checks.push(gatePlatformCoverageCheck());
     checks.push(gateNonReleaseOutcomeCheck());
     checks.push(gateRequirementCoverageCheck());
+    checks.push(await doctorUpgradeGatePolicyCheck());
     checks.push(gateSubsystemSummaryCheck());
     checks.push(safetyGuardCheck());
     checks.push(await failingCommandCheck(
@@ -2666,6 +2667,66 @@ function gateRequirementCoverageCheck() {
       id: "gate-requirement-coverage",
       status: "FAIL",
       command: "evaluate synthetic release gate requirement coverage",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function doctorUpgradeGatePolicyCheck() {
+  try {
+    const profile = JSON.parse(await readFile("profiles/doctor-upgrade.json", "utf8"));
+    const states = [
+      "legacy-core-config-doctor-2026-4-24",
+      "legacy-plugin-config-doctor-2026-5-22",
+      "legacy-provider-config-doctor-2026-5-7",
+      "legacy-channel-config-doctor-2026-5-7",
+      "legacy-runtime-pin-doctor-2026-5-8"
+    ];
+    const records = states.map((state) => ({
+      scenario: "doctor-repair-upgrade",
+      surface: "upgrade-existing-user",
+      state: { id: state },
+      status: "PASS",
+      title: "Doctor Repair Upgrade",
+      likelyOwner: "OpenClaw",
+      phases: []
+    }));
+    const gate = evaluateGate({
+      mode: "execution",
+      controls: {
+        include: [],
+        exclude: []
+      },
+      records
+    }, profile, {
+      resolvedCoverage: {
+        obligations: records.map((record) => ({
+          surface: "upgrade-existing-user",
+          requirement: "doctor-repair",
+          scenario: record.scenario,
+          state: record.state.id,
+          status: "planned"
+        }))
+      }
+    });
+
+    assertEqual(gate.verdict, "SHIP", "doctor upgrade gate ships with all stateful records");
+    assertEqual(gate.complete, true, "doctor upgrade gate complete");
+    assertEqual(gate.missingRequiredCount, 0, "doctor upgrade gate no missing stateful records");
+    assertEqual(gate.required?.length, states.length, "doctor upgrade gate requires every state");
+
+    return {
+      id: "doctor-upgrade-gate-policy",
+      status: "PASS",
+      command: "evaluate synthetic doctor upgrade stateful gate policy",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "doctor-upgrade-gate-policy",
+      status: "FAIL",
+      command: "evaluate synthetic doctor upgrade stateful gate policy",
       durationMs: 0,
       message: error.message
     };

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -195,6 +195,7 @@ export async function runSelfCheck(flags = {}) {
     checks.push(provisioningBlockedStatusCheck());
     checks.push(cleanupProofRequiredCheck());
     checks.push(await openClawStateSnapshotCheck(tmp));
+    checks.push(await doctorUpgradeSnapshotEvidenceCheck(tmp));
     checks.push(upgradeStateSnapshotInvariantsCheck());
     checks.push(upgradeLogDerivedInvariantsCheck());
     checks.push(localBuildTargetSetupResourceExclusionCheck());
@@ -287,6 +288,22 @@ export async function runSelfCheck(flags = {}) {
     checks.push(await jsonCommandCheck("local-build-upgrade-plan-json", "node bin/kova.mjs matrix plan --profile local-build-upgrade --target local-build:/tmp/openclaw --include scenario:upgrade-stable-release-to-local-build --json", (data) => {
       assertEqual(data.profile?.id, "local-build-upgrade", "local-build upgrade profile id");
       assertEqual(data.entries?.[0]?.scenario?.id, "upgrade-stable-release-to-local-build", "local-build stable upgrade scenario");
+    }));
+    checks.push(await jsonCommandCheck("doctor-upgrade-plan-json", "node bin/kova.mjs matrix plan --profile doctor-upgrade --target local-build:/tmp/openclaw --json", (data) => {
+      assertEqual(data.profile?.id, "doctor-upgrade", "doctor upgrade profile id");
+      assertEqual(data.entries?.length, 5, "doctor upgrade state variety");
+      assertEqual(data.resolvedCoverage?.statuses?.planned, 5, "doctor upgrade resolved obligations");
+      assertEqual(data.resolvedCoverage?.gaps?.length, 0, "doctor upgrade coverage gaps");
+      const states = new Set(data.entries?.map((entry) => entry.state?.id));
+      for (const state of [
+        "legacy-core-config-doctor-2026-4-24",
+        "legacy-plugin-config-doctor-2026-5-22",
+        "legacy-provider-config-doctor-2026-5-7",
+        "legacy-channel-config-doctor-2026-5-7",
+        "legacy-runtime-pin-doctor-2026-5-8"
+      ]) {
+        assertEqual(states.has(state), true, `doctor upgrade includes ${state}`);
+      }
     }));
     checks.push(await jsonCommandCheck("release-upgrade-dry-run-json", `node bin/kova.mjs run --target release:beta --scenario upgrade-stable-release-to-beta --state stable-release-user --report-dir ${quoteShell(tmp)} --json`, async (data) => {
       const report = JSON.parse(await readFile(data.jsonPath, "utf8"));
@@ -2137,6 +2154,58 @@ async function openClawStateSnapshotCheck(tmp) {
       id: "openclaw-state-snapshot",
       status: "FAIL",
       command: "capture bounded redacted OpenClaw state snapshot",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function doctorUpgradeSnapshotEvidenceCheck(tmp) {
+  const home = join(tmp, "doctor-upgrade-snapshot-openclaw-home");
+  const state = "legacy-channel-config-doctor-2026-5-7";
+  try {
+    const writeResult = await runCommand(
+      `node support/write-doctor-upgrade-state.mjs --state ${quoteShell(state)}`,
+      {
+        env: { OPENCLAW_HOME: home },
+        timeoutMs: 30000
+      }
+    );
+    if (writeResult.status !== 0) {
+      throw new Error(`doctor fixture writer failed: ${writeResult.stderr || writeResult.stdout}`);
+    }
+
+    const captureResult = await runCommand(
+      `node support/capture-openclaw-state.mjs --home ${quoteShell(home)} --label doctor-fixture`,
+      {
+        timeoutMs: 30000,
+        maxOutputChars: 200000
+      }
+    );
+    if (captureResult.status !== 0) {
+      throw new Error(`doctor fixture snapshot failed: ${captureResult.stderr || captureResult.stdout}`);
+    }
+    const snapshot = JSON.parse(captureResult.stdout);
+    const files = new Set((snapshot.files ?? []).map((file) => file.path));
+    assertEqual(files.has(".openclaw/openclaw.json"), true, "doctor fixture snapshot includes legacy OpenClaw config");
+    assertEqual(files.has("config/kova-doctor-upgrade-evidence.json"), true, "doctor fixture snapshot includes Kova evidence marker");
+    assertEqual(
+      snapshot.config?.files?.includes("config/kova-doctor-upgrade-evidence.json"),
+      true,
+      "doctor fixture evidence marker is summarized as config"
+    );
+
+    return {
+      id: "doctor-upgrade-snapshot-evidence",
+      status: "PASS",
+      command: "write doctor fixture and capture OpenClaw state snapshot",
+      durationMs: writeResult.durationMs + captureResult.durationMs
+    };
+  } catch (error) {
+    return {
+      id: "doctor-upgrade-snapshot-evidence",
+      status: "FAIL",
+      command: "write doctor fixture and capture OpenClaw state snapshot",
       durationMs: 0,
       message: error.message
     };

--- a/states/legacy-channel-config-doctor-2026-5-7.json
+++ b/states/legacy-channel-config-doctor-2026-5-7.json
@@ -1,0 +1,43 @@
+{
+  "id": "legacy-channel-config-doctor-2026-5-7",
+  "title": "Legacy Channel Config Doctor 2026.5.7",
+  "objective": "A channel config with removed core channel schema and stale channel plugin state, used to verify plugin-owned Doctor repairs do not leave config validation failures.",
+  "tags": [
+    "channels",
+    "plugins",
+    "config",
+    "doctor",
+    "upgrade"
+  ],
+  "setup": [
+    {
+      "id": "write-legacy-channel-config",
+      "title": "Write Legacy Channel Config",
+      "intent": "Create stale channel config from channel schema and external plugin repair boundaries.",
+      "afterPhase": "clone",
+      "commands": [
+        "ocm env exec {env} -- node {kovaRoot}/support/write-doctor-upgrade-state.mjs --state legacy-channel-config-doctor-2026-5-7"
+      ],
+      "evidence": [
+        "legacy channel config exists",
+        "doctor upgrade evidence names PR #78612 and PR #78876",
+        "Feishu stale-state repair commit evidence is recorded"
+      ]
+    }
+  ],
+  "traits": [
+    "existing-user",
+    "migration-state",
+    "config-state"
+  ],
+  "riskArea": "channel-config-doctor-repair",
+  "ownerArea": "channels",
+  "setupEvidence": [
+    "config/kova-doctor-upgrade-evidence.json lists PR #78612, PR #78876, and commit b7c461af7b as breakage evidence",
+    ".openclaw/openclaw.json contains removed core BlueBubbles-style channel config",
+    ".openclaw/openclaw.json contains stale Feishu and Telegram channel config shapes"
+  ],
+  "cleanupGuarantees": [
+    "disposable env cleanup removes legacy channel config fixture files"
+  ]
+}

--- a/states/legacy-core-config-doctor-2026-4-24.json
+++ b/states/legacy-core-config-doctor-2026-4-24.json
@@ -1,0 +1,43 @@
+{
+  "id": "legacy-core-config-doctor-2026-4-24",
+  "title": "Legacy Core Config Doctor 2026.4.24",
+  "objective": "A 2026.4.24-shaped core config with stale gateway/runtime/model keys and a preserved user field, used to verify Doctor repairs stale core config without dropping unrelated user config.",
+  "tags": [
+    "config",
+    "doctor",
+    "upgrade",
+    "2026-4-24"
+  ],
+  "setup": [
+    {
+      "id": "write-legacy-core-config",
+      "title": "Write Legacy Core Config",
+      "intent": "Create stale core config keys from the 2026.4.24 plugin-architecture boundary and write evidence explaining the breaking-change risk.",
+      "afterPhase": "clone",
+      "commands": [
+        "ocm env exec {env} -- node {kovaRoot}/support/write-doctor-upgrade-state.mjs --state legacy-core-config-doctor-2026-4-24"
+      ],
+      "evidence": [
+        "legacy core config exists",
+        "doctor upgrade evidence names PR #78896 and PR #79203",
+        "source-release marker identifies 2026.4.24 plugin-architecture boundary"
+      ]
+    }
+  ],
+  "traits": [
+    "existing-user",
+    "old-release",
+    "migration-state",
+    "config-state"
+  ],
+  "riskArea": "core-config-doctor-repair",
+  "ownerArea": "gateway",
+  "setupEvidence": [
+    "config/kova-doctor-upgrade-evidence.json lists PR #78896 and PR #79203 as breakage evidence",
+    ".openclaw/openclaw.json contains legacy gateway_port, runtime.pi, and models.defaultProvider keys",
+    "config/kova-source-release.json marks release 2026.4.24"
+  ],
+  "cleanupGuarantees": [
+    "disposable env cleanup removes legacy core config fixture files"
+  ]
+}

--- a/states/legacy-plugin-config-doctor-2026-5-22.json
+++ b/states/legacy-plugin-config-doctor-2026-5-22.json
@@ -1,0 +1,43 @@
+{
+  "id": "legacy-plugin-config-doctor-2026-5-22",
+  "title": "Legacy Plugin Config Doctor 2026.5.22",
+  "objective": "A plugin config containing stale install index data and bundled plugin load paths, used to verify Doctor does not reintroduce plugin load-path loops and leaves plugins list/gateway startup clean.",
+  "tags": [
+    "plugins",
+    "config",
+    "doctor",
+    "upgrade"
+  ],
+  "setup": [
+    {
+      "id": "write-legacy-plugin-config",
+      "title": "Write Legacy Plugin Config",
+      "intent": "Create stale plugin install metadata and bundled plugin load paths tied to recent plugin Doctor regressions.",
+      "afterPhase": "clone",
+      "commands": [
+        "ocm env exec {env} -- node {kovaRoot}/support/write-doctor-upgrade-state.mjs --state legacy-plugin-config-doctor-2026-5-22"
+      ],
+      "evidence": [
+        "legacy plugin config exists",
+        "doctor upgrade evidence names issue #85334 and PR #85358",
+        "stale plugins/installs.json exists"
+      ]
+    }
+  ],
+  "traits": [
+    "existing-user",
+    "migration-state",
+    "config-state",
+    "plugin-pressure"
+  ],
+  "riskArea": "plugin-config-doctor-repair",
+  "ownerArea": "plugins",
+  "setupEvidence": [
+    "config/kova-doctor-upgrade-evidence.json lists issue #85334, PR #85358, and PR #85170 as breakage evidence",
+    ".openclaw/openclaw.json contains legacy plugins.load.paths pointing at bundled plugin directories",
+    "plugins/installs.json uses an older install-index shape"
+  ],
+  "cleanupGuarantees": [
+    "disposable env cleanup removes legacy plugin config fixture files"
+  ]
+}

--- a/states/legacy-provider-config-doctor-2026-5-7.json
+++ b/states/legacy-provider-config-doctor-2026-5-7.json
@@ -1,0 +1,44 @@
+{
+  "id": "legacy-provider-config-doctor-2026-5-7",
+  "title": "Legacy Provider Config Doctor 2026.5.7",
+  "objective": "A provider/model config with OpenAI Codex model refs and legacy compat fields, used to verify Doctor preserves runtime-specific model routing and model discovery remains coherent.",
+  "tags": [
+    "providers",
+    "models",
+    "config",
+    "doctor",
+    "upgrade"
+  ],
+  "setup": [
+    {
+      "id": "write-legacy-provider-config",
+      "title": "Write Legacy Provider Config",
+      "intent": "Create stale provider model refs and compat fields from recent Doctor/provider normalization regressions.",
+      "afterPhase": "clone",
+      "commands": [
+        "ocm env exec {env} -- node {kovaRoot}/support/write-doctor-upgrade-state.mjs --state legacy-provider-config-doctor-2026-5-7"
+      ],
+      "evidence": [
+        "legacy provider config exists",
+        "doctor upgrade evidence names PR #78967 and PR #78971",
+        "OpenAI Codex model refs are present before repair"
+      ]
+    }
+  ],
+  "traits": [
+    "existing-user",
+    "migration-state",
+    "config-state",
+    "provider-pressure"
+  ],
+  "riskArea": "provider-config-doctor-repair",
+  "ownerArea": "models",
+  "setupEvidence": [
+    "config/kova-doctor-upgrade-evidence.json lists PR #78967, PR #78971, and provider alias catalog commits as breakage evidence",
+    ".openclaw/openclaw.json contains openai-codex/gpt-5 runtime-specific model refs",
+    ".openclaw/openclaw.json contains legacy compatibleProvider and responsesApi provider fields"
+  ],
+  "cleanupGuarantees": [
+    "disposable env cleanup removes legacy provider config fixture files"
+  ]
+}

--- a/states/legacy-runtime-pin-doctor-2026-5-8.json
+++ b/states/legacy-runtime-pin-doctor-2026-5-8.json
@@ -1,0 +1,43 @@
+{
+  "id": "legacy-runtime-pin-doctor-2026-5-8",
+  "title": "Legacy Runtime Pin Doctor 2026.5.8",
+  "objective": "A stale Pi runtime pin config from the Codex runtime routing migration boundary, used to verify Doctor removes or rewrites runtime pins and the default agent path remains usable.",
+  "tags": [
+    "runtime",
+    "config",
+    "doctor",
+    "upgrade"
+  ],
+  "setup": [
+    {
+      "id": "write-legacy-runtime-pin",
+      "title": "Write Legacy Runtime Pin",
+      "intent": "Create stale Pi runtime pins and disabled Codex plugin state tied to recent Codex migration Doctor contracts.",
+      "afterPhase": "clone",
+      "commands": [
+        "ocm env exec {env} -- node {kovaRoot}/support/write-doctor-upgrade-state.mjs --state legacy-runtime-pin-doctor-2026-5-8"
+      ],
+      "evidence": [
+        "legacy runtime pin config exists",
+        "doctor upgrade evidence names PR #79238 and PR #85312",
+        "stale Pi runtime path is present before repair"
+      ]
+    }
+  ],
+  "traits": [
+    "existing-user",
+    "migration-state",
+    "config-state",
+    "runtime-deps"
+  ],
+  "riskArea": "runtime-pin-doctor-repair",
+  "ownerArea": "agents",
+  "setupEvidence": [
+    "config/kova-doctor-upgrade-evidence.json lists PR #79238, PR #85312, and stale Pi runtime commits as breakage evidence",
+    ".openclaw/openclaw.json contains agents.defaults.agentRuntime.id=pi",
+    ".openclaw/openclaw.json contains stale /usr/local/lib/openclaw/pi-runtime path"
+  ],
+  "cleanupGuarantees": [
+    "disposable env cleanup removes legacy runtime pin fixture files"
+  ]
+}

--- a/support/write-doctor-upgrade-state.mjs
+++ b/support/write-doctor-upgrade-state.mjs
@@ -1,0 +1,289 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+function parseStateId(argv) {
+  const index = argv.indexOf("--state");
+  if (index === -1 || !argv[index + 1]) {
+    throw new Error("--state <id> is required");
+  }
+  return argv[index + 1];
+}
+
+async function writeJson(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+const fixtures = {
+  "legacy-channel-config-doctor-2026-5-7": {
+    title: "Legacy Channel Config Doctor Fixture",
+    boundary: "May 2026 channel and plugin-owned channel config repairs",
+    detects: [
+      "Doctor leaves removed core BlueBubbles config in the core schema",
+      "Doctor fails to surface missing external channel plugin repairs",
+      "post-repair status/plugins list regresses channel config loading"
+    ],
+    breakingChangeEvidence: [
+      "OpenClaw PR #78612 removed the core BlueBubbles schema",
+      "OpenClaw PR #78876 surfaced missing external plugin repairs for channels",
+      "OpenClaw commit b7c461af7b fixed stale Feishu channel state"
+    ],
+    files: {
+      ".openclaw/openclaw.json": {
+        schemaVersion: "openclaw.config.legacy.channel.v1",
+        channels: {
+          bluebubbles: {
+            enabled: true,
+            serverUrl: "http://127.0.0.1:12345",
+            passwordEnv: "KOVA_BLUEBUBBLES_PASSWORD"
+          },
+          feishu: {
+            enabled: true,
+            appId: "cli_legacy",
+            appSecretEnv: "KOVA_FEISHU_APP_SECRET",
+            configWrites: true,
+            legacyWebhookPath: "/openclaw/feishu"
+          },
+          telegram: {
+            enabled: true,
+            tokenEnv: "KOVA_TELEGRAM_TOKEN",
+            reasoningDefault: "concise"
+          }
+        },
+        plugins: {
+          externalChannels: ["bluebubbles", "feishu"]
+        }
+      },
+      "config/channel-legacy.json": {
+        schemaVersion: "kova.fixture.legacy-channel-config.v1",
+        channelConfigBoundary: "pr-78612-pr-78876-feishu-stale-state"
+      }
+    }
+  },
+  "legacy-core-config-doctor-2026-4-24": {
+    title: "Legacy Core Config Doctor Fixture",
+    boundary: "2026.4.24 plugin architecture and doctor config preservation boundary",
+    detects: [
+      "Doctor drops unrelated user config while repairing stale keys",
+      "gateway/runtime keys from older config shapes still affect post-upgrade status",
+      "doctor --non-interactive reports repairable validation errors after --fix"
+    ],
+    breakingChangeEvidence: [
+      "OpenClaw PR #78896 fixed preserving user config fields in doctor --fix",
+      "OpenClaw PR #79203 fixed duplicate gateway runtime warnings",
+      "Kova existing upgrade-from-2026-4-24 coverage marks the plugin-architecture release as an upgrade boundary"
+    ],
+    files: {
+      ".openclaw/openclaw.json": {
+        schemaVersion: "openclaw.config.legacy.core.2026-4-24",
+        gateway_port: 21120,
+        gateway: {
+          port: 21120,
+          runtime: "node",
+          runtimePath: "./dist/gateway.js"
+        },
+        runtime: {
+          default: "pi",
+          pi: {
+            enabled: true,
+            command: "openclaw-pi"
+          }
+        },
+        models: {
+          defaultProvider: "openai",
+          defaultModel: "gpt-4.1"
+        },
+        plugins: {
+          runtimeDeps: "legacy",
+          bundled: true
+        },
+        userPreservedField: {
+          shouldSurviveDoctorFix: true
+        }
+      },
+      "config/kova-source-release.json": {
+        schemaVersion: "kova.fixture.source-release.v1",
+        release: "2026.4.24",
+        surface: "doctor-repair-upgrade",
+        risk: "plugin-architecture-config-migration"
+      }
+    }
+  },
+  "legacy-plugin-config-doctor-2026-5-22": {
+    title: "Legacy Plugin Config Doctor Fixture",
+    boundary: "May 2026 bundled plugin loading and install-index repair boundary",
+    detects: [
+      "Doctor injects bundled plugin directories into plugins.load.paths again",
+      "plugin index repair leaves plugins list or gateway startup broken",
+      "gateway logs contain plugin load failures after repair"
+    ],
+    breakingChangeEvidence: [
+      "OpenClaw issue #85334 reported doctor --fix injecting bundled plugin paths",
+      "OpenClaw PR #85358 prevented bundled plugin load paths from being injected into config",
+      "OpenClaw PR #85170 fixed plugin id derivation for -plugin suffixes"
+    ],
+    files: {
+      ".openclaw/openclaw.json": {
+        schemaVersion: "openclaw.config.legacy.plugin.2026-5-22",
+        plugins: {
+          load: {
+            paths: [
+              "./plugins",
+              "./node_modules/@openclaw/plugins",
+              "/Applications/OpenClaw.app/Contents/Resources/app/plugins"
+            ]
+          },
+          entries: {
+            codexPlugin: {
+              enabled: true,
+              package: "@openclaw/codex-plugin"
+            },
+            browser: {
+              enabled: true,
+              bundledPath: "./plugins/browser"
+            }
+          }
+        }
+      },
+      "plugins/installs.json": {
+        schemaVersion: "openclaw.plugins.installs.legacy.v1",
+        plugins: [
+          "codex-plugin",
+          "browser"
+        ]
+      },
+      "config/plugin-legacy.json": {
+        schemaVersion: "kova.fixture.legacy-plugin-config.v1",
+        pluginBoundary: "issue-85334-pr-85358-pr-85170"
+      }
+    }
+  },
+  "legacy-provider-config-doctor-2026-5-7": {
+    title: "Legacy Provider Config Doctor Fixture",
+    boundary: "May 2026 provider and model normalization boundary",
+    detects: [
+      "Doctor rewrites agentRuntime-specific OpenAI Codex model refs incorrectly",
+      "provider alias catalog rows disappear after repair",
+      "models list cannot resolve configured provider/model aliases"
+    ],
+    breakingChangeEvidence: [
+      "OpenClaw PR #78967 preserved agentRuntime-specific model expressions during doctor normalization",
+      "OpenClaw PR #78971 fixed doctor model-ref warnings for openai-codex to openai rewrites",
+      "OpenClaw commits 00c87fd756 and 7be4f12d0b fixed provider aliases and release live provider catalog entries"
+    ],
+    files: {
+      ".openclaw/openclaw.json": {
+        schemaVersion: "openclaw.config.legacy.provider.2026-5-7",
+        auth: {
+          profiles: {
+            "openai-codex:default": {
+              provider: "openai-codex",
+              mode: "oauth"
+            }
+          }
+        },
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5"
+            },
+            agentRuntime: {
+              id: "codex",
+              fallback: "automatic"
+            }
+          }
+        },
+        models: {
+          providers: {
+            "openai-codex": {
+              compatibleProvider: "openai",
+              responsesApi: true,
+              store: false
+            }
+          },
+          aliases: {
+            "gpt-5-codex": "openai-codex/gpt-5"
+          }
+        }
+      },
+      "config/provider-legacy.json": {
+        schemaVersion: "kova.fixture.legacy-provider-config.v1",
+        providerBoundary: "pr-78967-pr-78971-provider-alias-catalog"
+      }
+    }
+  },
+  "legacy-runtime-pin-doctor-2026-5-8": {
+    title: "Legacy Runtime Pin Doctor Fixture",
+    boundary: "May 2026 Pi to Codex runtime routing boundary",
+    detects: [
+      "Doctor leaves stale pi runtime pins that break default agent routing",
+      "Codex migration plugin requirements are not surfaced before agent use",
+      "post-repair status still points at removed runtime paths"
+    ],
+    breakingChangeEvidence: [
+      "OpenClaw PR #79238 kept OpenAI Codex migrations on automatic runtime routing",
+      "OpenClaw PR #85312 clarified Codex migration plugin requirements",
+      "OpenClaw commits 1451b33323 and 614179b4f4 preserved shipped pi aliases and removed stale pi runtime paths"
+    ],
+    files: {
+      ".openclaw/openclaw.json": {
+        schemaVersion: "openclaw.config.legacy.runtime-pin.2026-5-8",
+        agents: {
+          defaults: {
+            agentRuntime: {
+              id: "pi",
+              command: "/usr/local/bin/openclaw-pi",
+              fallback: "none"
+            },
+            model: {
+              primary: "openai-codex/gpt-5"
+            }
+          }
+        },
+        runtimes: {
+          pi: {
+            enabled: true,
+            path: "/usr/local/lib/openclaw/pi-runtime/index.js"
+          }
+        },
+        plugins: {
+          entries: {
+            codex: {
+              enabled: false
+            }
+          }
+        }
+      },
+      "config/runtime-pin-legacy.json": {
+        schemaVersion: "kova.fixture.legacy-runtime-pin.v1",
+        runtimeBoundary: "pr-79238-pr-85312-stale-pi-path"
+      }
+    }
+  }
+};
+
+const stateId = parseStateId(process.argv);
+const fixture = fixtures[stateId];
+
+if (!fixture) {
+  const known = Object.keys(fixtures).sort().join(", ");
+  throw new Error(`unknown doctor upgrade state '${stateId}'. Known states: ${known}`);
+}
+
+const home = process.env.OPENCLAW_HOME;
+if (!home) {
+  throw new Error("OPENCLAW_HOME is required");
+}
+
+for (const [relPath, value] of Object.entries(fixture.files)) {
+  await writeJson(join(home, relPath), value);
+}
+
+await writeJson(join(home, "config", "kova-doctor-upgrade-evidence.json"), {
+  schemaVersion: "kova.fixture.doctor-upgrade-evidence.v1",
+  state: stateId,
+  title: fixture.title,
+  boundary: fixture.boundary,
+  detects: fixture.detects,
+  breakingChangeEvidence: fixture.breakingChangeEvidence
+});

--- a/surfaces/upgrade-existing-user.json
+++ b/surfaces/upgrade-existing-user.json
@@ -77,6 +77,32 @@
         "pluginIndexPresent",
         "doctorFixMs"
       ]
+    },
+    {
+      "id": "doctor-repair",
+      "states": [
+        "legacy-channel-config-doctor-2026-5-7",
+        "legacy-core-config-doctor-2026-4-24",
+        "legacy-plugin-config-doctor-2026-5-22",
+        "legacy-provider-config-doctor-2026-5-7",
+        "legacy-runtime-pin-doctor-2026-5-8"
+      ],
+      "targetKinds": [
+        "npm",
+        "release",
+        "runtime",
+        "local-build"
+      ],
+      "metrics": [
+        "upgradeMs",
+        "doctorFixMs",
+        "gatewayReadyMs",
+        "statusMs",
+        "pluginsListMs",
+        "modelsListMs",
+        "missingDependencyErrors",
+        "pluginLoadFailures"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a doctor-repair-upgrade scenario that clones a source env, applies legacy config, upgrades to the target, runs doctor --fix, then checks status/plugins/models/logs
- add doctor-upgrade profile with five legacy config states across core, plugin, provider, channel, and runtime-pin boundaries
- keep doctor-upgrade gate blocking policy derived from the profile entries so the five scenario/state pairs have one source of truth
- write state evidence markers citing recent OpenClaw PRs/issues/commits that explain why each profile detects breaking changes
- add catalog/selfcheck coverage for the new profile resolving all five obligations and for the stateful gate policy

## Verification
- node --check src/selfcheck.mjs && node --check support/write-doctor-upgrade-state.mjs
- node bin/kova.mjs matrix plan --profile doctor-upgrade --target local-build:/tmp/openclaw --json
- node --input-type=module -e 'import { readFile } from "node:fs/promises"; import { evaluateGate } from "./src/matrix/gate.mjs"; const profile = JSON.parse(await readFile("profiles/doctor-upgrade.json", "utf8")); const records = profile.entries.map((entry) => ({ scenario: entry.scenario, surface: "upgrade-existing-user", state: { id: entry.state }, status: "PASS", phases: [] })); const gate = evaluateGate({ mode: "execution", controls: { include: [], exclude: [] }, records }, profile, { resolvedCoverage: { obligations: records.map((record) => ({ surface: "upgrade-existing-user", requirement: "doctor-repair", scenario: record.scenario, state: record.state.id, status: "planned" })) } }); console.log(JSON.stringify({ ok: gate.ok, verdict: gate.verdict, complete: gate.complete, missingRequiredCount: gate.missingRequiredCount, requiredCount: gate.required.length }, null, 2));'
- git diff --check
- npm run check

## Verification result
- focused gate check returned `{ "ok": true, "verdict": "SHIP", "complete": true, "missingRequiredCount": 0, "requiredCount": 5 }`
- doctor-upgrade matrix plan reports `blockingCount: 5`, five planned obligations, and zero coverage gaps with `gate.blocking` omitted
- npm run check reaches 159/163 passing, including doctor-upgrade-plan-json and doctor-upgrade-gate-policy; the remaining four failures are local prerequisite failures because `ocm` is not installed/on PATH: setup-json, credential-store, setup-external-cli-verification, and cleanup-json

## Notes
- No real Kova scenario execution was run in this local checkout because OCM is unavailable.