### PR TITLE
fix: wait for bundled plugin startup readiness

### DIFF
--- a/scenarios/bundled-plugin-startup.json
+++ b/scenarios/bundled-plugin-startup.json
@@ -15,7 +15,7 @@
   },
   "phases": [
     {
-      "id": "startup",
+      "id": "gateway-start",
       "title": "Start Bundled Plugin Gateway",
       "intent": "Start OpenClaw and let bundled plugin bootstrap run in the same shape users get from the target runtime.",
       "commands": ["ocm start {env} {startSelector} --json"],

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -351,6 +351,7 @@ export async function runSelfCheck(flags = {}) {
     checks.push(runtimeDepsLogParserCheck());
     checks.push(embeddedRunLogParserCheck());
     checks.push(await bundledRuntimeDepsScenarioCheck());
+    checks.push(await bundledPluginStartupScenarioCheck());
     checks.push(runtimeDepsWarmReuseEvaluationCheck());
     checks.push(await performanceBaselineCheck(tmp));
     checks.push(markdownFailureCardsCheck());
@@ -3880,6 +3881,31 @@ async function bundledRuntimeDepsScenarioCheck() {
       id: "bundled-runtime-deps-scenario",
       status: "FAIL",
       command: "validate bundled runtime deps scenario log collection",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function bundledPluginStartupScenarioCheck() {
+  try {
+    const [scenario] = await loadScenarios("bundled-plugin-startup");
+    const startPhase = scenario.phases.find((phase) =>
+      (phase.commands ?? []).some((command) => /^ocm start /.test(command))
+    );
+    assertEqual(startPhase?.id, "gateway-start", "bundled plugin startup waits for readiness before auth setup");
+
+    return {
+      id: "bundled-plugin-startup-scenario",
+      status: "PASS",
+      command: "validate bundled plugin startup readiness ordering",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "bundled-plugin-startup-scenario",
+      status: "FAIL",
+      command: "validate bundled plugin startup readiness ordering",
       durationMs: 0,
       message: error.message
     };


### PR DESCRIPTION
## Problem

The pinned Kova runner only performs bounded readiness collection for recognized startup phase IDs. `bundled-plugin-startup` used the unrecognized `startup` ID, so its metrics used a zero readiness deadline and mock auth could rewrite `openclaw.json` while gateway startup migrations were still active.

OpenClaw run 29055518456 hit this race on repeat 2: the gateway rejected the mid-startup config change and entered migration-lock backoff for the lease TTL. Repeats 1 and 3 passed by timing.

## Change

- rename the phase to the runner's recognized `gateway-start` ID
- assert the scenario keeps readiness before the automatic auth setup

This makes Kova wait for gateway health before mutating the env config.

## Evidence

- `git diff --check`
- `node --check src/selfcheck.mjs`
- `bundled-plugin-startup-scenario` self-check passes
- `readiness-health-implies-listening` self-check remains green

Failure evidence: https://github.com/openclaw/openclaw/actions/runs/29055518456
