### PR TITLE
fix: attribute gateway snapshots to resource gates

### DIFF
--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -22,12 +22,10 @@ export function evaluateRecord(record, scenario, options = {}) {
   const violations = [];
   const allResults = collectResults(record);
   const measuredResults = collectResults(record, { excludePhaseIds: ["target-setup"] });
-  const resourceSummary = collectResourceSummary(measuredResults);
-  const peakTrackedRssMb = maxNullable(
-    collectPeakRss(record, { excludePhaseIds: ["target-setup"] }),
-    resourceSummary.peakTotalRssMb
-  );
-  const cpuPercentMaxTracked = maxNullable(collectCpuPercentMax(record), resourceSummary.maxTotalCpuPercent);
+  const gatewayProcessResources = collectGatewayProcessResources(record, { excludePhaseIds: ["target-setup"] });
+  const resourceSummary = collectResourceSummary(measuredResults, { gatewayProcessResources });
+  const peakTrackedRssMb = maxNullable(gatewayProcessResources?.peakRssMb, resourceSummary.peakTotalRssMb);
+  const cpuPercentMaxTracked = maxNullable(gatewayProcessResources?.maxCpuPercent, resourceSummary.maxTotalCpuPercent);
   const resourceGate = resolveResourceGate(resourceSummary, options.surface, {
     peakTrackedRssMb,
     cpuPercentMaxTracked
@@ -2238,28 +2236,55 @@ function recordExpectsGateway(record) {
   });
 }
 
-function collectPeakRss(record, options = {}) {
+function collectGatewayProcessResources(record, options = {}) {
+  // collectEnvMetrics.process samples OCM's supervised service.childPid, so it
+  // belongs to the gateway role without contaminating aggregate command trees.
   const excludePhaseIds = new Set(options.excludePhaseIds ?? []);
-  let peak = null;
+  let summary = null;
   for (const phase of record.phases ?? []) {
     if (excludePhaseIds.has(phase.id)) {
       continue;
     }
-    const rss = phase.metrics?.process?.rssMb;
-    if (typeof rss === "number") {
-      peak = peak === null ? rss : Math.max(peak, rss);
-    }
+    summary = mergeGatewayProcessMetrics(summary, phase.metrics?.process);
   }
-
-  const finalRss = record.finalMetrics?.process?.rssMb;
-  if (typeof finalRss === "number") {
-    peak = peak === null ? finalRss : Math.max(peak, finalRss);
-  }
-
-  return peak;
+  return mergeGatewayProcessMetrics(summary, record.finalMetrics?.process);
 }
 
-function collectResourceSummary(results) {
+function mergeGatewayProcessMetrics(summary, process) {
+  const rssMb = typeof process?.rssMb === "number" ? process.rssMb : null;
+  const cpuPercent = typeof process?.cpuPercent === "number" ? process.cpuPercent : null;
+  if (rssMb === null && cpuPercent === null) {
+    return summary;
+  }
+  const next = summary ?? {
+    peakRssMb: null,
+    maxCpuPercent: null,
+    peakRssAtMs: null,
+    peakCpuAtMs: null,
+    peakProcessCount: 1,
+    peakRssProcess: null,
+    peakCpuProcess: null
+  };
+  const compactProcess = {
+    pid: process.pid ?? null,
+    roles: ["gateway"],
+    role: "gateway",
+    rssMb,
+    cpuPercent,
+    command: process.command ?? null
+  };
+  if (rssMb !== null && (next.peakRssMb === null || rssMb > next.peakRssMb)) {
+    next.peakRssMb = rssMb;
+    next.peakRssProcess = compactProcess;
+  }
+  if (cpuPercent !== null && (next.maxCpuPercent === null || cpuPercent > next.maxCpuPercent)) {
+    next.maxCpuPercent = cpuPercent;
+    next.peakCpuProcess = compactProcess;
+  }
+  return next;
+}
+
+function collectResourceSummary(results, options = {}) {
   let sampleCount = 0;
   let peakTotalRssMb = null;
   let maxTotalCpuPercent = null;
@@ -2311,6 +2336,11 @@ function collectResourceSummary(results) {
       existing.lastSeenMs = Math.max(existing.lastSeenMs ?? process.lastSeenMs ?? 0, process.lastSeenMs ?? 0);
       byPid.set(process.pid, existing);
     }
+  }
+
+  if (options.gatewayProcessResources) {
+    mergeRoleSummaries(byRole, { gateway: options.gatewayProcessResources });
+    peakGatewayRssMb = maxNullable(peakGatewayRssMb, options.gatewayProcessResources.peakRssMb);
   }
 
   const processes = [...byPid.values()];
@@ -2528,23 +2558,6 @@ function mergeKeySpans(target, source) {
     existing.open = mergeOpenSpans(existing.open, summary.open ?? []).slice(0, 5);
     target[name] = existing;
   }
-}
-
-function collectCpuPercentMax(record) {
-  const values = [];
-  for (const phase of record.phases ?? []) {
-    const cpu = phase.metrics?.process?.cpuPercent;
-    if (typeof cpu === "number") {
-      values.push(cpu);
-    }
-  }
-
-  const finalCpu = record.finalMetrics?.process?.cpuPercent;
-  if (typeof finalCpu === "number") {
-    values.push(finalCpu);
-  }
-
-  return values.length === 0 ? null : Math.max(...values);
 }
 
 function maxNullable(...values) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -693,6 +693,58 @@ function primaryResourceRoleEvaluationCheck() {
       "missing configured role violation"
     );
 
+    const gatewayProcessRecord = syntheticPrimaryResourceRecord();
+    gatewayProcessRecord.phases[0].metrics.process = {
+      pid: 123,
+      rssMb: 1000,
+      cpuPercent: 300,
+      command: "openclaw-gateway"
+    };
+    gatewayProcessRecord.finalMetrics.process = {
+      pid: 123,
+      rssMb: 1100,
+      cpuPercent: 320,
+      command: "openclaw-gateway"
+    };
+    evaluateRecord(gatewayProcessRecord, { thresholds: { peakRssMb: 900, cpuPercentMax: 250 } }, {
+      surface: {
+        thresholds: {},
+        roleThresholds: { gateway: { peakRssMb: 900, maxCpuPercent: 250 } },
+        resourcePrimaryRole: "gateway"
+      }
+    });
+    assertEqual(gatewayProcessRecord.status, "FAIL", "gateway snapshots fail resource gates");
+    assertEqual(gatewayProcessRecord.measurements.peakRssMb, 1100, "gateway snapshot RSS reaches headline gate");
+    assertEqual(gatewayProcessRecord.measurements.cpuPercentMax, 320, "gateway snapshot CPU reaches headline gate");
+    assertEqual(gatewayProcessRecord.measurements.resourceByRole.gateway.peakRssMb, 1100, "gateway role merges snapshot RSS");
+    assertEqual(gatewayProcessRecord.measurements.resourceByRole.gateway.maxCpuPercent, 320, "gateway role merges snapshot CPU");
+    for (const metric of ["peakRssMb", "cpuPercentMax", "resourceByRole.gateway.peakRssMb", "resourceByRole.gateway.maxCpuPercent"]) {
+      assertEqual(
+        gatewayProcessRecord.violations.some((violation) => violation.metric === metric),
+        true,
+        `${metric} sees gateway snapshot`
+      );
+    }
+
+    const isolatedPluginRecord = syntheticPrimaryResourceRecord();
+    isolatedPluginRecord.finalMetrics.process = gatewayProcessRecord.finalMetrics.process;
+    evaluateRecord(isolatedPluginRecord, { thresholds: { peakRssMb: 1050, cpuPercentMax: 200 } }, {
+      surface: { thresholds: {}, roleThresholds: {}, resourcePrimaryRole: "plugin-cli" }
+    });
+    assertEqual(isolatedPluginRecord.status, "PASS", "gateway snapshot does not pollute plugin role gate");
+    assertEqual(isolatedPluginRecord.measurements.peakRssMb, 1000, "plugin role remains headline RSS gate");
+    assertEqual(isolatedPluginRecord.measurements.cpuPercentMax, 180, "plugin role remains headline CPU gate");
+
+    const finalOnlyRecord = syntheticPrimaryResourceRecord();
+    delete finalOnlyRecord.phases[0].results[0].resourceSamples;
+    finalOnlyRecord.finalMetrics.process = gatewayProcessRecord.finalMetrics.process;
+    evaluateRecord(finalOnlyRecord, { thresholds: { peakRssMb: 1200, cpuPercentMax: 400 } }, {
+      surface: { thresholds: {}, roleThresholds: {}, resourcePrimaryRole: "gateway" }
+    });
+    assertEqual(finalOnlyRecord.status, "PASS", "final gateway snapshot satisfies configured role evidence");
+    assertEqual(finalOnlyRecord.measurements.resourceGateKind, "role", "final gateway snapshot avoids missing-role gate");
+    assertEqual(finalOnlyRecord.measurements.peakRssMb, 1100, "final-only gateway RSS reaches headline gate");
+
     return {
       id: "primary-resource-role-evaluation",
       status: "PASS",


### PR DESCRIPTION
## Problem

OpenClaw's release performance workflow pins this Kova lineage. Its gateway resource gate can miss a phase/final supervised gateway-process RSS or CPU peak when sampled role values are lower, producing a false `PASS`.

## Fix

- attribute phase/final `service.childPid` snapshots to the gateway role
- keep those snapshots separate from aggregate command-tree totals
- preserve configured non-gateway primary-role gates
- extend the existing primary-role self-check with headline, role, isolation, and final-only cases

This is the semantic backport of #9 for the release lineage used by OpenClaw.

## Evidence

- reproduced the prior false pass at `b20d3b35118841db050a14f241098169aff4b9a2`
- `primary-resource-role-evaluation` passes with the new regression cases
- local self-check reached 99 passing checks; remaining failures are unchanged local OCM/auth prerequisites
- `node --check src/evaluator.mjs` and `node --check src/selfcheck.mjs`
- `git diff --check`
- Codex autoreview: clean, no actionable findings
