### PR TITLE
fix: calibrate bundled plugin gateway memory

### DIFF
--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -877,7 +877,7 @@ async function releaseResourceCalibrationCheck() {
       "fresh-install": { gateway: 1050, "status-cli": 850, "plugin-cli": 800 },
       "gateway-performance": { gateway: 1050, "gateway-tree": 1200, "plugin-cli": 800, "status-cli": 850 },
       "bundled-runtime-deps": { gateway: 1050 },
-      "bundled-plugin-startup": { gateway: 800, "plugin-cli": 800 }
+      "bundled-plugin-startup": { gateway: 950, "plugin-cli": 800 }
     };
     for (const [surfaceId, roleCaps] of Object.entries(expectedRoleCaps)) {
       const surface = surfaceById.get(surfaceId);

--- a/surfaces/bundled-plugin-startup.json
+++ b/surfaces/bundled-plugin-startup.json
@@ -9,7 +9,7 @@
   "processRoles": ["gateway", "command-tree", "plugin-cli", "package-manager", "runtime-staging"],
   "thresholds": { "gatewayReadyMs": 30000, "gatewayReadyHardTimeoutMs": 120000, "runtimeDepsStagingMs": 30000 },
   "roleThresholds": {
-    "gateway": { "peakRssMb": 800, "maxCpuPercent": 250 },
+    "gateway": { "peakRssMb": 950, "maxCpuPercent": 250 },
     "plugin-cli": { "peakRssMb": 800, "maxCpuPercent": 250 },
     "runtime-staging": { "peakRssMb": 900, "maxCpuPercent": 350 },
     "package-manager": { "peakRssMb": 900, "maxCpuPercent": 350 }


### PR DESCRIPTION
## Problem

After #13 correctly waits for the fully initialized bundled-plugin gateway, OpenClaw performance run 29056481114 measured healthy repeats at 812.0, 869.7, and 862.0 MB. They failed only against the older 800 MB gateway cap.

Recent ready-state evidence spans 805.3–878.9 MB with a median around 847.8 MB. A 900 MB cap leaves only 21.1 MB (2.4%) above the observed maximum, below normal same-head spread.

## Change

Raise only the `bundled-plugin-startup` gateway role cap from 800 to 950 MB and keep its calibration self-check aligned.

The 950 MB limit provides 8.1% headroom above the observed maximum, remains tighter than the 1050 MB stress-surface caps, and preserves Kova's separate 15% baseline RSS regression detection.

## Evidence

- `git diff --check`
- `node --check src/selfcheck.mjs`
- `release-resource-calibration` self-check passes
- `evaluation-violation-helpers` and `resource-role-thresholds` pass
- `node bin/kova.mjs plan --json`
- autoreview clean, confidence 0.93

Run: https://github.com/openclaw/openclaw/actions/runs/29056481114

Published report: https://github.com/openclaw/clawgrit-reports/blob/main/openclaw-performance/1946721c96623d17df2fb5dd8ae949a6b4066798/29056481114-1/mock-provider/report.md
