### PR TITLE
fix: attribute gateway snapshots to resource gates

### DIFF
--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -94,13 +94,11 @@ export function evaluateRecord(record, scenario, options = {}) {
   const allResults = collectResults(record);
   const measurementScopeSummary = summarizeMeasurementScopes(record);
   const measuredResults = collectResults(record, { productOnly: true });
-  const resourceSummary = collectResourceSummary(measuredResults);
+  const gatewayProcessResources = collectGatewayProcessResources(record, { productOnly: true });
+  const resourceSummary = collectResourceSummary(measuredResults, { gatewayProcessResources });
   const channelWorkflowResources = summarizeChannelWorkflowResources(measuredResults);
-  const peakTrackedRssMb = maxNullable(
-    collectPeakRss(record, { productOnly: true }),
-    resourceSummary.peakTotalRssMb
-  );
-  const cpuPercentMaxTracked = maxNullable(collectCpuPercentMax(record, { productOnly: true }), resourceSummary.maxTotalCpuPercent);
+  const peakTrackedRssMb = maxNullable(gatewayProcessResources?.peakRssMb, resourceSummary.peakTotalRssMb);
+  const cpuPercentMaxTracked = maxNullable(gatewayProcessResources?.maxCpuPercent, resourceSummary.maxTotalCpuPercent);
   const resourceGate = resolveResourceGate(resourceSummary, options.surface, {
     peakTrackedRssMb,
     cpuPercentMaxTracked
@@ -3506,31 +3504,54 @@ function recordExpectsGateway(record) {
   });
 }
 
-function collectPeakRss(record, options = {}) {
-  const excludePhaseIds = new Set(options.excludePhaseIds ?? []);
-  let peak = null;
+function collectGatewayProcessResources(record, options = {}) {
+  // collectEnvMetrics.process samples OCM's supervised service.childPid, so it
+  // belongs to the gateway role without contaminating aggregate command trees.
+  let summary = null;
   for (const phase of record.phases ?? []) {
-    if (excludePhaseIds.has(phase.id)) {
-      continue;
-    }
     if (options.productOnly === true && !measuredProductPhase(phase)) {
       continue;
     }
-    const rss = phase.metrics?.process?.rssMb;
-    if (typeof rss === "number") {
-      peak = peak === null ? rss : Math.max(peak, rss);
-    }
+    summary = mergeGatewayProcessMetrics(summary, phase.metrics?.process);
   }
-
-  const finalRss = record.finalMetrics?.process?.rssMb;
-  if (typeof finalRss === "number") {
-    peak = peak === null ? finalRss : Math.max(peak, finalRss);
-  }
-
-  return peak;
+  return mergeGatewayProcessMetrics(summary, record.finalMetrics?.process);
 }
 
-function collectResourceSummary(results) {
+function mergeGatewayProcessMetrics(summary, process) {
+  const rssMb = typeof process?.rssMb === "number" ? process.rssMb : null;
+  const cpuPercent = typeof process?.cpuPercent === "number" ? process.cpuPercent : null;
+  if (rssMb === null && cpuPercent === null) {
+    return summary;
+  }
+  const next = summary ?? {
+    peakRssMb: null,
+    maxCpuPercent: null,
+    peakRssAtMs: null,
+    peakCpuAtMs: null,
+    peakProcessCount: 1,
+    peakRssProcess: null,
+    peakCpuProcess: null
+  };
+  const compactProcess = {
+    pid: process.pid ?? null,
+    roles: ["gateway"],
+    role: "gateway",
+    rssMb,
+    cpuPercent,
+    command: process.command ?? null
+  };
+  if (rssMb !== null && (next.peakRssMb === null || rssMb > next.peakRssMb)) {
+    next.peakRssMb = rssMb;
+    next.peakRssProcess = compactProcess;
+  }
+  if (cpuPercent !== null && (next.maxCpuPercent === null || cpuPercent > next.maxCpuPercent)) {
+    next.maxCpuPercent = cpuPercent;
+    next.peakCpuProcess = compactProcess;
+  }
+  return next;
+}
+
+function collectResourceSummary(results, options = {}) {
   let sampleCount = 0;
   let peakTotalRssMb = null;
   let maxTotalCpuPercent = null;
@@ -3582,6 +3603,11 @@ function collectResourceSummary(results) {
       existing.lastSeenMs = Math.max(existing.lastSeenMs ?? process.lastSeenMs ?? 0, process.lastSeenMs ?? 0);
       byPid.set(process.pid, existing);
     }
+  }
+
+  if (options.gatewayProcessResources) {
+    mergeRoleSummaries(byRole, { gateway: options.gatewayProcessResources });
+    peakGatewayRssMb = maxNullable(peakGatewayRssMb, options.gatewayProcessResources.peakRssMb);
   }
 
   const processes = [...byPid.values()];
@@ -3888,26 +3914,6 @@ function mergeKeySpans(target, source) {
     existing.open = mergeOpenSpans(existing.open, summary.open ?? []).slice(0, 5);
     target[name] = existing;
   }
-}
-
-function collectCpuPercentMax(record, options = {}) {
-  const values = [];
-  for (const phase of record.phases ?? []) {
-    if (options.productOnly === true && !measuredProductPhase(phase)) {
-      continue;
-    }
-    const cpu = phase.metrics?.process?.cpuPercent;
-    if (typeof cpu === "number") {
-      values.push(cpu);
-    }
-  }
-
-  const finalCpu = record.finalMetrics?.process?.cpuPercent;
-  if (typeof finalCpu === "number") {
-    values.push(finalCpu);
-  }
-
-  return values.length === 0 ? null : Math.max(...values);
 }
 
 function maxNullable(...values) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -776,6 +776,7 @@ export async function runSelfCheck(flags = {}) {
     checks.push(await localBuildRuntimeCleanupCheck(tmp));
     checks.push(await localBuildRuntimeAlreadyAbsentCleanupCheck(tmp));
     checks.push(defaultGatewayResourceRoleCheck());
+    checks.push(gatewayProcessResourceRoleCheck());
     checks.push(compareRepeatAggregationCheck());
     checks.push(compareMetricOrderingCheck());
     checks.push(compareGatewayRssDedupeCheck());
@@ -1165,6 +1166,121 @@ function defaultGatewayResourceRoleCheck() {
       id: "default-gateway-resource-role",
       status: "FAIL",
       command: "evaluate default gateway RSS resource contract",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function gatewayProcessResourceRoleCheck() {
+  try {
+    const buildRecord = () => ({
+      scenario: "gateway-process-resource-role",
+      status: "PASS",
+      phases: [{
+        id: "scenario-command",
+        measurementScope: "product",
+        results: [{
+          command: "synthetic",
+          status: 0,
+          durationMs: 1,
+          resourceSamples: {
+            schemaVersion: "kova.resourceSamples.v1",
+            sampleCount: 1,
+            peakTotalRssMb: 700,
+            maxTotalCpuPercent: 80,
+            peakGatewayRssMb: 700,
+            byRole: {
+              gateway: { peakRssMb: 700, maxCpuPercent: 80, peakProcessCount: 1 },
+              "plugin-cli": { peakRssMb: 200, maxCpuPercent: 20, peakProcessCount: 1 }
+            },
+            topRolesByRss: [
+              { role: "gateway", peakRssMb: 700, maxCpuPercent: 80 },
+              { role: "plugin-cli", peakRssMb: 200, maxCpuPercent: 20 }
+            ],
+            topRolesByCpu: [
+              { role: "gateway", peakRssMb: 700, maxCpuPercent: 80 },
+              { role: "plugin-cli", peakRssMb: 200, maxCpuPercent: 20 }
+            ],
+            topByRss: [],
+            topByCpu: []
+          }
+        }],
+        metrics: {
+          process: { pid: 123, rssMb: 1000, cpuPercent: 300, command: "openclaw-gateway" },
+          logs: zeroLogMetrics()
+        }
+      }],
+      finalMetrics: {
+        process: { pid: 123, rssMb: 1100, cpuPercent: 320, command: "openclaw-gateway" },
+        service: { gatewayState: "running" },
+        logs: zeroLogMetrics()
+      }
+    });
+
+    const gatewayRecord = buildRecord();
+    evaluateRecord(gatewayRecord, { thresholds: { peakRssMb: 900, cpuPercentMax: 250 } }, {
+      surface: {
+        resourcePrimaryRole: "gateway",
+        thresholds: {},
+        roleThresholds: { gateway: { peakRssMb: 900, maxCpuPercent: 250 } }
+      }
+    });
+    assertEqual(gatewayRecord.status, "FAIL", "gateway final process metrics fail resource gate");
+    assertEqual(gatewayRecord.measurements.peakRssMb, 1100, "gateway final process RSS reaches headline gate");
+    assertEqual(gatewayRecord.measurements.cpuPercentMax, 320, "gateway final process CPU reaches headline gate");
+    assertEqual(gatewayRecord.measurements.resourceByRole.gateway.peakRssMb, 1100, "gateway role merges final process RSS");
+    assertEqual(gatewayRecord.measurements.resourceByRole.gateway.maxCpuPercent, 320, "gateway role merges final process CPU");
+    assertEqual(
+      gatewayRecord.violations.some((violation) => violation.metric === "peakRssMb"),
+      true,
+      "headline RSS threshold sees final process"
+    );
+    assertEqual(
+      gatewayRecord.violations.some((violation) => violation.metric === "cpuPercentMax"),
+      true,
+      "headline CPU threshold sees final process"
+    );
+    assertEqual(
+      gatewayRecord.violations.some((violation) => violation.metric === "resourceByRole.gateway.peakRssMb"),
+      true,
+      "gateway role RSS threshold sees final process"
+    );
+    assertEqual(
+      gatewayRecord.violations.some((violation) => violation.metric === "resourceByRole.gateway.maxCpuPercent"),
+      true,
+      "gateway role CPU threshold sees final process"
+    );
+
+    const pluginRecord = buildRecord();
+    evaluateRecord(pluginRecord, { thresholds: { peakRssMb: 300, cpuPercentMax: 50 } }, {
+      surface: { resourcePrimaryRole: "plugin-cli", thresholds: {} }
+    });
+    assertEqual(pluginRecord.status, "PASS", "gateway final process metrics do not pollute plugin role gate");
+    assertEqual(pluginRecord.measurements.peakRssMb, 200, "plugin role remains headline RSS gate");
+    assertEqual(pluginRecord.measurements.cpuPercentMax, 20, "plugin role remains headline CPU gate");
+    assertEqual(pluginRecord.measurements.resourceByRole.gateway.peakRssMb, 1100, "gateway final process RSS stays attributed");
+
+    const finalOnlyRecord = buildRecord();
+    delete finalOnlyRecord.phases[0].results[0].resourceSamples;
+    delete finalOnlyRecord.phases[0].metrics.process;
+    evaluateRecord(finalOnlyRecord, { thresholds: { peakRssMb: 1200, cpuPercentMax: 400 } }, {
+      surface: { resourcePrimaryRole: "gateway", thresholds: {} }
+    });
+    assertEqual(finalOnlyRecord.status, "PASS", "final gateway process metrics satisfy configured role evidence");
+    assertEqual(finalOnlyRecord.measurements.resourceGateKind, "role", "final gateway process avoids missing-role gate");
+    assertEqual(finalOnlyRecord.measurements.peakRssMb, 1100, "final-only gateway RSS reaches headline gate");
+    return {
+      id: "gateway-process-resource-role",
+      status: "PASS",
+      command: "evaluate gateway process resource role attribution",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "gateway-process-resource-role",
+      status: "FAIL",
+      command: "evaluate gateway process resource role attribution",
       durationMs: 0,
       message: error.message
     };


### PR DESCRIPTION
## Problem

Kova's gateway resource gate preferred sampled `resourceSummary.byRole.gateway` values over the supervised gateway process snapshots collected before cleanup. A gateway could therefore exceed RSS or CPU thresholds in phase/final metrics while the evaluator still reported `PASS`.

## Fix

- attribute product-phase and final `service.childPid` snapshots to the gateway role
- keep gateway snapshots separate from aggregate command-tree totals
- preserve non-gateway primary-role gates
- add regression coverage for headline thresholds, role thresholds, plugin-role isolation, and final-only gateway evidence

## Evidence

- reproduced the false pass on the previously pinned evaluator and current main
- new `gateway-process-resource-role` self-check passes
- `npm run check`: 199/203 checks passed locally; the four unrelated failures require the missing local OCM prerequisite
- `git diff --check`
- Codex autoreview: clean, no actionable findings
