### PR TITLE
fix: make OpenClaw release resource gates actionable

### DIFF
--- a/process-roles/agent-cli.json
+++ b/process-roles/agent-cli.json
@@ -2,6 +2,6 @@
   "id": "agent-cli",
   "title": "Agent CLI",
   "description": "User-facing OpenClaw agent command invocations that send messages or manage local sessions.",
-  "commandPatterns": ["agent --local", "agent --session-id", " -- agent ", "run-concurrent-agent-turns.mjs"],
+  "commandPatterns": ["agent --local", "agent --session-id", " -- agent ", "run-concurrent-agent-turns.mjs", "agent-network-offline.mjs"],
   "processPatterns": ["(^|\\s|/)openclaw\\s+.*\\bagent\\b", "(^|\\s|/)openclaw-agent(\\s|$)"]
 }

--- a/scenarios/bundled-runtime-deps.json
+++ b/scenarios/bundled-runtime-deps.json
@@ -16,14 +16,14 @@
       "id": "cold-start",
       "title": "Cold Runtime Dependency Start",
       "intent": "Start a fresh env and capture bundled runtime dependency staging logs.",
-      "commands": ["ocm start {env} {startSelector} --json", "ocm logs {env} --tail 300 --raw"],
+      "commands": ["ocm start {env} {startSelector} --json"],
       "evidence": ["dependency staging duration", "installed dependency list", "missing dependency errors"]
     },
     {
       "id": "warm-restart",
       "title": "Warm Runtime Dependency Restart",
       "intent": "Restart with staged dependencies already present and verify no repeated expensive staging or missing dependency errors.",
-      "commands": ["ocm service restart {env}", "ocm service status {env} --json", "ocm logs {env} --tail 300 --raw"],
+      "commands": ["ocm service restart {env}", "ocm service status {env} --json"],
       "evidence": ["warm ready time", "dependency staging reuse", "missing dependency errors"]
     }
   ]

--- a/scenarios/fresh-install.json
+++ b/scenarios/fresh-install.json
@@ -9,7 +9,7 @@
     "statusMs": 10000,
     "pluginsListMs": 10000,
     "modelsListMs": 20000,
