### PR TITLE
fix: calibrate gateway plugin memory

### DIFF
--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -820,7 +820,7 @@ async function releaseResourceCalibrationCheck() {
 
     const expectedRoleCaps = {
       "fresh-install": { gateway: 1050, "status-cli": 850, "plugin-cli": 800 },
-      "gateway-performance": { gateway: 1050, "gateway-tree": 1200, "status-cli": 850 },
+      "gateway-performance": { gateway: 1050, "gateway-tree": 1200, "plugin-cli": 800, "status-cli": 850 },
       "bundled-runtime-deps": { gateway: 1050 },
       "bundled-plugin-startup": { gateway: 800, "plugin-cli": 800 }
     };
@@ -829,6 +829,7 @@ async function releaseResourceCalibrationCheck() {
       const scenario = scenarioById.get(surfaceId) ?? null;
       const policy = resolveThresholdPolicy({ profile: releaseProfile, surface, scenario });
       for (const [role, peakRssMb] of Object.entries(roleCaps)) {
+        assertEqual(surface?.processRoles?.includes(role), true, `${surfaceId} declares ${role}`);
         assertEqual(policy.roleThresholds?.[role]?.peakRssMb, peakRssMb, `${surfaceId} ${role} RSS cap`);
       }
     }

--- a/surfaces/gateway-performance.json
+++ b/surfaces/gateway-performance.json
@@ -6,12 +6,13 @@
   "requiredStates": ["many-bundled-plugins", "gateway-already-running", "stale-service-state", "slow-filesystem"],
   "targetKinds": ["npm", "channel", "runtime", "local-build"],
   "requiredMetrics": ["coldReadyMs", "warmReadyMs", "healthP95Ms", "peakRssMb", "eventLoopMaxMs"],
-  "processRoles": ["gateway", "gateway-tree", "command-tree", "status-cli"],
+  "processRoles": ["gateway", "gateway-tree", "command-tree", "status-cli", "plugin-cli"],
   "resourcePrimaryRole": "gateway",
   "thresholds": { "coldReadyMs": 30000, "warmReadyMs": 15000, "healthP95Ms": 1000, "peakRssMb": 1050 },
   "roleThresholds": {
     "gateway": { "peakRssMb": 1050, "maxCpuPercent": 250 },
     "gateway-tree": { "peakRssMb": 1200, "maxCpuPercent": 300 },
+    "plugin-cli": { "peakRssMb": 800, "maxCpuPercent": 250 },
     "status-cli": { "peakRssMb": 850, "maxCpuPercent": 200 }
   },
   "diagnostics": {


### PR DESCRIPTION
## What Problem This Solves

The exact hosted release proof in openclaw/openclaw run 29050133376 passed 17 of 18 records. Its sole failure was `gateway-performance` repeat 3: `plugin-cli` peaked at 717.9 MB but inherited the global 650 MB cap.

## Why This Change Was Made

`gateway-performance` executes plugin commands, so it now declares `plugin-cli` and applies an 800 MB cap only on that surface. This matches the already calibrated plugin-command envelope without broadening the global release profile.

## User Impact

Release performance validation no longer rejects the measured gateway-performance plugin command while retaining the global 650 MB policy for other surfaces.

## Evidence

- Hosted failure: https://github.com/openclaw/openclaw/actions/runs/29050133376
- `node bin/kova.mjs self-check --json`: 106/111 checks passed; the five local failures require unavailable OCM/Cargo prerequisites.
- `git diff --check`: clean.
- Structured autoreview: clean after adding the role declaration and calibration assertion.
