### PR TITLE
fix: inherit release gateway memory cap

### DIFF
--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -877,7 +877,7 @@ async function releaseResourceCalibrationCheck() {
       "fresh-install": { gateway: 1050, "status-cli": 850, "plugin-cli": 800 },
       "gateway-performance": { gateway: 1050, "gateway-tree": 1200, "plugin-cli": 800, "status-cli": 850 },
       "bundled-runtime-deps": { gateway: 1050 },
-      "bundled-plugin-startup": { gateway: 950, "plugin-cli": 800 }
+      "bundled-plugin-startup": { gateway: 900, "plugin-cli": 800 }
     };
     for (const [surfaceId, roleCaps] of Object.entries(expectedRoleCaps)) {
       const surface = surfaceById.get(surfaceId);

--- a/surfaces/bundled-plugin-startup.json
+++ b/surfaces/bundled-plugin-startup.json
@@ -9,7 +9,6 @@
   "processRoles": ["gateway", "command-tree", "plugin-cli", "package-manager", "runtime-staging"],
   "thresholds": { "gatewayReadyMs": 30000, "gatewayReadyHardTimeoutMs": 120000, "runtimeDepsStagingMs": 30000 },
   "roleThresholds": {
-    "gateway": { "peakRssMb": 950, "maxCpuPercent": 250 },
     "plugin-cli": { "peakRssMb": 800, "maxCpuPercent": 250 },
     "runtime-staging": { "peakRssMb": 900, "maxCpuPercent": 350 },
     "package-manager": { "peakRssMb": 900, "maxCpuPercent": 350 }


### PR DESCRIPTION
## Problem

#14 set a 950 MB bundled-plugin gateway override, creating a surface-specific relaxation even though the release profile already owns the global gateway cap at 900 MB. Exact run 29056481114 recorded healthy bundled-plugin gateway peaks of 812.0, 869.7, and 862.0 MB, all below the existing global policy.

## Change

- remove the bundled-plugin startup surface's explicit gateway RSS override
- assert that its resolved release gateway cap remains 900 MB

The plugin CLI, runtime staging, and package manager overrides remain unchanged. A future healthy repeat above 900 MB would provide concrete evidence for global recalibration.

## Evidence

- `git diff --check`
- `node --check src/selfcheck.mjs`
- `node bin/kova.mjs self-check --only evaluation-violation-helpers,release-resource-calibration,resource-role-thresholds`
- `node bin/kova.mjs plan --json`
- fresh Codex autoreview: clean, no actionable findings
- exact OpenClaw performance run: https://github.com/openclaw/openclaw/actions/runs/29056481114
