### PR TITLE
fix: use final timeline open span state

### DIFF
--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -2440,6 +2440,9 @@ function collectTimelineSummary(record) {
   }
 
   const available = timelines.some((timeline) => timeline.available);
+  const currentTimeline = timelines.findLast((timeline) => timeline.available) ?? null;
+  const openSpans = [...(currentTimeline?.openSpans ?? [])];
+  const openSpanCount = currentTimeline?.openSpanCount ?? openSpans.length;
   let eventCount = 0;
   let parseErrorCount = 0;
   let slowestSpan = null;
@@ -2449,8 +2452,6 @@ function collectTimelineSummary(record) {
   let repeatedSpanCount = 0;
   let runtimeDepsStageMaxMs = null;
   let slowestRuntimeDepsPlugin = null;
-  let openSpanCount = 0;
-  let openSpans = [];
   const keySpans = {};
   const spanTotals = {};
 
@@ -2459,9 +2460,7 @@ function collectTimelineSummary(record) {
     parseErrorCount = Math.max(parseErrorCount, timeline.parseErrorCount ?? 0);
     childProcessFailedCount = Math.max(childProcessFailedCount, timeline.childProcesses?.failedCount ?? 0);
     repeatedSpanCount = Math.max(repeatedSpanCount, timeline.repeatedSpans?.length ?? 0);
-    openSpanCount = Math.max(openSpanCount, timeline.openSpanCount ?? timeline.openSpans?.length ?? 0);
-    openSpans = mergeOpenSpans(openSpans, timeline.openSpans ?? []);
-    mergeKeySpans(keySpans, timeline.keySpans ?? {});
+    mergeKeySpans(keySpans, timeline.keySpans ?? {}, { current: timeline === currentTimeline });
     mergeSpanTotals(spanTotals, timeline.spanTotals ?? {});
     eventLoopMaxMs = maxNullable(eventLoopMaxMs, timeline.eventLoop?.maxMs);
     providerRequestMaxMs = maxNullable(providerRequestMaxMs, timeline.providers?.maxDurationMs);
@@ -2528,13 +2527,7 @@ function mergeSpanTotals(target, source) {
   }
 }
 
-function mergeOpenSpans(current, candidate) {
-  return [...current, ...candidate]
-    .toSorted((left, right) => (right.ageMs ?? -1) - (left.ageMs ?? -1))
-    .slice(0, 25);
-}
-
-function mergeKeySpans(target, source) {
+function mergeKeySpans(target, source, { current = false } = {}) {
   for (const [name, summary] of Object.entries(source)) {
     const existing = target[name] ?? {
       name,
@@ -2548,14 +2541,16 @@ function mergeKeySpans(target, source) {
     };
     existing.count += summary.count ?? 0;
     existing.errorCount += summary.errorCount ?? 0;
-    existing.openCount += summary.openCount ?? 0;
     existing.totalDurationMs = roundNumber(existing.totalDurationMs + (summary.totalDurationMs ?? 0));
     existing.maxDurationMs = maxNullable(existing.maxDurationMs, summary.maxDurationMs);
     if (summary.slowest?.durationMs !== undefined &&
       (!existing.slowest || summary.slowest.durationMs > existing.slowest.durationMs)) {
       existing.slowest = summary.slowest;
     }
-    existing.open = mergeOpenSpans(existing.open, summary.open ?? []).slice(0, 5);
+    if (current) {
+      existing.openCount = summary.openCount ?? summary.open?.length ?? 0;
+      existing.open = [...(summary.open ?? [])].slice(0, 5);
+    }
     target[name] = existing;
   }
 }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3588,20 +3588,17 @@ function diagnosticsTimelineEvaluationCheck() {
       "missing diagnostic timeline violation"
     );
 
-    const openSpanRecord = {
-      scenario: "diagnostic-open-span",
-      status: "PASS",
-      phases: [],
-      finalMetrics: {
-        service: { gatewayState: "running" },
-        logs: zeroLogMetrics(),
-        timeline: parseTimelineText([
-          "{\"type\":\"span.start\",\"timestamp\":\"2026-04-29T15:30:00.000Z\",\"name\":\"runtimeDeps.stage\",\"spanId\":\"1\"}",
-          "{\"type\":\"eventLoop.sample\",\"timestamp\":\"2026-04-29T15:30:06.000Z\",\"name\":\"eventLoop\",\"maxMs\":400}"
-        ].join("\n"))
-      }
-    };
-    evaluateRecord(openSpanRecord, { thresholds: {} }, {
+    const runtimeDepsStart =
+      "{\"type\":\"span.start\",\"timestamp\":\"2026-04-29T15:30:00.000Z\",\"name\":\"runtimeDeps.stage\",\"spanId\":\"1\"}";
+    const openRuntimeDepsTimeline = parseTimelineText([
+      runtimeDepsStart,
+      "{\"type\":\"eventLoop.sample\",\"timestamp\":\"2026-04-29T15:30:06.000Z\",\"name\":\"eventLoop\",\"maxMs\":400}"
+    ].join("\n"));
+    const closedRuntimeDepsTimeline = parseTimelineText([
+      runtimeDepsStart,
+      "{\"type\":\"span.end\",\"timestamp\":\"2026-04-29T15:30:06.000Z\",\"name\":\"runtimeDeps.stage\",\"spanId\":\"1\",\"durationMs\":6000}"
+    ].join("\n"));
+    const runtimeDepsTimelineOptions = {
       targetPlan: { kind: "local-build" },
       profile: { id: "diagnostic", diagnostics: { timelineRequired: true } },
       surface: {
@@ -3609,8 +3606,47 @@ function diagnosticsTimelineEvaluationCheck() {
         diagnostics: { expectedSpans: ["runtimeDeps.stage"] },
         thresholds: {}
       }
-    });
-    assertEqual(openSpanRecord.status, "FAIL", "open required span status");
+    };
+    const closedSpanRecord = {
+      scenario: "diagnostic-closed-span",
+      status: "PASS",
+      phases: [{ id: "gateway-start", metrics: { timeline: openRuntimeDepsTimeline } }],
+      finalMetrics: {
+        service: { gatewayState: "running" },
+        logs: zeroLogMetrics(),
+        timeline: closedRuntimeDepsTimeline
+      }
+    };
+    evaluateRecord(closedSpanRecord, { thresholds: {} }, runtimeDepsTimelineOptions);
+    assertEqual(closedSpanRecord.status, "PASS", "required span closed by final timeline status");
+    assertEqual(closedSpanRecord.measurements.openclawOpenSpanCount, 0, "final timeline open span count");
+    assertEqual(closedSpanRecord.measurements.openclawOpenRequiredSpanCount, 0, "final timeline required open span count");
+    assertEqual(closedSpanRecord.measurements.openclawOpenSpans.length, 0, "final timeline open span list");
+    assertEqual(
+      closedSpanRecord.measurements.openclawKeySpans["runtimeDeps.stage"]?.openCount,
+      0,
+      "final timeline key span open count"
+    );
+    assertEqual(
+      closedSpanRecord.measurements.openclawKeySpans["runtimeDeps.stage"]?.open.length,
+      0,
+      "final timeline key span open list"
+    );
+    assertEqual(closedSpanRecord.measurements.openclawEventLoopMaxMs, 400, "historical timeline event-loop maximum");
+    assertEqual(closedSpanRecord.measurements.openclawSlowestSpanMs, 6000, "historical timeline slowest span");
+
+    const openSpanRecord = {
+      scenario: "diagnostic-open-span",
+      status: "PASS",
+      phases: [],
+      finalMetrics: {
+        service: { gatewayState: "running" },
+        logs: zeroLogMetrics(),
+        timeline: openRuntimeDepsTimeline
+      }
+    };
+    evaluateRecord(openSpanRecord, { thresholds: {} }, runtimeDepsTimelineOptions);
+    assertEqual(openSpanRecord.status, "FAIL", "required span still open in final timeline status");
     assertEqual(openSpanRecord.measurements.openclawOpenRequiredSpanCount, 1, "open required span measurement");
     assertEqual(
       openSpanRecord.violations.some((violation) => violation.metric === "openclawOpenRequiredSpanCount"),


### PR DESCRIPTION
## Problem

Exact OpenClaw performance run 29058028714 exposed a deterministic Kova false positive. Bundled-plugin startup repeats 1 and 2 captured `gateway.ready` as briefly open during the `gateway-start` snapshot (ages 134 ms and 154 ms), but every later snapshot and `finalMetrics.timeline` showed it closed with no open spans.

`collectTimelineSummary` merged open-span lists and maximized their count across every snapshot, so transient historical state survived into the final evaluation and incorrectly failed both repeats.

## Change

- source top-level open-span count/list from the final or latest available timeline snapshot
- source key-span open count/list from that same current snapshot
- retain historical aggregation for event counts, completed span totals, slowest spans, event-loop maxima, provider timing, and runtime-dependency timing
- add regressions proving an early-open/final-closed required span passes while a final-still-open required span continues to fail

## Evidence

- `git diff --check`
- `node --check src/evaluator.mjs`
- `node --check src/selfcheck.mjs`
- `node bin/kova.mjs plan --json`
- focused full-selfcheck output: `PASS diagnostics-timeline-parser` and `PASS diagnostics-timeline-evaluation`
- regression also preserves the historical 400 ms event-loop maximum and 6000 ms slowest completed span
- fresh Codex autoreview: clean, no actionable findings
- exact failing run: https://github.com/openclaw/openclaw/actions/runs/29058028714

The temporary checkout lacks local OCM prerequisites for unrelated setup/cleanup self-checks. Pull-request CI installs OCM and runs the complete suite on Ubuntu and macOS.
