### PR TITLE
Accept agent payload text in response extraction

### DIFF
--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -3773,6 +3773,10 @@ function extractAgentResponse(result) {
   const text = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
   try {
     const parsed = JSON.parse(result.stdout);
+    const payloadText = findPayloadText(parsed);
+    if (typeof payloadText === "string" && payloadText.trim().length > 0 && payloadText.trim() !== "NO_REPLY") {
+      return { usable: true, text: payloadText.trim() };
+    }
     const finalText = findFirstString(parsed, [
       "finalAssistantVisibleText",
       "finalAssistantRawText",
@@ -3802,6 +3806,19 @@ function responseMatchesExpectedText(response, expectedText) {
 
 function textEquals(actual, expected) {
   return typeof actual === "string" && typeof expected === "string" && actual.trim() === expected.trim();
+}
+
+function findPayloadText(value) {
+  const payloads = value?.payloads;
+  if (!Array.isArray(payloads)) {
+    return null;
+  }
+  for (const payload of payloads) {
+    if (typeof payload?.text === "string") {
+      return payload.text;
+    }
+  }
+  return null;
 }
 
 function findFirstString(value, keys) {

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -3773,10 +3773,6 @@ function extractAgentResponse(result) {
   const text = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
   try {
     const parsed = JSON.parse(result.stdout);
-    const payloadText = findPayloadText(parsed);
-    if (typeof payloadText === "string" && payloadText.trim().length > 0 && payloadText.trim() !== "NO_REPLY") {
-      return { usable: true, text: payloadText.trim() };
-    }
     const finalText = findFirstString(parsed, [
       "finalAssistantVisibleText",
       "finalAssistantRawText",
@@ -3806,19 +3802,6 @@ function responseMatchesExpectedText(response, expectedText) {
 
 function textEquals(actual, expected) {
   return typeof actual === "string" && typeof expected === "string" && actual.trim() === expected.trim();
-}
-
-function findPayloadText(value) {
-  const payloads = value?.payloads;
-  if (!Array.isArray(payloads)) {
-    return null;
-  }
-  for (const payload of payloads) {
-    if (typeof payload?.text === "string") {
-      return payload.text;
-    }
-  }
-  return null;
 }
 
 function findFirstString(value, keys) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -5790,7 +5790,7 @@ function providerFailureEvaluationCheck() {
             finishedAt: "2026-04-30T10:00:02.000Z",
             finishedAtEpochMs: 1777543202000,
             durationMs: 1000,
-            stdout: "{\"finalAssistantVisibleText\":\"KOVA_AGENT_OK\"}",
+            stdout: "{\"payloads\":[{\"text\":\"KOVA_AGENT_OK\"}]}",
             stderr: "",
             processSnapshots: {
               leaks: {
@@ -6659,7 +6659,7 @@ function agentColdWarmEvaluationCheck() {
             finishedAt: "2026-04-30T10:01:03.000Z",
             finishedAtEpochMs: 1777543263000,
             durationMs: 62000,
-            stdout: "{\"finalAssistantVisibleText\":\"KOVA_AGENT_OK\"}",
+            stdout: "{\"payloads\":[{\"text\":\"KOVA_AGENT_OK\"}]}",
             stderr: ""
           }],
           metrics: { logs: zeroLogMetrics(), health: { ok: true } }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -6675,7 +6675,7 @@ function agentColdWarmEvaluationCheck() {
             finishedAt: "2026-04-30T10:01:12.000Z",
             finishedAtEpochMs: 1777543272000,
             durationMs: 2000,
-            stdout: "{\"finalAssistantVisibleText\":\"KOVA_AGENT_OK\"}",
+            stdout: "{\"finalAssistantVisibleText\":\"KOVA_AGENT_OK\",\"payloads\":[{\"text\":\"WRONG_REPLY\"}]}",
             stderr: ""
           }],
           metrics: { logs: zeroLogMetrics(), health: { ok: true } }
@@ -6742,6 +6742,8 @@ function agentColdWarmEvaluationCheck() {
     assertEqual(record.measurements.coldProviderFinalMs, 800, "cold provider final");
     assertEqual(record.measurements.agentLatencyDiagnosis.kind, "cold-pre-provider-stall", "latency diagnosis kind");
     assertEqual(record.measurements.agentTurns[0].responseOk, true, "cold response ok");
+    assertEqual(record.measurements.agentTurns[0].responseText, "KOVA_AGENT_OK", "payload response text");
+    assertEqual(record.measurements.agentTurns[1].responseText, "KOVA_AGENT_OK", "final assistant response precedence");
     assertEqual(record.measurements.agentTurns[1].providerRoutes[0].value, "/v1/responses", "warm provider route evidence");
     assertEqual(
       renderPasteSummary({


### PR DESCRIPTION
## Summary
- Keep the existing agent response extraction precedence unchanged.
- Refresh self-check fixtures so payload-shaped OpenClaw JSON (`payloads[0].text`) is covered by the existing recursive extractor.
- Add mixed-shape self-check coverage proving `finalAssistantVisibleText` still wins when both legacy and payload text are present.

## Why
ClawSweeper found that the previous helper path was redundant and changed precedence by reading payload text before `finalAssistant*`. This narrows the PR to regression coverage only.

## Verification
- npm run check

Result: 156/160 checks passed. The remaining failures are unrelated local prerequisites: setup-json, credential-store, setup-external-cli-verification, and cleanup-json because `ocm` is not installed in this checkout environment.