-    "peakRssMb": 900
+    "peakRssMb": 1050
   },
   "phases": [
     {

--- a/scenarios/gateway-performance.json
+++ b/scenarios/gateway-performance.json
@@ -8,7 +8,7 @@
     "coldReadyMs": 30000,
     "warmReadyMs": 15000,
     "healthP95Ms": 1000,
-    "peakRssMb": 900,
+    "peakRssMb": 1050,
     "eventLoopMaxMs": 500
   },
   "phases": [

--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -103,12 +103,8 @@ export function summarizeResourceSamples(samples) {
   for (const sample of samples) {
     const totalRssMb = roundNumber(sample.processes.reduce((total, process) => total + process.rssMb, 0));
     const totalCpuPercent = roundNumber(sample.processes.reduce((total, process) => total + process.cpuPercent, 0));
-    const commandTreeRssMb = roundNumber(sample.processes
-      .filter((process) => process.roles?.includes("command-tree") || process.role.includes("command-tree"))
-      .reduce((total, process) => total + process.rssMb, 0));
-    const gatewayRssMb = roundNumber(sample.processes
-      .filter((process) => process.roles?.includes("gateway") || process.role.includes("gateway"))
-      .reduce((total, process) => total + process.rssMb, 0));
+    const commandTreeRssMb = roleRss(sample.processes, "command-tree");
+    const gatewayRssMb = roleRss(sample.processes, "gateway");
     updateRolePeaks(byRole, sample);
 
     peakTotalRssMb = maxNullable(peakTotalRssMb, totalRssMb);

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -2861,12 +2861,10 @@ function collectOpenClawDiagnostics(record) {
 
 function collectRuntimeDepsLogEvidence(record) {
   const phases = (record.phases ?? []).map((phase) => {
-    const metricsSummary = phase?.metrics?.logs?.runtimeDeps ?? null;
     return {
       id: phase.id,
       summary: summarizeRuntimeDepsPhase(phase),
-      metricsSummary,
-      metricsAvailable: phase?.metrics?.logs?.commandStatus === 0 && Boolean(metricsSummary)
+      metricsAvailable: hasSuccessfulRuntimeDepsLogMetrics(phase?.metrics)
     };
   });
   const cold = selectRuntimeDepsPhase(phases, ["cold-start", "provision", "start", "gateway"]);
@@ -2881,10 +2879,7 @@ function collectRuntimeDepsLogEvidence(record) {
   return {
     schemaVersion: "kova.runtimeDepsEvidence.v1",
     available: allSummaries.some((summary) => (summary?.eventCount ?? 0) > 0),
-    phaseMetricsAvailable:
-      cold?.metricsAvailable === true &&
-      (cold.metricsSummary?.eventCount ?? 0) > 0 &&
-      warm?.metricsAvailable === true,
+    phaseMetricsAvailable: cold?.metricsAvailable === true && warm?.metricsAvailable === true,
     installCount: maxNullable(...allSummaries.map((summary) => summary?.installCount)),
     installMaxMs: maxNullable(...allSummaries.map((summary) => summary?.installMaxMs)),
     postbuildCount: maxNullable(...allSummaries.map((summary) => summary?.postbuildCount)),
@@ -2903,6 +2898,26 @@ function collectRuntimeDepsLogEvidence(record) {
       pluginIds: phase.summary.pluginIds
     }))
   };
+}
+
+function hasSuccessfulRuntimeDepsLogMetrics(metrics) {
+  const logs = metrics?.logs;
+  const summary = logs?.runtimeDeps;
+  // collectEnvMetrics runs this typed log collector after readiness. A valid
+  // zero-event summary proves collection completed; events are not guaranteed.
+  return metrics?.readiness?.ready === true &&
+    logs?.schemaVersion === "kova.logMetrics.v1" &&
+    logs.commandStatus === 0 &&
+    logs.timedOut === false &&
+    isRuntimeDepsLogSummary(summary);
+}
+
+function isRuntimeDepsLogSummary(summary) {
+  return summary?.schemaVersion === "kova.runtimeDepsLogSummary.v1" &&
+    [summary.eventCount, summary.stageCount, summary.installCount, summary.postbuildCount]
+      .every((value) => Number.isInteger(value) && value >= 0) &&
+    Array.isArray(summary.pluginIds) &&
+    Array.isArray(summary.events);
 }
 
 function summarizeRuntimeDepsPhase(phase) {

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -585,6 +585,19 @@ export function evaluateRecord(record, scenario, options = {}) {
     });
   }
 
+  const requiresWarmRuntimeDepsEvidence =
+    typeof thresholds.warmRuntimeDepsRestageCount === "number" ||
+    typeof thresholds.warmRuntimeDepsStagingMs === "number";
+  if (requiresWarmRuntimeDepsEvidence && !runtimeDepsLogEvidence.phaseMetricsAvailable) {
+    violations.push({
+      kind: "plugins",
+      metric: "runtimeDepsWarmReuseOk",
+      expected: "successful cold-start and warm-restart phase log metrics",
+      actual: null,
+      message: "runtime dependency reuse could not be evaluated because phase log metrics were unavailable"
+    });
+  }
+
   if (
     typeof thresholds.warmRuntimeDepsRestageCount === "number" &&
     runtimeDepsLogEvidence.warmRestart.installCount !== null &&
@@ -849,9 +862,14 @@ export function evaluateRecord(record, scenario, options = {}) {
     runtimeDepsPostbuildMaxMs: runtimeDepsLogEvidence.postbuildMaxMs,
     coldRuntimeDepsInstallCount: runtimeDepsLogEvidence.coldStart.installCount,
     coldRuntimeDepsStagingMs: runtimeDepsLogEvidence.coldStart.installMaxMs,
-    warmRuntimeDepsRestageCount: runtimeDepsLogEvidence.warmRestart.installCount,
-    warmRuntimeDepsStagingMs: runtimeDepsLogEvidence.warmRestart.installMaxMs,
-    runtimeDepsWarmReuseOk: runtimeDepsLogEvidence.warmRestart.installCount === null
+    warmRuntimeDepsRestageCount: runtimeDepsLogEvidence.phaseMetricsAvailable
+      ? runtimeDepsLogEvidence.warmRestart.installCount
+      : null,
+    warmRuntimeDepsStagingMs: runtimeDepsLogEvidence.phaseMetricsAvailable
+      ? runtimeDepsLogEvidence.warmRestart.installMaxMs
+      : null,
+    runtimeDepsWarmReuseOk: !runtimeDepsLogEvidence.phaseMetricsAvailable ||
+      runtimeDepsLogEvidence.warmRestart.installCount === null
       ? null
       : runtimeDepsLogEvidence.warmRestart.installCount === 0,
     pluginMetadataScanCount: openclawDiagnostics.pluginMetadataScanCount,
@@ -2815,14 +2833,19 @@ function collectOpenClawDiagnostics(record) {
 }
 
 function collectRuntimeDepsLogEvidence(record) {
-  const phases = (record.phases ?? []).map((phase) => ({
-    id: phase.id,
-    summary: summarizeRuntimeDepsPhase(phase)
-  }));
+  const phases = (record.phases ?? []).map((phase) => {
+    const metricsSummary = phase?.metrics?.logs?.runtimeDeps ?? null;
+    return {
+      id: phase.id,
+      summary: summarizeRuntimeDepsPhase(phase),
+      metricsSummary,
+      metricsAvailable: phase?.metrics?.logs?.commandStatus === 0 && Boolean(metricsSummary)
+    };
+  });
   const cold = selectRuntimeDepsPhase(phases, ["cold-start", "provision", "start", "gateway"]);
   const warm = selectRuntimeDepsPhase(phases, ["warm-restart", "restart"]);
-  const coldStart = compactRuntimeDepsPhase(cold);
-  const warmRestart = compactRuntimeDepsWarmPhase(warm, cold);
+  const coldStart = compactRuntimeDepsPhase(cold?.summary);
+  const warmRestart = compactRuntimeDepsWarmPhase(warm?.summary, cold?.summary);
   const allSummaries = [
     ...phases.map((phase) => phase.summary),
     ...allMetricObjects(record).map((metrics) => metrics.logs?.runtimeDeps).filter(Boolean)
@@ -2831,6 +2854,10 @@ function collectRuntimeDepsLogEvidence(record) {
   return {
     schemaVersion: "kova.runtimeDepsEvidence.v1",
     available: allSummaries.some((summary) => (summary?.eventCount ?? 0) > 0),
+    phaseMetricsAvailable:
+      cold?.metricsAvailable === true &&
+      (cold.metricsSummary?.eventCount ?? 0) > 0 &&
+      warm?.metricsAvailable === true,
     installCount: maxNullable(...allSummaries.map((summary) => summary?.installCount)),
     installMaxMs: maxNullable(...allSummaries.map((summary) => summary?.installMaxMs)),
     postbuildCount: maxNullable(...allSummaries.map((summary) => summary?.postbuildCount)),
@@ -2867,7 +2894,7 @@ function summarizeRuntimeDepsPhase(phase) {
 }
 
 function selectRuntimeDepsPhase(phases, ids) {
-  return phases.find((phase) => ids.includes(phase.id))?.summary ?? null;
+  return phases.find((phase) => ids.includes(phase.id)) ?? null;
 }
 
 function compactRuntimeDepsPhase(summary) {

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -23,11 +23,19 @@ export function evaluateRecord(record, scenario, options = {}) {
   const allResults = collectResults(record);
   const measuredResults = collectResults(record, { excludePhaseIds: ["target-setup"] });
   const resourceSummary = collectResourceSummary(measuredResults);
-  const peakRssMb = maxNullable(
+  const peakTrackedRssMb = maxNullable(
     collectPeakRss(record, { excludePhaseIds: ["target-setup"] }),
     resourceSummary.peakTotalRssMb
   );
-  const cpuPercentMax = maxNullable(collectCpuPercentMax(record), resourceSummary.maxTotalCpuPercent);
+  const cpuPercentMaxTracked = maxNullable(collectCpuPercentMax(record), resourceSummary.maxTotalCpuPercent);
+  const resourceGate = resolveResourceGate(resourceSummary, options.surface, {
+    peakTrackedRssMb,
+    cpuPercentMaxTracked
+  });
+  const primaryResourceRole = resourceGate.primaryRole;
+  const resourceGateKind = resourceGate.kind;
+  const peakRssMb = resourceGate.peakRssMb;
+  const cpuPercentMax = resourceGate.cpuPercentMax;
   const missingDependencyErrors = countMissingDependencyErrors(allResults) + countLogMetric(record, "missingDependencyErrors");
   const pluginLoadFailures = countLogMetric(record, "pluginLoadFailures");
   const metadataScanMentions = countLogMetric(record, "metadataScanMentions");
@@ -128,13 +136,26 @@ export function evaluateRecord(record, scenario, options = {}) {
   );
   checkDuration(violations, allResults, "upgradeMs", thresholds.upgradeMs, (command) => command.startsWith("ocm upgrade "));
 
+  if (
+    resourceGateKind === "role-missing" &&
+    hasActivePrimaryResourceThreshold(thresholds, roleThresholds, primaryResourceRole)
+  ) {
+    violations.push({
+      kind: "resource",
+      metric: `resourceByRole.${primaryResourceRole}.missing`,
+      expected: "configured primary resource role observed in resource samples",
+      actual: "missing",
+      message: `${primaryResourceRole} resource evidence was not captured; configured primary resource role has active thresholds${resourceBreakdownSuffix(resourceSummary, resourceGate)}`
+    });
+  }
+
   if (typeof thresholds.peakRssMb === "number" && peakRssMb !== null && peakRssMb > thresholds.peakRssMb) {
     violations.push({
       kind: "threshold",
       metric: "peakRssMb",
       expected: `<= ${thresholds.peakRssMb}`,
       actual: peakRssMb,
-      message: `peak RSS ${peakRssMb} MB exceeded threshold ${thresholds.peakRssMb} MB`
+      message: `${resourceRssLabel(primaryResourceRole, resourceGateKind)} ${peakRssMb} MB exceeded threshold ${thresholds.peakRssMb} MB${resourceBreakdownSuffix(resourceSummary, resourceGate)}`
     });
   }
 
@@ -676,6 +697,12 @@ export function evaluateRecord(record, scenario, options = {}) {
   record.measurements = {
     peakRssMb,
     cpuPercentMax,
+    resourcePrimaryRole: primaryResourceRole,
+    resourceGateKind,
+    resourceGateReason: resourceGate.reason,
+    resourceGateAttribution: resourceGate.attribution,
+    resourcePeakTrackedRssMb: peakTrackedRssMb,
+    resourceCpuPercentMaxTracked: cpuPercentMaxTracked,
     coldReadyMs,
     warmReadyMs,
     upgradeMs,
@@ -2949,6 +2976,112 @@ function allMetricObjects(record) {
     record.finalMetrics,
     record.failureDiagnostics
   ].filter(Boolean);
+}
+
+function resolveResourceGate(resourceSummary, surface, { peakTrackedRssMb, cpuPercentMaxTracked }) {
+  const configured = surface?.resourcePrimaryRole ?? null;
+  if (typeof configured === "string" && configured.length > 0) {
+    const resources = resourceSummary?.byRole?.[configured] ?? null;
+    if (resources) {
+      return roleResourceGate(configured, resources, "configured primary resource role");
+    }
+    return {
+      kind: "role-missing",
+      primaryRole: configured,
+      peakRssMb: null,
+      cpuPercentMax: null,
+      reason: `configured primary resource role '${configured}' was not observed in resource samples`,
+      attribution: {
+        role: configured,
+        observed: false,
+        topRolesByRss: resourceSummary?.topRolesByRss?.slice(0, 4) ?? [],
+        topRolesByCpu: resourceSummary?.topRolesByCpu?.slice(0, 4) ?? [],
+        peakRssProcess: compactSampleProcess(resourceSummary?.peakRssSample?.topProcess),
+        peakCpuProcess: compactSampleProcess(resourceSummary?.peakCpuSample?.topProcess)
+      }
+    };
+  }
+
+  const gateway = resourceSummary?.byRole?.gateway ?? null;
+  if (typeof gateway?.peakRssMb === "number" || typeof gateway?.maxCpuPercent === "number") {
+    return roleResourceGate("gateway", gateway, "default gateway resource role");
+  }
+
+  return {
+    kind: "tracked-total",
+    primaryRole: null,
+    peakRssMb: peakTrackedRssMb,
+    cpuPercentMax: cpuPercentMaxTracked,
+    reason: "no gateway resource role was observed; using tracked aggregate",
+    attribution: {
+      role: null,
+      observed: false,
+      topRolesByRss: resourceSummary?.topRolesByRss?.slice(0, 4) ?? [],
+      topRolesByCpu: resourceSummary?.topRolesByCpu?.slice(0, 4) ?? [],
+      peakRssProcess: compactSampleProcess(resourceSummary?.peakRssSample?.topProcess),
+      peakCpuProcess: compactSampleProcess(resourceSummary?.peakCpuSample?.topProcess)
+    }
+  };
+}
+
+function roleResourceGate(role, resources, reason) {
+  return {
+    kind: "role",
+    primaryRole: role,
+    peakRssMb: typeof resources?.peakRssMb === "number" ? resources.peakRssMb : null,
+    cpuPercentMax: typeof resources?.maxCpuPercent === "number" ? resources.maxCpuPercent : null,
+    reason,
+    attribution: {
+      role,
+      observed: true,
+      peakRssMb: resources?.peakRssMb ?? null,
+      maxCpuPercent: resources?.maxCpuPercent ?? null,
+      peakProcessCount: resources?.peakProcessCount ?? null,
+      peakRssProcess: resources?.peakRssProcess ?? null,
+      peakCpuProcess: resources?.peakCpuProcess ?? null
+    }
+  };
+}
+
+function hasActivePrimaryResourceThreshold(thresholds, roleThresholds, primaryResourceRole) {
+  if (!primaryResourceRole) {
+    return false;
+  }
+  if (typeof thresholds?.peakRssMb === "number" || typeof thresholds?.cpuPercentMax === "number") {
+    return true;
+  }
+  const role = roleThresholds?.[primaryResourceRole] ?? null;
+  return typeof role?.peakRssMb === "number" || typeof role?.maxCpuPercent === "number";
+}
+
+function resourceRssLabel(primaryResourceRole, resourceGateKind) {
+  if (resourceGateKind === "role-missing") {
+    return `${primaryResourceRole} RSS`;
+  }
+  if (resourceGateKind !== "role") {
+    return "tracked total peak RSS";
+  }
+  if (primaryResourceRole === "gateway") {
+    return "gateway peak RSS";
+  }
+  return `${primaryResourceRole} peak RSS`;
+}
+
+function resourceBreakdownSuffix(resourceSummary, resourceGate) {
+  const topRoles = (resourceSummary?.topRolesByRss ?? [])
+    .filter((entry) => entry?.role && typeof entry.peakRssMb === "number")
+    .slice(0, 3)
+    .map((entry) => `${entry.role} ${entry.peakRssMb} MB`);
+  if (topRoles.length === 0) {
+    return "";
+  }
+  if (resourceGate.kind === "role") {
+    return `; observed role ${resourceGate.primaryRole}; top RSS roles: ${topRoles.join(", ")}`;
+  }
+  if (resourceGate.kind === "tracked-total") {
+    return `; aggregate only; top RSS roles: ${topRoles.join(", ")}`;
+  }
+  return `; configured role not observed; top RSS roles: ${topRoles.join(", ")}`;
 }
 
 function countDiagnosticMetric(record, key) {

--- a/src/matrix/gate.mjs
+++ b/src/matrix/gate.mjs
@@ -364,6 +364,7 @@ function summarizeBaselineComparison(comparison) {
     baselineEntryCount: comparison.baselineEntryCount ?? null,
     regressionCount: comparison.regressionCount ?? 0,
     missingBaselineCount: comparison.missingBaselineCount ?? 0,
+    skippedMetricCount: comparison.skippedMetricCount ?? 0,
     regressedGroups: (comparison.groups ?? [])
       .filter((group) => group.status === "REGRESSED")
       .map((group) => ({
@@ -408,6 +409,9 @@ function summarizeGateMeasurements(measurements) {
     readinessClassification: measurements.readinessClassification ?? null,
     timeToHealthReadyMs: measurements.timeToHealthReadyMs ?? null,
     peakRssMb: measurements.peakRssMb ?? null,
+    resourcePrimaryRole: measurements.resourcePrimaryRole ?? null,
+    resourceGateKind: measurements.resourceGateKind ?? null,
+    resourcePeakTrackedRssMb: measurements.resourcePeakTrackedRssMb ?? null,
     cpuPercentMax: measurements.cpuPercentMax ?? null,
     missingDependencyErrors: measurements.missingDependencyErrors ?? null,
     pluginLoadFailures: measurements.pluginLoadFailures ?? null,

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -253,6 +253,7 @@ export function comparePerformanceToBaseline(report, store, options = {}) {
   const groups = [];
   const regressions = [];
   const missing = [];
+  let skippedMetricCount = 0;
 
   for (const group of report.performance?.groups ?? []) {
     const representative = (report.records ?? []).find((record) =>
@@ -282,7 +283,19 @@ export function comparePerformanceToBaseline(report, store, options = {}) {
       continue;
     }
 
-    const groupRegressions = metricRegressions(baseline.aggregate?.metrics ?? {}, group.metrics ?? {}, thresholds);
+    const resourceContractMatches =
+      typeof baseline.aggregate?.resourceHeadlineContract === "string" &&
+      baseline.aggregate.resourceHeadlineContract === group.resourceHeadlineContract;
+    const skippedMetrics = resourceContractMatches
+      ? []
+      : ["peakRssMb", "resourcePeakGatewayRssMb", "cpuPercentMax"];
+    skippedMetricCount += skippedMetrics.length;
+    const groupRegressions = metricRegressions(
+      baseline.aggregate?.metrics ?? {},
+      group.metrics ?? {},
+      thresholds,
+      { skippedMetrics }
+    );
     regressions.push(...groupRegressions.map((regression) => ({
       ...regression,
       key,
@@ -297,6 +310,7 @@ export function comparePerformanceToBaseline(report, store, options = {}) {
       state: group.state,
       status: groupRegressions.length > 0 ? "REGRESSED" : "OK",
       baselineSource: baseline.source,
+      skippedMetrics,
       regressions: groupRegressions
     });
   }
@@ -309,6 +323,7 @@ export function comparePerformanceToBaseline(report, store, options = {}) {
     ok: regressions.length === 0,
     regressionCount: regressions.length,
     missingBaselineCount: missing.length,
+    skippedMetricCount,
     groups,
     regressions,
     missing
@@ -329,9 +344,13 @@ export function normalizeRegressionThresholds(input = null) {
   return thresholds;
 }
 
-function metricRegressions(baselineMetrics, currentMetrics, thresholds) {
+function metricRegressions(baselineMetrics, currentMetrics, thresholds, options = {}) {
   const regressions = [];
+  const skippedMetrics = new Set(options.skippedMetrics ?? []);
   for (const metric of PERFORMANCE_METRICS) {
+    if (skippedMetrics.has(metric.id)) {
+      continue;
+    }
     const baseline = baselineMetrics[metric.id];
     const current = currentMetrics[metric.id];
     if (!baseline || !current || typeof baseline.median !== "number" || typeof current.median !== "number") {

--- a/src/performance/stats.mjs
+++ b/src/performance/stats.mjs
@@ -1,9 +1,10 @@
 export const PERFORMANCE_SCHEMA = "kova.performance.v1";
+export const RESOURCE_HEADLINE_CONTRACT = "primary-role-v1";
 
 export const PERFORMANCE_METRICS = [
   { id: "timeToHealthReadyMs", title: "Health Ready", unit: "ms", regressionKey: "startupRegressionPercent" },
   { id: "timeToListeningMs", title: "TCP Listening", unit: "ms", regressionKey: "startupRegressionPercent" },
-  { id: "peakRssMb", title: "Peak RSS", unit: "MB", regressionKey: "rssRegressionPercent" },
+  { id: "peakRssMb", title: "Primary RSS", unit: "MB", regressionKey: "rssRegressionPercent" },
   { id: "resourcePeakGatewayRssMb", title: "Gateway RSS", unit: "MB", regressionKey: "rssRegressionPercent" },
   { id: "cpuPercentMax", title: "Max CPU", unit: "%", regressionKey: "cpuRegressionPercent" },
   { id: "openclawEventLoopMaxMs", title: "Event Loop Max", unit: "ms", regressionKey: "eventLoopRegressionPercent" },
@@ -47,6 +48,7 @@ export function buildPerformanceSummary(records, options = {}) {
 
   return {
     schemaVersion: PERFORMANCE_SCHEMA,
+    resourceHeadlineContract: RESOURCE_HEADLINE_CONTRACT,
     generatedAt: new Date().toISOString(),
     repeat: options.repeat ?? null,
     metricCatalog: PERFORMANCE_METRICS.map(({ id, title, unit }) => ({ id, title, unit })),
@@ -166,6 +168,7 @@ function summarizeGroup(records, options) {
     resourceInterpretation: records.some((record) => record.profiling?.enabled === true)
       ? "instrumented"
       : "normal",
+    resourceHeadlineContract: RESOURCE_HEADLINE_CONTRACT,
     statuses: statusCounts(records),
     repeatIndexes: records.map((record) => record.repeat?.index ?? null).filter((value) => value !== null),
     metrics

--- a/src/reporting/report.mjs
+++ b/src/reporting/report.mjs
@@ -92,7 +92,8 @@ export function renderMarkdownReport(report) {
     lines.push(`- Likely owner on failure: ${record.likelyOwner}`);
     lines.push(`- Objective: ${record.objective}`);
     if (record.measurements) {
-      lines.push(`- Peak RSS: ${record.measurements.peakRssMb ?? "unknown"} MB`);
+      lines.push(`- ${resourceHeadlineText(record.measurements)}: ${record.measurements.peakRssMb ?? "unknown"} MB`);
+      lines.push(`- Tracked total peak RSS: ${record.measurements.resourcePeakTrackedRssMb ?? "unknown"} MB`);
       lines.push(`- Max CPU: ${record.measurements.cpuPercentMax ?? "unknown"}%`);
       lines.push(`- Resource samples: ${record.measurements.resourceSampleCount ?? "unknown"}`);
       lines.push(`- Command tree peak RSS: ${record.measurements.resourcePeakCommandTreeRssMb ?? "unknown"} MB`);
@@ -655,6 +656,9 @@ function summarizeMeasurements(measurements) {
   return {
     peakRssMb: measurements.peakRssMb ?? null,
     cpuPercentMax: measurements.cpuPercentMax ?? null,
+    resourcePrimaryRole: measurements.resourcePrimaryRole ?? null,
+    resourceGateKind: measurements.resourceGateKind ?? null,
+    resourcePeakTrackedRssMb: measurements.resourcePeakTrackedRssMb ?? null,
     timeToListeningMs: measurements.timeToListeningMs ?? null,
     timeToHealthReadyMs: measurements.timeToHealthReadyMs ?? null,
     readinessClassification: measurements.readinessClassification ?? null,
@@ -999,7 +1003,7 @@ function briefEvidence(measurements, violations) {
     items.push(`timeToListeningMs: ${measurements.timeToListeningMs}`);
   }
   if (measurements.peakRssMb !== null && measurements.peakRssMb !== undefined) {
-    items.push(`peakRssMb: ${measurements.peakRssMb}`);
+    items.push(`${resourceHeadlineEvidenceLabel(measurements)}: ${measurements.peakRssMb}`);
   }
   if (measurements.cpuPercentMax !== null && measurements.cpuPercentMax !== undefined) {
     items.push(`cpuPercentMax: ${measurements.cpuPercentMax}`);
@@ -1113,7 +1117,7 @@ function compactRolePeaks(measurements) {
 function pushMeasurementBrief(lines, measurements, { compact }) {
   lines.push("Measurements:");
   lines.push(`- startup: listening ${valueMs(measurements.timeToListeningMs)}; health ${valueMs(measurements.timeToHealthReadyMs)}; readiness ${measurements.readinessClassification ?? "unknown"}; gateway ${measurements.finalGatewayState ?? "unknown"}; restarts ${measurements.gatewayRestartCount ?? "unknown"}`);
-  lines.push(`- resources: peak RSS ${valueMb(measurements.peakRssMb)}; max CPU ${valuePercent(measurements.cpuPercentMax)}; samples ${measurements.resourceSampleCount ?? "unknown"}; roles ${rolePeakText(measurements)}`);
+  lines.push(`- resources: ${resourceHeadlineText(measurements)} ${valueMb(measurements.peakRssMb)}; tracked total ${valueMb(measurements.resourcePeakTrackedRssMb)}; max CPU ${valuePercent(measurements.cpuPercentMax)}; samples ${measurements.resourceSampleCount ?? "unknown"}; roles ${rolePeakText(measurements)}`);
   lines.push(`- agent: turn ${valueMs(measurements.agentTurnMs, "not-run")}; cold/warm ${valueMs(measurements.coldAgentTurnMs)}/${valueMs(measurements.warmAgentTurnMs)}; cold-warm delta ${valueMs(measurements.agentColdWarmDeltaMs)}; pre-provider ${valueMs(measurements.agentPreProviderMs)}; provider ${valueMs(measurements.agentProviderFinalMs)}; cleanup ${valueMs(measurements.agentCleanupMaxMs)}; diagnosis ${measurements.agentLatencyDiagnosis?.kind ?? "unknown"}; leaks ${measurements.agentProcessLeakCount ?? "unknown"}`);
   lines.push(`- plugins/runtime: missing deps ${measurements.missingDependencyErrors ?? "unknown"}; plugin failures ${measurements.pluginLoadFailures ?? "unknown"}; runtime deps ${valueMs(measurements.runtimeDepsStagingMs)}${runtimeDepsPluginText(measurements)}; warm restages ${measurements.warmRuntimeDepsRestageCount ?? "unknown"}; warm reuse ${measurements.runtimeDepsWarmReuseOk ?? "unknown"}`);
 
@@ -1184,6 +1188,34 @@ function valueMb(value) {
 
 function valuePercent(value) {
   return value === null || value === undefined ? "unknown" : `${value}%`;
+}
+
+function resourceHeadlineEvidenceLabel(measurements) {
+  const role = measurements.resourcePrimaryRole ?? null;
+  if (measurements.resourceGateKind === "role-missing") {
+    return role ? `${role}RssMbNotObserved` : "resourceRoleNotObserved";
+  }
+  if (measurements.resourceGateKind === "tracked-total") {
+    return "trackedTotalRssMb";
+  }
+  if (role === "gateway" || !role) {
+    return "gatewayRssMb";
+  }
+  return `${role}RssMb`;
+}
+
+function resourceHeadlineText(measurements) {
+  const role = measurements.resourcePrimaryRole ?? null;
+  if (measurements.resourceGateKind === "role-missing") {
+    return role ? `${role} RSS not observed` : "Primary RSS not observed";
+  }
+  if (measurements.resourceGateKind === "tracked-total") {
+    return "Tracked total RSS";
+  }
+  if (role === "gateway" || !role) {
+    return "Gateway RSS";
+  }
+  return `${role} RSS`;
 }
 
 function buildFixerPrompt({ report, primaryBlocker, why, measurements, evidence, likelyOwner }) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -16,7 +16,7 @@ import {
 } from "./performance/baselines.mjs";
 import { buildPerformanceSummary } from "./performance/stats.mjs";
 import { loadProcessRoles } from "./registries/process-roles.mjs";
-import { validateScenarioShape } from "./registries/scenarios.mjs";
+import { loadScenarios, validateScenarioShape } from "./registries/scenarios.mjs";
 import { validateStateShape } from "./registries/states.mjs";
 import { validateRegistryReferences } from "./registries/validate.mjs";
 import { assertSafeScenarioCommand } from "./safety.mjs";
@@ -338,6 +338,7 @@ export async function runSelfCheck(flags = {}) {
     checks.push(diagnosticsTimelineEvaluationCheck());
     checks.push(runtimeDepsLogParserCheck());
     checks.push(embeddedRunLogParserCheck());
+    checks.push(await bundledRuntimeDepsScenarioCheck());
     checks.push(runtimeDepsWarmReuseEvaluationCheck());
     checks.push(await performanceBaselineCheck(tmp));
     checks.push(markdownFailureCardsCheck());
@@ -3443,6 +3444,33 @@ function runtimeDepsWarmReuseEvaluationCheck() {
     assertEqual(cleanRecord.measurements.warmRuntimeDepsRestageCount, 0, "warm restage count");
     assertEqual(cleanRecord.measurements.runtimeDepsWarmReuseOk, true, "warm reuse ok");
 
+    const missingEvidenceRecord = runtimeDepsRecord({
+      coldLog,
+      warmLog: coldLog,
+      includeRuntimeDepsEvidence: false
+    });
+    evaluateRecord(missingEvidenceRecord, scenario, { surface, targetPlan: { kind: "npm" } });
+    assertEqual(missingEvidenceRecord.status, "FAIL", "missing runtime deps evidence status");
+    assertEqual(missingEvidenceRecord.measurements.runtimeDepsWarmReuseOk, null, "missing evidence leaves warm reuse unknown");
+    assertEqual(
+      missingEvidenceRecord.violations.some((violation) => violation.metric === "runtimeDepsWarmReuseOk"),
+      true,
+      "missing runtime deps evidence violation"
+    );
+
+    const emptyEvidenceRecord = runtimeDepsRecord({
+      coldLog: "",
+      warmLog: ""
+    });
+    evaluateRecord(emptyEvidenceRecord, scenario, { surface, targetPlan: { kind: "npm" } });
+    assertEqual(emptyEvidenceRecord.status, "FAIL", "empty runtime deps evidence status");
+    assertEqual(emptyEvidenceRecord.measurements.runtimeDepsWarmReuseOk, null, "empty evidence leaves warm reuse unknown");
+    assertEqual(
+      emptyEvidenceRecord.violations.some((violation) => violation.metric === "runtimeDepsWarmReuseOk"),
+      true,
+      "empty runtime deps evidence violation"
+    );
+
     const restagedRecord = runtimeDepsRecord({
       coldLog,
       warmLog: [
@@ -3488,25 +3516,61 @@ function runtimeDepsWarmReuseEvaluationCheck() {
   }
 }
 
-function runtimeDepsRecord({ coldLog, warmLog }) {
+async function bundledRuntimeDepsScenarioCheck() {
+  try {
+    const [scenario] = await loadScenarios("bundled-runtime-deps");
+    const lifecycleCommands = scenario.phases.flatMap((phase) => phase.commands ?? []);
+    for (const [index, command] of lifecycleCommands.entries()) {
+      if (!/^ocm (?:start|service restart) /.test(command)) {
+        continue;
+      }
+      const nextCommand = lifecycleCommands[index + 1] ?? "";
+      if (/^ocm logs /.test(nextCommand)) {
+        throw new Error(`bundled-runtime-deps runs logs immediately after '${command}'`);
+      }
+    }
+    assertEqual(
+      lifecycleCommands.some((command) => /^ocm logs /.test(command)),
+      false,
+      "bundled runtime deps scenario relies on phase log metrics"
+    );
+
+    return {
+      id: "bundled-runtime-deps-scenario",
+      status: "PASS",
+      command: "validate bundled runtime deps scenario log collection",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "bundled-runtime-deps-scenario",
+      status: "FAIL",
+      command: "validate bundled runtime deps scenario log collection",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function runtimeDepsRecord({ coldLog, warmLog, includeRuntimeDepsEvidence = true }) {
   return {
     scenario: "bundled-runtime-deps",
     status: "PASS",
     phases: [
       {
         id: "cold-start",
-        results: [{ command: "ocm logs kova-runtime-deps --tail 300 --raw", status: 0, stdout: coldLog, stderr: "", durationMs: 100 }],
+        results: [{ command: "ocm start kova-runtime-deps runtime:stable --json", status: 0, stdout: "", stderr: "", durationMs: 100 }],
         metrics: {
           service: { gatewayState: "running" },
-          logs: zeroLogMetrics()
+          logs: runtimeDepsLogMetrics(coldLog, includeRuntimeDepsEvidence)
         }
       },
       {
         id: "warm-restart",
-        results: [{ command: "ocm logs kova-runtime-deps --tail 300 --raw", status: 0, stdout: warmLog, stderr: "", durationMs: 100 }],
+        results: [{ command: "ocm service restart kova-runtime-deps", status: 0, stdout: "", stderr: "", durationMs: 100 }],
         metrics: {
           service: { gatewayState: "running" },
-          logs: zeroLogMetrics()
+          logs: runtimeDepsLogMetrics(warmLog, includeRuntimeDepsEvidence)
         }
       }
     ],
@@ -3514,6 +3578,14 @@ function runtimeDepsRecord({ coldLog, warmLog }) {
       service: { gatewayState: "running" },
       logs: zeroLogMetrics()
     }
+  };
+}
+
+function runtimeDepsLogMetrics(log, includeRuntimeDepsEvidence) {
+  return {
+    ...zeroLogMetrics(),
+    commandStatus: 0,
+    ...(includeRuntimeDepsEvidence ? { runtimeDeps: summarizeRuntimeDepsLogs(log) } : {})
   };
 }
 

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -18,6 +18,7 @@ import { buildPerformanceSummary } from "./performance/stats.mjs";
 import { loadProcessRoles } from "./registries/process-roles.mjs";
 import { loadScenarios, validateScenarioShape } from "./registries/scenarios.mjs";
 import { validateStateShape } from "./registries/states.mjs";
+import { loadSurfaces } from "./registries/surfaces.mjs";
 import { validateRegistryReferences } from "./registries/validate.mjs";
 import { assertSafeScenarioCommand } from "./safety.mjs";
 import { parseTimelineText } from "./collectors/timeline.mjs";
@@ -35,7 +36,12 @@ import {
   parseProviderRequestLog,
   parseTimelineProviderRequestLog
 } from "./collectors/provider.mjs";
-import { captureProcessSnapshot, classifyRegistryRolesForProcess, diffProcessSnapshots } from "./collectors/resources.mjs";
+import {
+  captureProcessSnapshot,
+  classifyRegistryRolesForProcess,
+  diffProcessSnapshots,
+  summarizeResourceSamples
+} from "./collectors/resources.mjs";
 import { renderMarkdownReport, renderPasteSummary, renderReportSummary } from "./reporting/report.mjs";
 import { compareReports, renderCompareSummary } from "./reporting/compare.mjs";
 import {
@@ -111,6 +117,8 @@ export async function runSelfCheck(flags = {}) {
     checks.push(ocmCommandBuildersCheck());
     checks.push(evaluationViolationHelpersCheck());
     checks.push(localBuildTargetSetupResourceExclusionCheck());
+    checks.push(primaryResourceRoleEvaluationCheck());
+    checks.push(await primaryResourceRoleRegistryCheck());
     checks.push(await jsonCommandCheck("plan-json", "node bin/kova.mjs plan --json", (data) => {
       assertEqual(data.schemaVersion, "kova.plan.v1", "plan schema");
       assertArrayNotEmpty(data.surfaces, "plan surfaces");
@@ -585,16 +593,28 @@ function localBuildTargetSetupResourceExclusionCheck() {
         },
         {
           id: "scenario-command",
-          results: [{
-            command: "ocm @kova-self-check -- status",
-            status: 0,
-            durationMs: 100,
-            resourceSamples: syntheticResourceSamples({
-              peakRssMb: 100,
-              maxCpuPercent: 20,
-              role: "gateway"
-            })
-          }]
+          results: [
+            {
+              command: "ocm @kova-self-check -- status",
+              status: 0,
+              durationMs: 100,
+              resourceSamples: syntheticResourceSamples({
+                peakRssMb: 100,
+                maxCpuPercent: 20,
+                role: "gateway"
+              })
+            },
+            {
+              command: "node support/kova-helper.mjs",
+              status: 0,
+              durationMs: 100,
+              resourceSamples: syntheticResourceSamples({
+                peakRssMb: 600,
+                maxCpuPercent: 30,
+                role: "command-tree"
+              })
+            }
+          ]
         }
       ],
       finalMetrics: {
@@ -602,12 +622,15 @@ function localBuildTargetSetupResourceExclusionCheck() {
         logs: zeroLogMetrics()
       }
     };
-    evaluateRecord(record, { thresholds: { peakRssMb: 900 } }, {
-      surface: { thresholds: {} },
+    evaluateRecord(record, { thresholds: { peakRssMb: 200 } }, {
+      surface: { thresholds: {}, resourcePrimaryRole: "gateway" },
       targetPlan: { kind: "local-build" }
     });
     assertEqual(record.status, "PASS", "local-build target setup resources ignored status");
     assertEqual(record.measurements.peakRssMb, 100, "local-build target setup resources ignored RSS");
+    assertEqual(record.measurements.resourcePeakTrackedRssMb, 600, "tracked product helper RSS retained separately");
+    assertEqual(record.measurements.resourcePrimaryRole, "gateway", "primary resource role retained");
+    assertEqual(record.measurements.resourceGateKind, "role", "primary resource role gates headline RSS");
     assertEqual(record.measurements.resourceByRole.gateway.peakRssMb, 100, "scenario role RSS retained");
     assertEqual(record.measurements.resourceByRole["build-tooling"], undefined, "target setup role excluded");
     assertEqual(record.violations, undefined, "no-service local-build record has no gateway violation");
@@ -622,6 +645,153 @@ function localBuildTargetSetupResourceExclusionCheck() {
       id: "local-build-target-setup-resource-exclusion",
       status: "FAIL",
       command: "evaluate local-build target setup resource exclusion",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function primaryResourceRoleEvaluationCheck() {
+  try {
+    const scenario = { thresholds: { peakRssMb: 900 } };
+    const gatewayRecord = syntheticPrimaryResourceRecord();
+    evaluateRecord(gatewayRecord, scenario, {
+      surface: { thresholds: {}, roleThresholds: {}, resourcePrimaryRole: "gateway" }
+    });
+    assertEqual(gatewayRecord.status, "PASS", "configured gateway role gates below threshold");
+    assertEqual(gatewayRecord.measurements.peakRssMb, 700, "configured gateway role is headline RSS");
+    assertEqual(gatewayRecord.measurements.resourcePeakTrackedRssMb, 1250, "aggregate RSS remains diagnostic");
+    assertEqual(gatewayRecord.measurements.resourceGateKind, "role", "configured gateway uses role gate");
+
+    const pluginRecord = syntheticPrimaryResourceRecord();
+    evaluateRecord(pluginRecord, scenario, {
+      surface: { thresholds: {}, roleThresholds: {}, resourcePrimaryRole: "plugin-cli" }
+    });
+    assertEqual(pluginRecord.status, "FAIL", "configured plugin role gates above threshold");
+    assertEqual(pluginRecord.measurements.peakRssMb, 1000, "configured plugin role is headline RSS");
+    assertEqual(pluginRecord.measurements.resourcePeakTrackedRssMb, 1250, "failed role keeps aggregate diagnostic");
+    assertEqual(
+      pluginRecord.violations.some((violation) => violation.metric === "peakRssMb"),
+      true,
+      "configured plugin role produces headline threshold violation"
+    );
+
+    const missingRoleRecord = syntheticPrimaryResourceRecord();
+    evaluateRecord(missingRoleRecord, scenario, {
+      surface: { thresholds: {}, roleThresholds: {}, resourcePrimaryRole: "mcp-runtime" }
+    });
+    assertEqual(missingRoleRecord.status, "FAIL", "missing configured role fails closed");
+    assertEqual(missingRoleRecord.measurements.peakRssMb, null, "missing role does not relabel aggregate RSS");
+    assertEqual(missingRoleRecord.measurements.resourcePeakTrackedRssMb, 1250, "missing role keeps aggregate diagnostic");
+    assertEqual(missingRoleRecord.measurements.resourceGateKind, "role-missing", "missing role gate kind");
+    assertEqual(
+      missingRoleRecord.violations.some((violation) => violation.metric === "resourceByRole.mcp-runtime.missing"),
+      true,
+      "missing configured role violation"
+    );
+
+    return {
+      id: "primary-resource-role-evaluation",
+      status: "PASS",
+      command: "evaluate configured primary resource role gating",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "primary-resource-role-evaluation",
+      status: "FAIL",
+      command: "evaluate configured primary resource role gating",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function syntheticPrimaryResourceRecord() {
+  return {
+    scenario: "synthetic-primary-resource-role",
+    status: "PASS",
+    phases: [{
+      id: "sample",
+      results: [{
+        command: "synthetic resource sample",
+        status: 0,
+        durationMs: 1,
+        resourceSamples: {
+          schemaVersion: "kova.resourceSamples.v1",
+          sampleCount: 1,
+          peakTotalRssMb: 1250,
+          maxTotalCpuPercent: 180,
+          peakCommandTreeRssMb: 1000,
+          peakGatewayRssMb: 700,
+          byRole: {
+            gateway: { peakRssMb: 700, maxCpuPercent: 80, peakProcessCount: 1 },
+            "plugin-cli": { peakRssMb: 1000, maxCpuPercent: 180, peakProcessCount: 1 }
+          },
+          topRolesByRss: [
+            { role: "plugin-cli", peakRssMb: 1000, maxCpuPercent: 180 },
+            { role: "gateway", peakRssMb: 700, maxCpuPercent: 80 }
+          ],
+          topRolesByCpu: [
+            { role: "plugin-cli", peakRssMb: 1000, maxCpuPercent: 180 },
+            { role: "gateway", peakRssMb: 700, maxCpuPercent: 80 }
+          ],
+          topByRss: [],
+          topByCpu: []
+        }
+      }],
+      metrics: { logs: zeroLogMetrics() }
+    }],
+    finalMetrics: {
+      service: { gatewayState: "running" },
+      logs: zeroLogMetrics()
+    }
+  };
+}
+
+async function primaryResourceRoleRegistryCheck() {
+  try {
+    const scenarios = await loadScenarios();
+    const surfaces = await loadSurfaces();
+    const surfaceById = new Map(surfaces.map((surface) => [surface.id, surface]));
+    const gatedSurfaceIds = new Set(
+      surfaces
+        .filter((surface) =>
+          typeof surface.thresholds?.peakRssMb === "number" ||
+          surface.requiredMetrics?.includes("peakRssMb")
+        )
+        .map((surface) => surface.id)
+    );
+    for (const scenario of scenarios) {
+      if (typeof scenario.thresholds?.peakRssMb === "number") {
+        gatedSurfaceIds.add(scenario.surface);
+      }
+    }
+    for (const surfaceId of gatedSurfaceIds) {
+      const surface = surfaceById.get(surfaceId);
+      assertEqual(
+        typeof surface?.resourcePrimaryRole === "string" && surface.resourcePrimaryRole.length > 0,
+        true,
+        `${surfaceId} declares its primary RSS role`
+      );
+      assertEqual(
+        surface.processRoles?.includes(surface.resourcePrimaryRole),
+        true,
+        `${surfaceId} primary RSS role belongs to its process roles`
+      );
+    }
+
+    return {
+      id: "primary-resource-role-registry",
+      status: "PASS",
+      command: "validate primary resource roles for RSS-gated surfaces",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "primary-resource-role-registry",
+      status: "FAIL",
+      command: "validate primary resource roles for RSS-gated surfaces",
       durationMs: 0,
       message: error.message
     };
@@ -881,9 +1051,9 @@ async function performanceBaselineCheck(tmp) {
       platform,
       target: "local-build:/tmp/openclaw",
       records: [
-        syntheticPerformanceRecord(1, { timeToHealthReadyMs: 1000, peakRssMb: 400, cpuPercentMax: 20, eventLoopDelayMs: 100, agentTurnMs: 2000 }),
-        syntheticPerformanceRecord(2, { timeToHealthReadyMs: 1200, peakRssMb: 420, cpuPercentMax: 22, eventLoopDelayMs: 110, agentTurnMs: 2200 }),
-        syntheticPerformanceRecord(3, { timeToHealthReadyMs: 1100, peakRssMb: 410, cpuPercentMax: 21, eventLoopDelayMs: 105, agentTurnMs: 2100 })
+        syntheticPerformanceRecord(1, { timeToHealthReadyMs: 1000, peakRssMb: 400, resourcePeakGatewayRssMb: 400, cpuPercentMax: 20, eventLoopDelayMs: 100, agentTurnMs: 2000 }),
+        syntheticPerformanceRecord(2, { timeToHealthReadyMs: 1200, peakRssMb: 420, resourcePeakGatewayRssMb: 420, cpuPercentMax: 22, eventLoopDelayMs: 110, agentTurnMs: 2200 }),
+        syntheticPerformanceRecord(3, { timeToHealthReadyMs: 1100, peakRssMb: 410, resourcePeakGatewayRssMb: 410, cpuPercentMax: 21, eventLoopDelayMs: 105, agentTurnMs: 2100 })
       ]
     });
     baselineReport.performance = buildPerformanceSummary(baselineReport.records, { repeat: 3 });
@@ -930,15 +1100,20 @@ async function performanceBaselineCheck(tmp) {
     await saveBaselineStore(baselinePath, savedStore);
     const loadedStore = await loadBaselineStore(baselinePath);
     assertEqual(Object.keys(loadedStore.entries).length, 1, "baseline entry count");
+    assertEqual(
+      Object.values(loadedStore.entries)[0]?.aggregate?.resourceHeadlineContract,
+      "primary-role-v1",
+      "baseline stores resource headline contract"
+    );
 
     const currentReport = syntheticPerformanceReport({
       runId: "current",
       platform,
       target: "local-build:/tmp/openclaw",
       records: [
-        syntheticPerformanceRecord(1, { timeToHealthReadyMs: 1800, peakRssMb: 500, cpuPercentMax: 30, eventLoopDelayMs: 180, agentTurnMs: 3000 }),
-        syntheticPerformanceRecord(2, { timeToHealthReadyMs: 1900, peakRssMb: 510, cpuPercentMax: 31, eventLoopDelayMs: 190, agentTurnMs: 3100 }),
-        syntheticPerformanceRecord(3, { timeToHealthReadyMs: 2000, peakRssMb: 520, cpuPercentMax: 32, eventLoopDelayMs: 200, agentTurnMs: 3200 })
+        syntheticPerformanceRecord(1, { timeToHealthReadyMs: 1800, peakRssMb: 500, resourcePeakGatewayRssMb: 500, cpuPercentMax: 30, eventLoopDelayMs: 180, agentTurnMs: 3000 }),
+        syntheticPerformanceRecord(2, { timeToHealthReadyMs: 1900, peakRssMb: 510, resourcePeakGatewayRssMb: 510, cpuPercentMax: 31, eventLoopDelayMs: 190, agentTurnMs: 3100 }),
+        syntheticPerformanceRecord(3, { timeToHealthReadyMs: 2000, peakRssMb: 520, resourcePeakGatewayRssMb: 520, cpuPercentMax: 32, eventLoopDelayMs: 200, agentTurnMs: 3200 })
       ]
     });
     currentReport.performance = buildPerformanceSummary(currentReport.records, { repeat: 3 });
@@ -957,6 +1132,42 @@ async function performanceBaselineCheck(tmp) {
     });
     assertEqual(comparison.ok, false, "baseline comparison regression");
     assertEqual(comparison.regressions.some((regression) => regression.metric === "timeToHealthReadyMs"), true, "startup regression present");
+    assertEqual(comparison.regressions.some((regression) => regression.metric === "peakRssMb"), true, "compatible primary RSS regression present");
+    assertEqual(
+      comparison.regressions.some((regression) => regression.metric === "resourcePeakGatewayRssMb"),
+      true,
+      "compatible exact gateway RSS regression present"
+    );
+    assertEqual(comparison.regressions.some((regression) => regression.metric === "cpuPercentMax"), true, "compatible primary CPU regression present");
+
+    const legacyStore = structuredClone(loadedStore);
+    delete Object.values(legacyStore.entries)[0].aggregate.resourceHeadlineContract;
+    const legacyComparison = comparePerformanceToBaseline(currentReport, legacyStore, {
+      targetPlan,
+      regressionThresholds: { rssRegressionPercent: 10 }
+    });
+    assertEqual(
+      legacyComparison.regressions.some((regression) => regression.metric === "peakRssMb"),
+      false,
+      "legacy aggregate RSS is not compared with primary RSS"
+    );
+    assertEqual(
+      legacyComparison.regressions.some((regression) => regression.metric === "cpuPercentMax"),
+      false,
+      "legacy aggregate CPU is not compared with primary CPU"
+    );
+    assertEqual(
+      legacyComparison.regressions.some((regression) => regression.metric === "resourcePeakGatewayRssMb"),
+      false,
+      "legacy substring gateway RSS is not compared with exact gateway RSS"
+    );
+    assertEqual(
+      legacyComparison.groups[0]?.skippedMetrics?.includes("peakRssMb") &&
+        legacyComparison.groups[0]?.skippedMetrics?.includes("resourcePeakGatewayRssMb") &&
+        legacyComparison.groups[0]?.skippedMetrics?.includes("cpuPercentMax"),
+      true,
+      "legacy resource contract mismatch is reported"
+    );
     const regressedReview = reviewBaselineUpdate({
       ...currentReport,
       baseline: { path: baselinePath, comparison }
@@ -3825,6 +4036,14 @@ async function resourceRolePollutionCheck() {
         existingRoles: ["command-tree"]
       }
     );
+    const networkOfflineRoles = classifyRegistryRolesForProcess(
+      { command: "node support/agent-network-offline.mjs --env kova-agent-network-offline" },
+      {
+        processRoles,
+        rootCommand: "node support/agent-network-offline.mjs --env kova-agent-network-offline",
+        existingRoles: ["command-tree"]
+      }
+    );
     const openclawAgentRoles = classifyRegistryRolesForProcess(
       { command: "openclaw-agent" },
       {
@@ -3833,6 +4052,28 @@ async function resourceRolePollutionCheck() {
         existingRoles: ["command-tree"]
       }
     );
+    const resourceSummary = summarizeResourceSamples([{
+      timestamp: "2026-05-07T00:00:00.000Z",
+      elapsedMs: 1000,
+      processes: [
+        {
+          pid: 100,
+          rssMb: 700,
+          cpuPercent: 100,
+          roles: ["gateway", "gateway-tree"],
+          role: "gateway,gateway-tree",
+          command: "openclaw"
+        },
+        {
+          pid: 101,
+          rssMb: 60,
+          cpuPercent: 1,
+          roles: ["command-tree", "gateway-session-client", "gateway-tree"],
+          role: "command-tree,gateway-session-client,gateway-tree",
+          command: "node support/run-gateway-session-send-turn.mjs"
+        }
+      ]
+    }]);
 
     assertEqual(mockProviderRoles.includes("mock-provider"), true, "mock provider helper remains classified");
     assertEqual(mockProviderRoles.includes("agent-cli"), false, "KOVA_AGENT_OK marker must not imply agent-cli");
@@ -3840,8 +4081,12 @@ async function resourceRolePollutionCheck() {
     assertEqual(mockProviderRoles.includes("browser-sidecar"), false, "browser env name must not imply browser-sidecar");
     assertEqual(envNameRoles.includes("runtime-management"), false, "mcp-runtime env name must not imply runtime-management");
     assertEqual(envNameRoles.includes("model-cli"), false, "configure-openclaw fixture helper must not imply model-cli");
+    assertEqual(networkOfflineRoles.includes("agent-cli"), true, "network offline wrapper keeps agent-cli sampling alive");
     assertEqual(openclawAgentRoles.includes("agent-cli"), true, "openclaw-agent process must imply agent-cli");
     assertEqual(openclawAgentRoles.includes("agent-process"), true, "openclaw-agent process must imply agent-process");
+    assertEqual(resourceSummary.peakGatewayRssMb, 700, "gateway-tree descendants do not inflate gateway RSS");
+    assertEqual(resourceSummary.peakCommandTreeRssMb, 60, "gateway session client remains command-tree RSS");
+    assertEqual(resourceSummary.byRole["gateway-tree"].peakRssMb, 760, "gateway-tree aggregate remains diagnostic");
     return {
       id: "resource-role-pollution-boundary",
       status: "PASS",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3725,17 +3725,29 @@ function runtimeDepsWarmReuseEvaluationCheck() {
       "missing runtime deps evidence violation"
     );
 
-    const emptyEvidenceRecord = runtimeDepsRecord({
+    const zeroEventEvidenceRecord = runtimeDepsRecord({
       coldLog: "",
       warmLog: ""
     });
-    evaluateRecord(emptyEvidenceRecord, scenario, { surface, targetPlan: { kind: "npm" } });
-    assertEqual(emptyEvidenceRecord.status, "FAIL", "empty runtime deps evidence status");
-    assertEqual(emptyEvidenceRecord.measurements.runtimeDepsWarmReuseOk, null, "empty evidence leaves warm reuse unknown");
+    evaluateRecord(zeroEventEvidenceRecord, scenario, { surface, targetPlan: { kind: "npm" } });
+    assertEqual(zeroEventEvidenceRecord.status, "PASS", "successful zero-event runtime deps evidence status");
+    assertEqual(zeroEventEvidenceRecord.measurements.runtimeDepsLogEvidence.phaseMetricsAvailable, true, "zero-event phase metrics available");
+    assertEqual(zeroEventEvidenceRecord.measurements.coldRuntimeDepsInstallCount, 0, "zero-event cold install count");
+    assertEqual(zeroEventEvidenceRecord.measurements.warmRuntimeDepsRestageCount, 0, "zero-event warm restage count");
+    assertEqual(zeroEventEvidenceRecord.measurements.runtimeDepsWarmReuseOk, true, "zero-event warm reuse ok");
+
+    const collectorFailureRecord = runtimeDepsRecord({
+      coldLog: "",
+      warmLog: "",
+      coldLogStatus: 1
+    });
+    evaluateRecord(collectorFailureRecord, scenario, { surface, targetPlan: { kind: "npm" } });
+    assertEqual(collectorFailureRecord.status, "FAIL", "failed runtime deps collector status");
+    assertEqual(collectorFailureRecord.measurements.runtimeDepsWarmReuseOk, null, "collector failure leaves warm reuse unknown");
     assertEqual(
-      emptyEvidenceRecord.violations.some((violation) => violation.metric === "runtimeDepsWarmReuseOk"),
+      collectorFailureRecord.violations.some((violation) => violation.metric === "runtimeDepsWarmReuseOk"),
       true,
-      "empty runtime deps evidence violation"
+      "failed runtime deps collector violation"
     );
 
     const restagedRecord = runtimeDepsRecord({
@@ -3819,7 +3831,13 @@ async function bundledRuntimeDepsScenarioCheck() {
   }
 }
 
-function runtimeDepsRecord({ coldLog, warmLog, includeRuntimeDepsEvidence = true }) {
+function runtimeDepsRecord({
+  coldLog,
+  warmLog,
+  includeRuntimeDepsEvidence = true,
+  coldLogStatus = 0,
+  warmLogStatus = 0
+}) {
   return {
     scenario: "bundled-runtime-deps",
     status: "PASS",
@@ -3829,7 +3847,8 @@ function runtimeDepsRecord({ coldLog, warmLog, includeRuntimeDepsEvidence = true
         results: [{ command: "ocm start kova-runtime-deps runtime:stable --json", status: 0, stdout: "", stderr: "", durationMs: 100 }],
         metrics: {
           service: { gatewayState: "running" },
-          logs: runtimeDepsLogMetrics(coldLog, includeRuntimeDepsEvidence)
+          readiness: { ready: true },
+          logs: runtimeDepsLogMetrics(coldLog, includeRuntimeDepsEvidence, coldLogStatus)
         }
       },
       {
@@ -3837,7 +3856,8 @@ function runtimeDepsRecord({ coldLog, warmLog, includeRuntimeDepsEvidence = true
         results: [{ command: "ocm service restart kova-runtime-deps", status: 0, stdout: "", stderr: "", durationMs: 100 }],
         metrics: {
           service: { gatewayState: "running" },
-          logs: runtimeDepsLogMetrics(warmLog, includeRuntimeDepsEvidence)
+          readiness: { ready: true },
+          logs: runtimeDepsLogMetrics(warmLog, includeRuntimeDepsEvidence, warmLogStatus)
         }
       }
     ],
@@ -3848,10 +3868,12 @@ function runtimeDepsRecord({ coldLog, warmLog, includeRuntimeDepsEvidence = true
   };
 }
 
-function runtimeDepsLogMetrics(log, includeRuntimeDepsEvidence) {
+function runtimeDepsLogMetrics(log, includeRuntimeDepsEvidence, commandStatus) {
   return {
     ...zeroLogMetrics(),
-    commandStatus: 0,
+    schemaVersion: "kova.logMetrics.v1",
+    commandStatus,
+    timedOut: false,
     ...(includeRuntimeDepsEvidence ? { runtimeDeps: summarizeRuntimeDepsLogs(log) } : {})
   };
 }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -16,6 +16,7 @@ import {
 } from "./performance/baselines.mjs";
 import { buildPerformanceSummary } from "./performance/stats.mjs";
 import { loadProcessRoles } from "./registries/process-roles.mjs";
+import { loadProfile } from "./registries/profiles.mjs";
 import { loadScenarios, validateScenarioShape } from "./registries/scenarios.mjs";
 import { validateStateShape } from "./registries/states.mjs";
 import { loadSurfaces } from "./registries/surfaces.mjs";
@@ -62,6 +63,7 @@ import {
   checkRoleThresholds,
   checkTurnThreshold
 } from "./evaluation/violations.mjs";
+import { resolveThresholdPolicy } from "./evaluation/thresholds.mjs";
 
 export async function runSelfCheck(flags = {}) {
   const checks = [];
@@ -119,6 +121,7 @@ export async function runSelfCheck(flags = {}) {
     checks.push(localBuildTargetSetupResourceExclusionCheck());
     checks.push(primaryResourceRoleEvaluationCheck());
     checks.push(await primaryResourceRoleRegistryCheck());
+    checks.push(await releaseResourceCalibrationCheck());
     checks.push(await jsonCommandCheck("plan-json", "node bin/kova.mjs plan --json", (data) => {
       assertEqual(data.schemaVersion, "kova.plan.v1", "plan schema");
       assertArrayNotEmpty(data.surfaces, "plan surfaces");
@@ -792,6 +795,59 @@ async function primaryResourceRoleRegistryCheck() {
       id: "primary-resource-role-registry",
       status: "FAIL",
       command: "validate primary resource roles for RSS-gated surfaces",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function releaseResourceCalibrationCheck() {
+  try {
+    const [scenarios, surfaces, releaseProfile] = await Promise.all([
+      loadScenarios(),
+      loadSurfaces(),
+      loadProfile("release")
+    ]);
+    const scenarioById = new Map(scenarios.map((scenario) => [scenario.id, scenario]));
+    const surfaceById = new Map(surfaces.map((surface) => [surface.id, surface]));
+
+    for (const scenarioId of ["fresh-install", "gateway-performance"]) {
+      const scenario = scenarioById.get(scenarioId);
+      const surface = surfaceById.get(scenarioId);
+      assertEqual(scenario?.thresholds?.peakRssMb, 1050, `${scenarioId} scenario primary RSS cap`);
+      assertEqual(surface?.thresholds?.peakRssMb, 1050, `${scenarioId} surface primary RSS cap`);
+    }
+
+    const expectedRoleCaps = {
+      "fresh-install": { gateway: 1050, "status-cli": 850, "plugin-cli": 800 },
+      "gateway-performance": { gateway: 1050, "gateway-tree": 1200, "status-cli": 850 },
+      "bundled-runtime-deps": { gateway: 1050 },
+      "bundled-plugin-startup": { gateway: 800, "plugin-cli": 800 }
+    };
+    for (const [surfaceId, roleCaps] of Object.entries(expectedRoleCaps)) {
+      const surface = surfaceById.get(surfaceId);
+      const scenario = scenarioById.get(surfaceId) ?? null;
+      const policy = resolveThresholdPolicy({ profile: releaseProfile, surface, scenario });
+      for (const [role, peakRssMb] of Object.entries(roleCaps)) {
+        assertEqual(policy.roleThresholds?.[role]?.peakRssMb, peakRssMb, `${surfaceId} ${role} RSS cap`);
+      }
+    }
+
+    assertEqual(releaseProfile.calibration?.roles?.gateway?.peakRssMb, 900, "global release gateway RSS cap");
+    assertEqual(releaseProfile.calibration?.roles?.["plugin-cli"]?.peakRssMb, 650, "global release plugin RSS cap");
+    assertEqual(releaseProfile.calibration?.roles?.["status-cli"], undefined, "global release status role stays uncalibrated");
+
+    return {
+      id: "release-resource-calibration",
+      status: "PASS",
+      command: "validate release resource calibration scope",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "release-resource-calibration",
+      status: "FAIL",
+      command: "validate release resource calibration scope",
       durationMs: 0,
       message: error.message
     };

--- a/surfaces/agent-cli-local-turn.json
+++ b/surfaces/agent-cli-local-turn.json
@@ -7,6 +7,7 @@
   "targetKinds": ["npm", "channel", "runtime", "local-build"],
   "requiredMetrics": ["agentTurnMs", "agentTurnP95Ms", "agentTurnMaxMs", "coldAgentTurnMs", "warmAgentTurnMs", "agentColdWarmDeltaMs", "coldPreProviderMs", "warmPreProviderMs", "agentPreProviderP95Ms", "agentCleanupMaxMs", "healthP95Ms", "peakRssMb", "providerTimeoutMentions", "pluginLoadFailures"],
   "processRoles": ["gateway", "command-tree", "agent-cli", "agent-process", "mock-provider"],
+  "resourcePrimaryRole": "agent-cli",
   "thresholds": { "agentTurnMs": 45000, "coldAgentTurnMs": 45000, "warmAgentTurnMs": 15000, "coldWarmDeltaMs": 30000, "preProviderMs": 10000, "providerFinalMs": 3000, "agentCleanupMs": 5000, "healthP95Ms": 1000, "peakRssMb": 900 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 700, "maxCpuPercent": 250 },

--- a/surfaces/agent-gateway-rpc-turn.json
+++ b/surfaces/agent-gateway-rpc-turn.json
@@ -7,6 +7,7 @@
   "targetKinds": ["npm", "channel", "runtime", "local-build"],
   "requiredMetrics": ["agentTurnMs", "agentTurnP95Ms", "agentTurnMaxMs", "coldPreProviderMs", "healthP95Ms", "peakRssMb", "pluginLoadFailures"],
   "processRoles": ["gateway", "command-tree", "agent-cli", "agent-process", "mock-provider"],
+  "resourcePrimaryRole": "agent-cli",
   "thresholds": { "agentTurnMs": 45000, "preProviderMs": 10000, "providerFinalMs": 3000, "healthP95Ms": 1000, "peakRssMb": 900 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 700, "maxCpuPercent": 250 },

--- a/surfaces/browser-automation.json
+++ b/surfaces/browser-automation.json
@@ -19,6 +19,7 @@
     "pluginLoadFailures"
   ],
   "processRoles": ["gateway", "gateway-tree", "command-tree", "browser-sidecar", "status-cli"],
+  "resourcePrimaryRole": "browser-sidecar",
   "thresholds": {
     "gatewayReadyMs": 30000,
     "statusMs": 10000,

--- a/surfaces/bundled-plugin-startup.json
+++ b/surfaces/bundled-plugin-startup.json
@@ -10,6 +10,7 @@
   "thresholds": { "gatewayReadyMs": 30000, "gatewayReadyHardTimeoutMs": 120000, "runtimeDepsStagingMs": 30000 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 800, "maxCpuPercent": 250 },
+    "plugin-cli": { "peakRssMb": 800, "maxCpuPercent": 250 },
     "runtime-staging": { "peakRssMb": 900, "maxCpuPercent": 350 },
     "package-manager": { "peakRssMb": 900, "maxCpuPercent": 350 }
   },

--- a/surfaces/bundled-runtime-deps.json
+++ b/surfaces/bundled-runtime-deps.json
@@ -24,7 +24,7 @@
     "warmRuntimeDepsStagingMs": 5000
   },
   "roleThresholds": {
-    "gateway": { "peakRssMb": 800, "maxCpuPercent": 250 },
+    "gateway": { "peakRssMb": 1050, "maxCpuPercent": 250 },
     "runtime-staging": { "peakRssMb": 900, "maxCpuPercent": 350 },
     "package-manager": { "peakRssMb": 900, "maxCpuPercent": 350 }
   },

--- a/surfaces/cross-platform-smoke.json
+++ b/surfaces/cross-platform-smoke.json
@@ -7,6 +7,7 @@
   "targetKinds": ["npm", "channel", "runtime", "local-build"],
   "requiredMetrics": ["gatewayReadyMs", "healthMs", "syncFsStallDetected", "peakRssMb"],
   "processRoles": ["gateway", "command-tree", "status-cli"],
+  "resourcePrimaryRole": "gateway",
   "thresholds": { "gatewayReadyMs": 45000, "healthMs": 5000 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 800, "maxCpuPercent": 250 },

--- a/surfaces/dashboard-session-send-turn.json
+++ b/surfaces/dashboard-session-send-turn.json
@@ -7,6 +7,7 @@
   "targetKinds": ["npm", "channel", "runtime", "local-build"],
   "requiredMetrics": ["agentTurnMs", "agentTurnP95Ms", "coldPreProviderMs", "healthP95Ms", "peakRssMb", "pluginLoadFailures"],
   "processRoles": ["gateway", "command-tree", "dashboard-cli", "agent-process", "mock-provider"],
+  "resourcePrimaryRole": "gateway",
   "thresholds": { "agentTurnMs": 45000, "preProviderMs": 10000, "providerFinalMs": 3000, "healthP95Ms": 1000, "peakRssMb": 900 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 700, "maxCpuPercent": 250 },

--- a/surfaces/fresh-install.json
+++ b/surfaces/fresh-install.json
@@ -8,11 +8,11 @@
   "requiredMetrics": ["gatewayReadyMs", "statusMs", "pluginsListMs", "modelsListMs", "peakRssMb"],
   "processRoles": ["gateway", "command-tree", "status-cli", "plugin-cli", "model-cli"],
   "resourcePrimaryRole": "gateway",
-  "thresholds": { "gatewayReadyMs": 30000, "statusMs": 10000, "peakRssMb": 900 },
+  "thresholds": { "gatewayReadyMs": 30000, "statusMs": 10000, "peakRssMb": 1050 },
   "roleThresholds": {
-    "gateway": { "peakRssMb": 800, "maxCpuPercent": 250 },
-    "status-cli": { "peakRssMb": 500, "maxCpuPercent": 200 },
-    "plugin-cli": { "peakRssMb": 600, "maxCpuPercent": 250 },
+    "gateway": { "peakRssMb": 1050, "maxCpuPercent": 250 },
+    "status-cli": { "peakRssMb": 850, "maxCpuPercent": 200 },
+    "plugin-cli": { "peakRssMb": 800, "maxCpuPercent": 250 },
     "model-cli": { "peakRssMb": 700, "maxCpuPercent": 250 }
   },
   "diagnostics": {

--- a/surfaces/fresh-install.json
+++ b/surfaces/fresh-install.json
@@ -7,6 +7,7 @@
   "targetKinds": ["npm", "channel", "runtime", "local-build"],
   "requiredMetrics": ["gatewayReadyMs", "statusMs", "pluginsListMs", "modelsListMs", "peakRssMb"],
   "processRoles": ["gateway", "command-tree", "status-cli", "plugin-cli", "model-cli"],
+  "resourcePrimaryRole": "gateway",
   "thresholds": { "gatewayReadyMs": 30000, "statusMs": 10000, "peakRssMb": 900 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 800, "maxCpuPercent": 250 },

--- a/surfaces/gateway-performance.json
+++ b/surfaces/gateway-performance.json
@@ -7,6 +7,7 @@
   "targetKinds": ["npm", "channel", "runtime", "local-build"],
   "requiredMetrics": ["coldReadyMs", "warmReadyMs", "healthP95Ms", "peakRssMb", "eventLoopMaxMs"],
   "processRoles": ["gateway", "gateway-tree", "command-tree", "status-cli"],
+  "resourcePrimaryRole": "gateway",
   "thresholds": { "coldReadyMs": 30000, "warmReadyMs": 15000, "healthP95Ms": 1000, "peakRssMb": 900 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 800, "maxCpuPercent": 250 },

--- a/surfaces/gateway-performance.json
+++ b/surfaces/gateway-performance.json
@@ -8,11 +8,11 @@
   "requiredMetrics": ["coldReadyMs", "warmReadyMs", "healthP95Ms", "peakRssMb", "eventLoopMaxMs"],
   "processRoles": ["gateway", "gateway-tree", "command-tree", "status-cli"],
   "resourcePrimaryRole": "gateway",
-  "thresholds": { "coldReadyMs": 30000, "warmReadyMs": 15000, "healthP95Ms": 1000, "peakRssMb": 900 },
+  "thresholds": { "coldReadyMs": 30000, "warmReadyMs": 15000, "healthP95Ms": 1000, "peakRssMb": 1050 },
   "roleThresholds": {
-    "gateway": { "peakRssMb": 800, "maxCpuPercent": 250 },
-    "gateway-tree": { "peakRssMb": 1000, "maxCpuPercent": 300 },
-    "status-cli": { "peakRssMb": 500, "maxCpuPercent": 200 }
+    "gateway": { "peakRssMb": 1050, "maxCpuPercent": 250 },
+    "gateway-tree": { "peakRssMb": 1200, "maxCpuPercent": 300 },
+    "status-cli": { "peakRssMb": 850, "maxCpuPercent": 200 }
   },
   "diagnostics": {
     "timelineRequiredForSourceBuild": true,

--- a/surfaces/mcp-runtime.json
+++ b/surfaces/mcp-runtime.json
@@ -7,6 +7,7 @@
   "targetKinds": ["npm", "channel", "runtime", "local-build"],
   "requiredMetrics": ["mcpInitializeMs", "mcpToolsListMs", "mcpShutdownMs", "mcpToolCountMin", "mcpProcessLeaks", "gatewayReadyMs", "statusMs", "pluginLoadFailures", "peakRssMb"],
   "processRoles": ["gateway", "command-tree", "mcp-runtime"],
+  "resourcePrimaryRole": "mcp-runtime",
   "thresholds": {
     "gatewayReadyMs": 30000,
     "statusMs": 10000,

--- a/surfaces/media-understanding.json
+++ b/surfaces/media-understanding.json
@@ -14,6 +14,7 @@
     "peakRssMb"
   ],
   "processRoles": ["gateway", "command-tree", "mock-provider"],
+  "resourcePrimaryRole": "gateway",
   "thresholds": {
     "mediaDescribeMs": 10000,
     "mediaTimeoutObserved": 1,

--- a/surfaces/network-offline.json
+++ b/surfaces/network-offline.json
@@ -13,6 +13,7 @@
     "peakRssMb"
   ],
   "processRoles": ["gateway", "command-tree", "agent-cli", "agent-process"],
+  "resourcePrimaryRole": "agent-cli",
   "thresholds": {
     "networkFailureObserved": 1,
     "networkStatusAfterFailureMs": 10000,

--- a/surfaces/openai-compatible-turn.json
+++ b/surfaces/openai-compatible-turn.json
@@ -7,6 +7,7 @@
   "targetKinds": ["npm", "channel", "runtime", "local-build"],
   "requiredMetrics": ["agentTurnMs", "agentTurnP95Ms", "coldPreProviderMs", "healthP95Ms", "peakRssMb", "pluginLoadFailures"],
   "processRoles": ["gateway", "command-tree", "openai-compatible-client", "agent-process", "mock-provider"],
+  "resourcePrimaryRole": "gateway",
   "thresholds": { "agentTurnMs": 45000, "preProviderMs": 10000, "providerFinalMs": 3000, "healthP95Ms": 1000, "peakRssMb": 900 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 700, "maxCpuPercent": 250 },

--- a/surfaces/release-runtime-startup.json
+++ b/surfaces/release-runtime-startup.json
@@ -7,6 +7,7 @@
   "targetKinds": ["local-build", "npm", "channel", "runtime"],
   "requiredMetrics": ["gatewayReadyMs", "gatewayReadyHardTimeoutMs", "statusMs", "pluginsListMs", "peakRssMb", "runtimeDepsStagingMs", "pluginLoadFailures"],
   "processRoles": ["gateway", "gateway-tree", "command-tree", "runtime-management", "package-manager", "build-tooling", "runtime-staging", "plugin-cli"],
+  "resourcePrimaryRole": "gateway",
   "thresholds": { "gatewayReadyMs": 30000, "gatewayReadyHardTimeoutMs": 120000, "runtimeDepsStagingMs": 30000, "peakRssMb": 900 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 800, "maxCpuPercent": 250 },

--- a/surfaces/soak.json
+++ b/surfaces/soak.json
@@ -18,6 +18,7 @@
     "restartCount"
   ],
   "processRoles": ["gateway", "gateway-tree", "command-tree", "status-cli", "plugin-cli", "model-cli"],
+  "resourcePrimaryRole": "gateway",
   "thresholds": {
     "soakMinDurationMs": 60000,
     "soakCommandP95Ms": 10000,

--- a/surfaces/tui-message-turn.json
+++ b/surfaces/tui-message-turn.json
@@ -7,6 +7,7 @@
   "targetKinds": ["npm", "channel", "runtime", "local-build"],
   "requiredMetrics": ["agentTurnMs", "agentTurnP95Ms", "coldPreProviderMs", "healthP95Ms", "peakRssMb", "pluginLoadFailures"],
   "processRoles": ["gateway", "command-tree", "tui-cli", "agent-process", "mock-provider"],
+  "resourcePrimaryRole": "tui-cli",
   "thresholds": { "agentTurnMs": 45000, "preProviderMs": 10000, "providerFinalMs": 3000, "healthP95Ms": 1000, "peakRssMb": 900 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 700, "maxCpuPercent": 250 },

--- a/surfaces/workspace-scan.json
+++ b/surfaces/workspace-scan.json
@@ -17,6 +17,7 @@
     "eventLoopMaxMs"
   ],
   "processRoles": ["gateway", "gateway-tree", "command-tree", "status-cli", "plugin-cli", "model-cli"],
+  "resourcePrimaryRole": "gateway",
   "thresholds": {
     "warmReadyMs": 30000,
     "statusMs": 10000,


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's full release performance lane exposed two Kova false negatives after the workflow began exercising all managed-service scenarios:

- `bundled-runtime-deps` read OCM logs immediately after service start/restart, racing OCM's asynchronous child-log creation.
- release RSS policy gated the aggregate gateway-plus-CLI process tree and stale per-role ceilings, including limits that the accepted shipped release itself exceeds.

The existing `fix/agent-payload-truncation` branch is the OpenClaw-pinned release lineage. This PR targets that branch so it retains truncated agent-payload parsing and the extended release timeout while fixing the newly exposed gates.

## What Changed

- Collect runtime-dependency logs through Kova's post-readiness phase metrics rather than immediate `ocm logs` commands.
- Treat successful typed zero-event log summaries as valid evidence while failing closed on missing, malformed, timed-out, or failed collectors.
- Introduce explicit `resourcePrimaryRole` attribution and gate headline RSS/CPU against that role; tracked aggregate RSS remains diagnostic.
- Use exact role membership so `gateway-tree` is not misclassified as `gateway`.
- Version the resource-headline baseline contract and skip incompatible legacy resource metrics explicitly.
- Calibrate only the exercised OpenClaw release surfaces from repeated current and shipped controls; global role defaults remain unchanged.
- Expand selfchecks for missing roles, zero-event evidence, legacy baselines, exact role matching, report attribution, and scoped calibration.

## Evidence

- Full Kova selfcheck: 106/111 pass locally; the five remaining checks require unavailable local OCM/Cargo prerequisites and are expected in this checkout.
- Focused selfchecks cover the payload-truncation and 300-second timeout behavior from the pinned lineage.
- Re-evaluated saved repeat=3 current and shipped OpenClaw release reports: completed zero-event cold/warm log collections produce `runtimeDepsWarmReuseOk=true`; incomplete evidence fails closed.
- Repeated current/shipped controls fit the scoped primary-role ceilings without broadening global policy.
- Fresh autoreview: no accepted/actionable findings.

OpenClaw will pin the landed immutable commit and run the exact hosted release profile before its release matrix is considered green.
