### PR TITLE
fix: separate setup resource measurements

### DIFF
--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -3,6 +3,11 @@ import { computeProviderTurnAttribution } from "./collectors/provider.mjs";
 import { summarizeRuntimeDepsLogs } from "./collectors/logs.mjs";
 import { resolveThresholdPolicy } from "./evaluation/thresholds.mjs";
 import {
+  measuredProductPhase,
+  measurementScopeForPhase,
+  normalizeMeasurementScope
+} from "./measurement-contract.mjs";
+import {
   checkAggregateThreshold,
   checkDuration,
   checkEvidenceThreshold,
@@ -21,8 +26,9 @@ export function evaluateRecord(record, scenario, options = {}) {
   const roleThresholds = thresholdPolicy.roleThresholds;
   const violations = [];
   const allResults = collectResults(record);
-  const measuredResults = collectResults(record, { excludePhaseIds: ["target-setup"] });
-  const gatewayProcessResources = collectGatewayProcessResources(record, { excludePhaseIds: ["target-setup"] });
+  const measurementScopeSummary = summarizeMeasurementScopes(record);
+  const measuredResults = collectResults(record, { productOnly: true });
+  const gatewayProcessResources = collectGatewayProcessResources(record, { productOnly: true });
   const resourceSummary = collectResourceSummary(measuredResults, { gatewayProcessResources });
   const peakTrackedRssMb = maxNullable(gatewayProcessResources?.peakRssMb, resourceSummary.peakTotalRssMb);
   const cpuPercentMaxTracked = maxNullable(gatewayProcessResources?.maxCpuPercent, resourceSummary.maxTotalCpuPercent);
@@ -695,6 +701,8 @@ export function evaluateRecord(record, scenario, options = {}) {
   record.measurements = {
     peakRssMb,
     cpuPercentMax,
+    measurementScopeSummary,
+    resourceMeasurementScope: "product",
     resourcePrimaryRole: primaryResourceRole,
     resourceGateKind,
     resourceGateReason: resourceGate.reason,
@@ -2212,11 +2220,38 @@ function healthFailureCount(samples) {
   return samples.filter((sample) => sample && !sample.ok).length;
 }
 
+function summarizeMeasurementScopes(record) {
+  const phases = { product: 0, harness: 0, cleanup: 0 };
+  const results = { product: 0, harness: 0, cleanup: 0 };
+  for (const phase of record.phases ?? []) {
+    const phaseScope = measurementScopeForPhase(phase);
+    phases[phaseScope] += 1;
+    for (const result of phase.results ?? []) {
+      const resultScope = result.measurementScope
+        ? normalizeMeasurementScope(result.measurementScope, phase.id)
+        : phaseScope;
+      results[resultScope] += 1;
+    }
+  }
+  return {
+    schemaVersion: "kova.measurementScopeSummary.v1",
+    productPhaseCount: phases.product,
+    harnessPhaseCount: phases.harness,
+    cleanupPhaseCount: phases.cleanup,
+    productCommandCount: results.product,
+    harnessCommandCount: results.harness,
+    cleanupCommandCount: results.cleanup
+  };
+}
+
 function collectResults(record, options = {}) {
   const excludePhaseIds = new Set(options.excludePhaseIds ?? []);
   const results = [];
   for (const phase of record.phases ?? []) {
     if (excludePhaseIds.has(phase.id)) {
+      continue;
+    }
+    if (options.productOnly === true && !measuredProductPhase(phase)) {
       continue;
     }
     for (const result of phase.results ?? []) {
@@ -2243,6 +2278,9 @@ function collectGatewayProcessResources(record, options = {}) {
   let summary = null;
   for (const phase of record.phases ?? []) {
     if (excludePhaseIds.has(phase.id)) {
+      continue;
+    }
+    if (options.productOnly === true && !measuredProductPhase(phase)) {
       continue;
     }
     summary = mergeGatewayProcessMetrics(summary, phase.metrics?.process);

--- a/src/measurement-contract.mjs
+++ b/src/measurement-contract.mjs
@@ -1,0 +1,37 @@
+export const MEASUREMENT_SCOPES = new Set(["product", "harness", "cleanup"]);
+
+export function normalizeMeasurementScope(value, phaseId = null) {
+  if (MEASUREMENT_SCOPES.has(value)) {
+    return value;
+  }
+  if (
+    phaseId === "target-setup" ||
+    phaseId === "auth-prepare" ||
+    phaseId === "auth-setup" ||
+    phaseId === "prepare" ||
+    phaseId?.startsWith("state-")
+  ) {
+    return "harness";
+  }
+  if (phaseId === "cleanup" || phaseId === "auth-cleanup" || phaseId === "env-cleanup") {
+    return "cleanup";
+  }
+  return "product";
+}
+
+export function measuredProductPhase(phase) {
+  return measurementScopeForPhase(phase) === "product";
+}
+
+export function measurementScopeForPhase(phase) {
+  if (MEASUREMENT_SCOPES.has(phase?.measurementScope)) {
+    return phase.measurementScope;
+  }
+  if (
+    phase?.id === "provision" &&
+    (phase.commands ?? []).some((command) => /(?:^|\s)--no-service(?:\s|$)/.test(command))
+  ) {
+    return "harness";
+  }
+  return normalizeMeasurementScope(phase?.measurementScope, phase?.id);
+}

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -120,6 +120,7 @@ export async function runSelfCheck(flags = {}) {
     checks.push(ocmCommandBuildersCheck());
     checks.push(evaluationViolationHelpersCheck());
     checks.push(localBuildTargetSetupResourceExclusionCheck());
+    checks.push(setupResourceExclusionCheck());
     checks.push(primaryResourceRoleEvaluationCheck());
     checks.push(await primaryResourceRoleRegistryCheck());
     checks.push(await releaseResourceCalibrationCheck());
@@ -651,6 +652,166 @@ function localBuildTargetSetupResourceExclusionCheck() {
       id: "local-build-target-setup-resource-exclusion",
       status: "FAIL",
       command: "evaluate local-build target setup resource exclusion",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function setupResourceExclusionCheck() {
+  try {
+    const record = {
+      scenario: "setup-resource-scope",
+      status: "PASS",
+      phases: [
+        {
+          id: "auth-setup",
+          results: [
+            {
+              command: "npm install",
+              status: 0,
+              durationMs: 100,
+              resourceSamples: syntheticResourceSamples({
+                peakRssMb: 1600,
+                maxCpuPercent: 200,
+                role: "command-tree"
+              })
+            },
+            {
+              command: "npm install",
+              status: 0,
+              durationMs: 100,
+              resourceSamples: syntheticResourceSamples({
+                peakRssMb: 950,
+                maxCpuPercent: 180,
+                role: "package-manager"
+              })
+            }
+          ],
+          metrics: {
+            process: {
+              pid: 1,
+              rssMb: 1400,
+              cpuPercent: 220,
+              command: "openclaw-gateway"
+            }
+          }
+        },
+        {
+          id: "state-provision",
+          results: [{
+            command: "node setup-fixture.mjs",
+            status: 0,
+            durationMs: 100,
+            resourceSamples: syntheticResourceSamples({
+              peakRssMb: 1300,
+              maxCpuPercent: 150,
+              role: "command-tree"
+            })
+          }]
+        },
+        {
+          id: "scenario-command",
+          results: [
+            {
+              command: "ocm @kova-self-check -- status",
+              status: 0,
+              durationMs: 100,
+              resourceSamples: syntheticResourceSamples({
+                peakRssMb: 100,
+                maxCpuPercent: 20,
+                role: "gateway"
+              })
+            },
+            {
+              command: "node support/kova-helper.mjs",
+              status: 0,
+              durationMs: 100,
+              resourceSamples: syntheticResourceSamples({
+                peakRssMb: 600,
+                maxCpuPercent: 30,
+                role: "command-tree"
+              })
+            }
+          ]
+        },
+        {
+          id: "auth-cleanup",
+          results: [{
+            command: "rm -rf auth-state",
+            status: 0,
+            durationMs: 100,
+            resourceSamples: syntheticResourceSamples({
+              peakRssMb: 1500,
+              maxCpuPercent: 190,
+              role: "command-tree"
+            })
+          }]
+        }
+      ],
+      finalMetrics: {
+        process: {
+          pid: 2,
+          rssMb: 100,
+          cpuPercent: 20,
+          command: "openclaw-gateway"
+        },
+        service: { gatewayState: "running" },
+        logs: zeroLogMetrics()
+      }
+    };
+    const options = {
+      profile: {
+        calibration: {
+          roles: {
+            "command-tree": { peakRssMb: 1200 },
+            "package-manager": { peakRssMb: 900 }
+          }
+        }
+      },
+      surface: { thresholds: {}, resourcePrimaryRole: "gateway" }
+    };
+    evaluateRecord(record, { thresholds: { peakRssMb: 900 } }, options);
+    assertEqual(record.status, "PASS", "setup resources do not fail runtime gates");
+    assertEqual(record.measurements.peakRssMb, 100, "final product gateway remains headline RSS");
+    assertEqual(record.measurements.resourcePeakTrackedRssMb, 600, "product command tree remains tracked");
+    assertEqual(record.measurements.resourceByRole["command-tree"].peakRssMb, 600, "setup command tree is excluded");
+    assertEqual(record.measurements.resourceByRole["package-manager"], undefined, "setup package manager is excluded");
+    assertEqual(record.measurements.resourceMeasurementScope, "product", "resource gate scope is explicit");
+    assertEqual(record.measurements.measurementScopeSummary.productPhaseCount, 1, "product phase count");
+    assertEqual(record.measurements.measurementScopeSummary.harnessPhaseCount, 2, "harness phase count");
+    assertEqual(record.measurements.measurementScopeSummary.cleanupPhaseCount, 1, "cleanup phase count");
+    assertEqual(record.measurements.measurementScopeSummary.harnessCommandCount, 3, "harness command count");
+    assertEqual(record.phases[0].results[0].resourceSamples.peakTotalRssMb, 1600, "raw setup RSS remains available");
+
+    const runtimeRegression = structuredClone(record);
+    runtimeRegression.status = "PASS";
+    delete runtimeRegression.measurements;
+    delete runtimeRegression.violations;
+    runtimeRegression.phases.find((phase) => phase.id === "scenario-command").results[1].resourceSamples =
+      syntheticResourceSamples({
+        peakRssMb: 1300,
+        maxCpuPercent: 30,
+        role: "command-tree"
+      });
+    evaluateRecord(runtimeRegression, { thresholds: { peakRssMb: 900 } }, options);
+    assertEqual(runtimeRegression.status, "FAIL", "product runtime resources still fail closed");
+    assertEqual(
+      runtimeRegression.violations.some((violation) => violation.metric === "resourceByRole.command-tree.peakRssMb"),
+      true,
+      "product command tree threshold remains active"
+    );
+    return {
+      id: "setup-resource-exclusion",
+      status: "PASS",
+      command: "evaluate setup and runtime resource scopes",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "setup-resource-exclusion",
+      status: "FAIL",
+      command: "evaluate setup and runtime resource scopes",
       durationMs: 0,
       message: error.message
     };


### PR DESCRIPTION
## Problem

OpenClaw Performance run 29059635824 falsely blocked the beta candidate because live auth setup reached 1548.2 MB of aggregate `command-tree` RSS while running `npm install`.

The actual product path passed its configured limits: the local agent peaked at 855.1 MB against the 900 MB agent caps, completed two genuine OpenAI Responses turns, and had no leaks or runtime errors. Kova currently excludes `target-setup` from resource gates, but still merges auth, state-fixture, and cleanup resource samples into product role thresholds.

## Change

- classify measurement phases as product, harness, or cleanup
- use only product phases for headline RSS/CPU, gateway snapshots, and per-role resource gates
- preserve every raw setup command, resource sample, and artifact for diagnostics
- report the phase and command counts for each measurement scope
- prove setup `command-tree` and `package-manager` peaks cannot fail runtime gates
- prove a real product `command-tree` regression still fails closed

This keeps the existing global role thresholds intact. It changes accounting scope, not release calibration.

## Evidence

- `git diff --check`
- `node --check src/evaluator.mjs`
- `node --check src/measurement-contract.mjs`
- `node --check src/selfcheck.mjs`
- full local self-check reached `PASS setup-resource-exclusion`, `PASS primary-resource-role-evaluation`, and `PASS release-resource-calibration`; unrelated setup/cleanup checks require OCM, which is installed by hosted CI
- exact run 29059635824 artifact replay with this evaluator: live 1/1 PASS and mock 18/18 PASS
- live replay retained raw auth-setup RSS at 1548.2 MB while gating product RSS at 855.1 MB
- fresh Codex autoreview: clean, no actionable findings

Exact failing run: https://github.com/openclaw/openclaw/actions/runs/29059635824
