### PR TITLE
fix: restore explicit plugin gateway limits

### DIFF
--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -877,7 +877,7 @@ async function releaseResourceCalibrationCheck() {
       "fresh-install": { gateway: 1050, "status-cli": 850, "plugin-cli": 800 },
       "gateway-performance": { gateway: 1050, "gateway-tree": 1200, "plugin-cli": 800, "status-cli": 850 },
       "bundled-runtime-deps": { gateway: 1050 },
-      "bundled-plugin-startup": { gateway: 900, "plugin-cli": 800 }
+      "bundled-plugin-startup": { gateway: 950, "plugin-cli": 800 }
     };
     for (const [surfaceId, roleCaps] of Object.entries(expectedRoleCaps)) {
       const surface = surfaceById.get(surfaceId);
@@ -888,6 +888,28 @@ async function releaseResourceCalibrationCheck() {
         assertEqual(policy.roleThresholds?.[role]?.peakRssMb, peakRssMb, `${surfaceId} ${role} RSS cap`);
       }
     }
+
+    const bundledPluginSurface = surfaceById.get("bundled-plugin-startup");
+    const bundledPluginPolicy = resolveThresholdPolicy({
+      profile: releaseProfile,
+      surface: bundledPluginSurface,
+      scenario: null
+    });
+    assertEqual(
+      bundledPluginSurface?.roleThresholds?.gateway?.peakRssMb,
+      950,
+      "bundled-plugin startup explicitly owns gateway RSS cap"
+    );
+    assertEqual(
+      bundledPluginSurface?.roleThresholds?.gateway?.maxCpuPercent,
+      250,
+      "bundled-plugin startup explicitly owns gateway CPU cap"
+    );
+    assertEqual(
+      bundledPluginPolicy.roleThresholds?.gateway?.maxCpuPercent,
+      250,
+      "bundled-plugin startup resolved gateway CPU cap"
+    );
 
     assertEqual(releaseProfile.calibration?.roles?.gateway?.peakRssMb, 900, "global release gateway RSS cap");
     assertEqual(releaseProfile.calibration?.roles?.["plugin-cli"]?.peakRssMb, 650, "global release plugin RSS cap");

--- a/surfaces/bundled-plugin-startup.json
+++ b/surfaces/bundled-plugin-startup.json
@@ -9,6 +9,7 @@
   "processRoles": ["gateway", "command-tree", "plugin-cli", "package-manager", "runtime-staging"],
   "thresholds": { "gatewayReadyMs": 30000, "gatewayReadyHardTimeoutMs": 120000, "runtimeDepsStagingMs": 30000 },
   "roleThresholds": {
+    "gateway": { "peakRssMb": 950, "maxCpuPercent": 250 },
     "plugin-cli": { "peakRssMb": 800, "maxCpuPercent": 250 },
     "runtime-staging": { "peakRssMb": 900, "maxCpuPercent": 350 },
     "package-manager": { "peakRssMb": 900, "maxCpuPercent": 350 }


### PR DESCRIPTION
## Problem

#15 removed the bundled-plugin gateway override to inherit the release profile's 900 MB RSS cap. Threshold resolution merges fields, so that removal also silently relaxed `maxCpuPercent` from the surface's 250% limit to the global 300% limit.

The exact ready-state peak was 878.9 MB, leaving only 21.1 MB (2.4%) under 900 MB amid a 57.7 MB same-head range. That is too little headroom for a reliable release gate; sibling plugin-pressure surfaces already use higher explicit caps.

## Change

- restore the bundled-plugin startup gateway override at 950 MB RSS and 250% CPU
- assert both explicit gateway fields in the release calibration self-check
- assert the resolved CPU cap remains 250% after field-wise policy merging

This supersedes #15 and preserves the narrower CPU policy while avoiding a high false-block risk from the 900 MB global RSS cap.

## Evidence

- `git diff --check`
- `node --check src/selfcheck.mjs`
- `node bin/kova.mjs plan --json`
- direct threshold-resolution probe: `{ "peakRssMb": 950, "maxCpuPercent": 250 }`
- fresh Codex autoreview: clean, no actionable findings
- exact OpenClaw performance run: https://github.com/openclaw/openclaw/actions/runs/29056481114

The full local self-check reached the changed `release-resource-calibration` and `resource-role-thresholds` checks successfully; unrelated setup and cleanup checks require OCM/prerequisites unavailable in this temporary checkout. Pull-request CI installs OCM and runs the full suite on Ubuntu and macOS.
