### PR TITLE
fix: version product resource measurements

### DIFF
--- a/docs/CONTRACT_REGISTRY.md
+++ b/docs/CONTRACT_REGISTRY.md
@@ -35,6 +35,17 @@ Then:
 Do not add a surface for an implementation detail. A surface should represent a
 real OpenClaw workflow a user or release gate cares about.
 
+## Phase Measurement Scope
+
+Scenario phases may set `measurementScope` to `product`, `harness`, or
+`cleanup`. Resource gates use only `product` phases. Clone, source-runtime,
+stable-source startup, auth, fixture setup, and target-build phases are harness
+work; candidate upgrade and post-upgrade verification are product work.
+
+Scope belongs to the phase because command resource samples and post-phase
+gateway snapshots share one owner. Command results cannot override their
+phase's scope.
+
 ## Add A State
 
 Create `states/<id>.json`.

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -56,6 +56,8 @@ kova.report.v1
   },
   "performance": {
     "schemaVersion": "kova.performance.v1",
+    "resourceMeasurementScope": "product",
+    "resourceHeadlineContract": "primary-role-product-scope-v2",
     "repeat": 3,
     "groupCount": 1,
     "unstableGroupCount": 0,
@@ -116,6 +118,10 @@ Important fields:
 - `collectorArtifactDirs`: stable per-record artifact directories used by
   collectors
 - `measurements`: evaluated measurements
+- `measurements.resourceMeasurementScope`: scope used for resource gates
+- `measurements.resourceHeadlineContract`: versioned resource accounting
+  contract used to decide whether historical resource values are comparable
+- `measurements.measurementScopeSummary`: phase and command counts by scope
 - `providerEvidence`: provider request timing, route/model/status summaries,
   optional token-like usage totals, and whether evidence came from mock-provider
   logs or OpenClaw timeline events
@@ -135,6 +141,8 @@ attempt was needed.
 
 Executed phases include:
 
+- `measurementScope`: `product`, `harness`, or `cleanup`; command resource
+  samples and post-phase process metrics inherit this phase-owned scope
 - `commands`: commands Kova ran
 - `results`: status, duration, stdout/stderr snippets, timeout state
 - `metrics`: service and process snapshot after the phase
@@ -299,6 +307,11 @@ percent, and increase percent. Release gates treat baseline regressions as
 blocking performance regressions, so a functional pass can still become
 `DO_NOT_SHIP` when OpenClaw gets materially slower or heavier.
 
+Resource baselines are comparable only when both `resourceMeasurementScope` and
+`resourceHeadlineContract` match. Kova skips RSS/CPU deltas from older or
+different accounting contracts, reports the mismatch and skipped metrics, and
+continues comparing non-resource metrics.
+
 ## Run Receipt
 
 `kova run --json` prints a receipt instead of text paths:
@@ -311,12 +324,16 @@ blocking performance regressions, so a functional pass can still become
   "reportPath": "/path/to/report.md",
   "jsonPath": "/path/to/report.json",
   "performance": {
+    "resourceMeasurementScope": "product",
+    "resourceHeadlineContract": "primary-role-product-scope-v2",
     "repeat": 3,
     "groupCount": 1,
     "unstableGroupCount": 0,
     "profiledRunCount": 0,
     "baselineRegressionCount": 0,
     "missingBaselineCount": 0,
+    "resourceContractMismatchCount": 0,
+    "skippedMetricCount": 0,
     "baselineReviewOk": true,
     "baselineReviewBlockerCount": 0,
     "savedBaselinePath": "/path/to/baselines.json"
@@ -492,8 +509,9 @@ The matrix receipt includes only the gate verdict/count summary; the full cards
 and subsystem briefs live in the JSON report.
 
 When `--baseline` is used, the gate also includes a compact historical baseline
-summary with regression count, missing baseline count, and regressed scenario
-groups. Baseline regressions remain blocking gate cards.
+summary with regression count, missing baseline count, resource contract
+mismatches, skipped metrics, and regressed scenario groups. Baseline regressions
+remain blocking gate cards.
 
 For non-ship gate runs, Kova retains a durable copy under
 `artifacts/release-gates/<runId>/`:
@@ -516,6 +534,8 @@ retained-artifacts.json
   "schemaVersion": "kova.compare.v1",
   "ok": false,
   "regressionCount": 1,
+  "resourceContractMismatchCount": 0,
+  "skippedMetricCount": 0,
   "scenarios": [
     {
       "key": "fresh-install:fresh",
@@ -534,7 +554,10 @@ retained-artifacts.json
 Comparison currently detects status regressions, missing scenario/state entries,
 and increases in peak RSS, health failures, health p95, missing dependency
 errors, plugin load failures, metadata scan mentions, and config normalization
-mentions.
+mentions. Resource deltas are compared only when both reports have the same
+resource scope and headline contract. Mismatched reports keep raw values but
+mark their resource deltas non-comparable and continue with non-resource
+regressions.
 
 ## Artifact Bundle
 

--- a/scenarios/dashboard-session-send-turn-existing-user.json
+++ b/scenarios/dashboard-session-send-turn-existing-user.json
@@ -23,6 +23,7 @@
   "phases": [
     {
       "id": "clone",
+      "measurementScope": "harness",
       "title": "Clone Existing Env",
       "intent": "Clone a durable existing user env into a disposable Kova env before runtime or message testing.",
       "commands": ["ocm env clone {sourceEnv} {env} --json"],
@@ -30,6 +31,7 @@
     },
     {
       "id": "upgrade",
+      "measurementScope": "product",
       "title": "Move Clone To Target Runtime",
       "intent": "Run the real OCM upgrade path so the cloned user state runs the requested OpenClaw target runtime.",
       "commands": ["ocm upgrade {env} {upgradeSelector} --json", "ocm service status {env} --json"],
@@ -37,6 +39,7 @@
     },
     {
       "id": "gateway-start",
+      "measurementScope": "product",
       "title": "Start Gateway",
       "intent": "Start the cloned gateway after upgrade and wait for readiness before sending a dashboard-style message.",
       "commands": ["ocm service install {env} --json", "ocm service start {env} --json"],
@@ -44,6 +47,7 @@
     },
     {
       "id": "dashboard-session-turn",
+      "measurementScope": "product",
       "title": "Dashboard Session Message",
       "intent": "Exercise Gateway sessions.send on cloned user state and verify final assistant text appears in chat history.",
       "commands": [
@@ -53,6 +57,7 @@
     },
     {
       "id": "post-dashboard-health",
+      "measurementScope": "product",
       "title": "Post-Dashboard Gateway Health",
       "intent": "Verify the cloned gateway remains responsive after the dashboard-style turn and collect logs for embedded-run/liveness evidence.",
       "commands": ["ocm @{env} -- status", "ocm logs {env} --tail 300 --raw"],

--- a/scenarios/upgrade-durable-clone-to-local-build.json
+++ b/scenarios/upgrade-durable-clone-to-local-build.json
@@ -17,6 +17,7 @@
   "phases": [
     {
       "id": "clone",
+      "measurementScope": "harness",
       "title": "Clone Existing Env",
       "intent": "Clone a durable existing env into a disposable Kova env before any local-build upgrade action.",
       "commands": ["ocm env clone {sourceEnv} {env} --json", "ocm service status {env} --json"],
@@ -24,6 +25,7 @@
     },
     {
       "id": "upgrade",
+      "measurementScope": "product",
       "title": "Upgrade Clone To Local Build",
       "intent": "Run the real OpenClaw upgrade path against the cloned user state using the release-shaped local build runtime.",
       "commands": ["ocm upgrade {env} {upgradeSelector} --json"],
@@ -31,6 +33,7 @@
     },
     {
       "id": "post-upgrade",
+      "measurementScope": "product",
       "title": "Post-Upgrade Clone Checks",
       "intent": "Verify cloned user state survives local-build upgrade, including plugin index migration and gateway readiness.",
       "commands": ["ocm service status {env} --json", "ocm @{env} -- status", "ocm @{env} -- plugins list", "ocm @{env} -- doctor --fix", "ocm logs {env} --tail 400 --raw"],

--- a/scenarios/upgrade-existing-user.json
+++ b/scenarios/upgrade-existing-user.json
@@ -13,6 +13,7 @@
   "phases": [
     {
       "id": "clone",
+      "measurementScope": "harness",
       "title": "Clone Existing Env",
       "intent": "Clone a durable existing env into a disposable Kova env before any upgrade actions.",
       "commands": ["ocm env clone {sourceEnv} {env} --json"],
@@ -20,6 +21,7 @@
     },
     {
       "id": "source-runtime",
+      "measurementScope": "harness",
       "title": "Prepare Source Runtime",
       "intent": "Optionally bind the clone to the source release and start it once to establish pre-upgrade state.",
       "commands": ["ocm upgrade {env} {fromUpgradeSelector} --json", "ocm service status {env} --json"],
@@ -27,6 +29,7 @@
     },
     {
       "id": "upgrade",
+      "measurementScope": "product",
       "title": "Upgrade To Target",
       "intent": "Run the real OpenClaw upgrade path through OCM and verify post-upgrade service reconciliation.",
       "commands": ["ocm upgrade {env} {upgradeSelector} --json"],
@@ -34,6 +37,7 @@
     },
     {
       "id": "post-upgrade",
+      "measurementScope": "product",
       "title": "Post-Upgrade OpenClaw Checks",
       "intent": "Verify OpenClaw state after upgrade, including plugin install index and gateway readiness.",
       "commands": ["ocm @{env} -- status", "ocm @{env} -- plugins list", "ocm @{env} -- doctor --fix", "ocm logs {env} --tail 250 --raw"],

--- a/scenarios/upgrade-from-2026-4-20.json
+++ b/scenarios/upgrade-from-2026-4-20.json
@@ -14,6 +14,7 @@
   "phases": [
     {
       "id": "clone",
+      "measurementScope": "harness",
       "title": "Clone Existing Env",
       "intent": "Clone a durable existing env into a disposable Kova env before any old-release or upgrade action.",
       "commands": ["ocm env clone {sourceEnv} {env} --json"],
@@ -21,6 +22,7 @@
     },
     {
       "id": "source-runtime",
+      "measurementScope": "harness",
       "title": "Move Clone To 2026.4.20",
       "intent": "Use the real OCM upgrade path to bind and reconcile the cloned env on OpenClaw 2026.4.20 before the target upgrade.",
       "commands": ["ocm upgrade {env} --version 2026.4.20 --json", "ocm service status {env} --json", "ocm @{env} -- status"],
@@ -28,6 +30,7 @@
     },
     {
       "id": "upgrade",
+      "measurementScope": "product",
       "title": "Upgrade To Target",
       "intent": "Run the real target upgrade path through OCM and verify post-upgrade service reconciliation.",
       "commands": ["ocm upgrade {env} {upgradeSelector} --json"],
@@ -35,6 +38,7 @@
     },
     {
       "id": "post-upgrade",
+      "measurementScope": "product",
       "title": "Post-Upgrade OpenClaw Checks",
       "intent": "Verify OpenClaw state after upgrade, including plugin install index, plugin command behavior, doctor recovery, and gateway logs.",
       "commands": ["ocm @{env} -- status", "ocm @{env} -- plugins list", "ocm @{env} -- doctor --fix", "ocm logs {env} --tail 300 --raw"],

--- a/scenarios/upgrade-from-2026-4-24.json
+++ b/scenarios/upgrade-from-2026-4-24.json
@@ -16,6 +16,7 @@
   "phases": [
     {
       "id": "clone",
+      "measurementScope": "harness",
       "title": "Clone Existing Env",
       "intent": "Clone a durable existing env into a disposable Kova env before any old-release or upgrade action.",
       "commands": ["ocm env clone {sourceEnv} {env} --json"],
@@ -23,6 +24,7 @@
     },
     {
       "id": "source-runtime",
+      "measurementScope": "harness",
       "title": "Move Clone To 2026.4.24",
       "intent": "Use the real OCM upgrade path to bind and reconcile the cloned env on OpenClaw 2026.4.24 before the target upgrade.",
       "commands": ["ocm upgrade {env} --version 2026.4.24 --json", "ocm service status {env} --json", "ocm @{env} -- status", "ocm logs {env} --tail 300 --raw"],
@@ -30,6 +32,7 @@
     },
     {
       "id": "upgrade",
+      "measurementScope": "product",
       "title": "Upgrade To Target",
       "intent": "Run the real target upgrade path through OCM and verify post-upgrade service reconciliation.",
       "commands": ["ocm upgrade {env} {upgradeSelector} --json"],
@@ -37,6 +40,7 @@
     },
     {
       "id": "post-upgrade",
+      "measurementScope": "product",
       "title": "Post-Upgrade Plugin Checks",
       "intent": "Verify the target OpenClaw fixes plugin architecture state from 2026.4.24 without missing dependency errors or plugin load failures.",
       "commands": ["ocm @{env} -- status", "ocm @{env} -- plugins list", "ocm @{env} -- doctor --fix", "ocm logs {env} --tail 400 --raw"],

--- a/scenarios/upgrade-stable-channel-to-beta.json
+++ b/scenarios/upgrade-stable-channel-to-beta.json
@@ -18,6 +18,7 @@
   "phases": [
     {
       "id": "start",
+      "measurementScope": "harness",
       "title": "Start Stable Channel Env",
       "intent": "Create a disposable env through the real stable channel before switching to beta.",
       "commands": ["ocm start {env} --channel stable --json", "ocm service status {env} --json", "ocm @{env} -- status"],
@@ -25,6 +26,7 @@
     },
     {
       "id": "upgrade",
+      "measurementScope": "product",
       "title": "Upgrade To Beta",
       "intent": "Run the real OpenClaw upgrade path to the beta channel through OCM.",
       "commands": ["ocm upgrade {env} {upgradeSelector} --json"],
@@ -32,6 +34,7 @@
     },
     {
       "id": "post-upgrade",
+      "measurementScope": "product",
       "title": "Post-Beta Upgrade Checks",
       "intent": "Verify OpenClaw is usable after the beta channel upgrade and capture plugin/runtime dependency evidence.",
       "commands": ["ocm service status {env} --json", "ocm @{env} -- status", "ocm @{env} -- plugins list", "ocm @{env} -- doctor --fix", "ocm logs {env} --tail 400 --raw"],

--- a/scenarios/upgrade-stable-channel-to-local-build.json
+++ b/scenarios/upgrade-stable-channel-to-local-build.json
@@ -17,6 +17,7 @@
   "phases": [
     {
       "id": "start",
+      "measurementScope": "harness",
       "title": "Start Stable Channel Env",
       "intent": "Create a disposable env through the real stable channel before upgrading to the local release-shaped runtime.",
       "commands": ["ocm start {env} --channel stable --json", "ocm service status {env} --json", "ocm @{env} -- status"],
@@ -24,6 +25,7 @@
     },
     {
       "id": "upgrade",
+      "measurementScope": "product",
       "title": "Upgrade To Local Build",
       "intent": "Run the real OpenClaw upgrade path to the release-shaped local build runtime.",
       "commands": ["ocm upgrade {env} {upgradeSelector} --json"],
@@ -31,6 +33,7 @@
     },
     {
       "id": "post-upgrade",
+      "measurementScope": "product",
       "title": "Post-Local-Build Upgrade Checks",
       "intent": "Verify the local build handles plugin indexes, runtime deps, doctor recovery, and gateway readiness after upgrade.",
       "commands": ["ocm service status {env} --json", "ocm @{env} -- status", "ocm @{env} -- plugins list", "ocm @{env} -- doctor --fix", "ocm logs {env} --tail 400 --raw"],

--- a/src/auth.mjs
+++ b/src/auth.mjs
@@ -201,6 +201,7 @@ export function buildAuthPreparePhase(authPolicy, artifactDir) {
   const dir = mockDir(artifactDir);
   return {
     id: "auth-prepare",
+    measurementScope: "harness",
     title: "Auth Prepare",
     intent: "Start Kova's deterministic mock provider for the disposable OpenClaw env.",
     commands: [startMockProviderCommand(dir, authPolicy.mockProvider)],
@@ -216,6 +217,7 @@ export function buildAuthSetupPhase(authPolicy, envName, artifactDir) {
     const dir = mockDir(artifactDir);
     return {
       id: "auth-setup",
+      measurementScope: "harness",
       title: "Auth Setup",
       intent: "Configure the disposable OpenClaw env with Kova's mock provider auth.",
       commands: [configureMockAuthCommand(envName, dir)],
@@ -224,6 +226,7 @@ export function buildAuthSetupPhase(authPolicy, envName, artifactDir) {
   }
   return {
     id: "auth-setup",
+    measurementScope: "harness",
     title: "Auth Setup",
     intent: liveAuthSetupIntent(authPolicy),
     commands: [configureLiveAuthCommand(authPolicy, envName)],
@@ -238,6 +241,7 @@ export function buildAuthCleanupPhase(authPolicy, artifactDir) {
   const dir = mockDir(artifactDir);
   return {
     id: "auth-cleanup",
+    measurementScope: "cleanup",
     title: "Auth Cleanup",
     intent: "Stop Kova's deterministic mock provider.",
     commands: [`if test -f ${quoteShell(join(dir, "pid"))}; then kill "$(cat ${quoteShell(join(dir, "pid"))})" 2>/dev/null || true; fi`],

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -4,9 +4,12 @@ import { summarizeRuntimeDepsLogs } from "./collectors/logs.mjs";
 import { resolveThresholdPolicy } from "./evaluation/thresholds.mjs";
 import {
   measuredProductPhase,
-  measurementScopeForPhase,
-  normalizeMeasurementScope
+  measurementScopeForPhase
 } from "./measurement-contract.mjs";
+import {
+  RESOURCE_HEADLINE_CONTRACT,
+  RESOURCE_MEASUREMENT_SCOPE
+} from "./performance/stats.mjs";
 import {
   checkAggregateThreshold,
   checkDuration,
@@ -702,7 +705,8 @@ export function evaluateRecord(record, scenario, options = {}) {
     peakRssMb,
     cpuPercentMax,
     measurementScopeSummary,
-    resourceMeasurementScope: "product",
+    resourceMeasurementScope: RESOURCE_MEASUREMENT_SCOPE,
+    resourceHeadlineContract: RESOURCE_HEADLINE_CONTRACT,
     resourcePrimaryRole: primaryResourceRole,
     resourceGateKind,
     resourceGateReason: resourceGate.reason,
@@ -2226,12 +2230,7 @@ function summarizeMeasurementScopes(record) {
   for (const phase of record.phases ?? []) {
     const phaseScope = measurementScopeForPhase(phase);
     phases[phaseScope] += 1;
-    for (const result of phase.results ?? []) {
-      const resultScope = result.measurementScope
-        ? normalizeMeasurementScope(result.measurementScope, phase.id)
-        : phaseScope;
-      results[resultScope] += 1;
-    }
+    results[phaseScope] += phase.results?.length ?? 0;
   }
   return {
     schemaVersion: "kova.measurementScopeSummary.v1",

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -672,7 +672,9 @@ function summarizeGateReceipt(gate) {
     subsystemCount: gate.subsystems?.length ?? 0,
     fixerSummaryCount: gate.fixerSummaries?.length ?? 0,
     baselineRegressionCount: gate.baseline?.regressionCount ?? null,
-    missingBaselineCount: gate.baseline?.missingBaselineCount ?? null
+    missingBaselineCount: gate.baseline?.missingBaselineCount ?? null,
+    resourceContractMismatchCount: gate.baseline?.resourceContractMismatchCount ?? null,
+    skippedMetricCount: gate.baseline?.skippedMetricCount ?? null
   };
 }
 
@@ -682,12 +684,16 @@ function summarizePerformanceReceipt(performance, baseline) {
   }
   return {
     schemaVersion: performance.schemaVersion,
+    resourceMeasurementScope: performance.resourceMeasurementScope ?? null,
+    resourceHeadlineContract: performance.resourceHeadlineContract ?? null,
     repeat: performance.repeat,
     groupCount: performance.groupCount,
     unstableGroupCount: performance.unstableGroupCount,
     profiledRunCount: performance.profiledRunCount ?? 0,
     baselineRegressionCount: baseline?.comparison?.regressionCount ?? null,
     missingBaselineCount: baseline?.comparison?.missingBaselineCount ?? null,
+    resourceContractMismatchCount: baseline?.comparison?.resourceContractMismatchCount ?? null,
+    skippedMetricCount: baseline?.comparison?.skippedMetricCount ?? null,
     baselineReviewOk: baseline?.review?.ok ?? null,
     baselineReviewBlockerCount: baseline?.review?.blockerCount ?? null,
     savedBaselinePath: baseline?.saved?.path ?? null

--- a/src/matrix/gate.mjs
+++ b/src/matrix/gate.mjs
@@ -365,6 +365,19 @@ function summarizeBaselineComparison(comparison) {
     regressionCount: comparison.regressionCount ?? 0,
     missingBaselineCount: comparison.missingBaselineCount ?? 0,
     skippedMetricCount: comparison.skippedMetricCount ?? 0,
+    resourceMeasurementScope: comparison.resourceMeasurementScope ?? null,
+    resourceHeadlineContract: comparison.resourceHeadlineContract ?? null,
+    resourceContractMismatchCount: comparison.resourceContractMismatchCount ?? 0,
+    resourceContractMismatches: (comparison.groups ?? [])
+      .filter((group) => group.resourceComparison?.compatible === false)
+      .slice(0, 10)
+      .map((group) => ({
+        scenario: group.scenario,
+        state: group.state ?? null,
+        surface: group.surface ?? null,
+        resourceComparison: group.resourceComparison,
+        skippedMetrics: group.skippedMetrics ?? []
+      })),
     regressedGroups: (comparison.groups ?? [])
       .filter((group) => group.status === "REGRESSED")
       .map((group) => ({

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -254,8 +254,13 @@ export function comparePerformanceToBaseline(report, store, options = {}) {
   const regressions = [];
   const missing = [];
   let skippedMetricCount = 0;
+  let resourceContractMismatchCount = 0;
 
   for (const group of report.performance?.groups ?? []) {
+    const currentResourceMeasurementScope =
+      group.resourceMeasurementScope ?? report.performance?.resourceMeasurementScope ?? null;
+    const currentResourceHeadlineContract =
+      group.resourceHeadlineContract ?? report.performance?.resourceHeadlineContract ?? null;
     const representative = (report.records ?? []).find((record) =>
       record.scenario === group.scenario && record.state?.id === group.state && record.surface === group.surface
     );
@@ -278,14 +283,28 @@ export function comparePerformanceToBaseline(report, store, options = {}) {
         surface: group.surface,
         state: group.state,
         status: "NO_BASELINE",
+        resourceComparison: {
+          currentMeasurementScope: currentResourceMeasurementScope,
+          currentHeadlineContract: currentResourceHeadlineContract,
+          baselineMeasurementScope: null,
+          baselineHeadlineContract: null,
+          compatible: null
+        },
         regressions: []
       });
       continue;
     }
 
+    const baselineResourceMeasurementScope = baseline.aggregate?.resourceMeasurementScope ?? null;
+    const baselineResourceHeadlineContract = baseline.aggregate?.resourceHeadlineContract ?? null;
     const resourceContractMatches =
-      typeof baseline.aggregate?.resourceHeadlineContract === "string" &&
-      baseline.aggregate.resourceHeadlineContract === group.resourceHeadlineContract;
+      typeof baselineResourceMeasurementScope === "string" &&
+      baselineResourceMeasurementScope === currentResourceMeasurementScope &&
+      typeof baselineResourceHeadlineContract === "string" &&
+      baselineResourceHeadlineContract === currentResourceHeadlineContract;
+    if (!resourceContractMatches) {
+      resourceContractMismatchCount += 1;
+    }
     const skippedMetrics = resourceContractMatches
       ? []
       : ["peakRssMb", "resourcePeakGatewayRssMb", "cpuPercentMax"];
@@ -310,6 +329,13 @@ export function comparePerformanceToBaseline(report, store, options = {}) {
       state: group.state,
       status: groupRegressions.length > 0 ? "REGRESSED" : "OK",
       baselineSource: baseline.source,
+      resourceComparison: {
+        currentMeasurementScope: currentResourceMeasurementScope,
+        currentHeadlineContract: currentResourceHeadlineContract,
+        baselineMeasurementScope: baselineResourceMeasurementScope,
+        baselineHeadlineContract: baselineResourceHeadlineContract,
+        compatible: resourceContractMatches
+      },
       skippedMetrics,
       regressions: groupRegressions
     });
@@ -324,6 +350,9 @@ export function comparePerformanceToBaseline(report, store, options = {}) {
     regressionCount: regressions.length,
     missingBaselineCount: missing.length,
     skippedMetricCount,
+    resourceMeasurementScope: report.performance?.resourceMeasurementScope ?? null,
+    resourceHeadlineContract: report.performance?.resourceHeadlineContract ?? null,
+    resourceContractMismatchCount,
     groups,
     regressions,
     missing

--- a/src/performance/stats.mjs
+++ b/src/performance/stats.mjs
@@ -1,5 +1,6 @@
 export const PERFORMANCE_SCHEMA = "kova.performance.v1";
-export const RESOURCE_HEADLINE_CONTRACT = "primary-role-v1";
+export const RESOURCE_MEASUREMENT_SCOPE = "product";
+export const RESOURCE_HEADLINE_CONTRACT = "primary-role-product-scope-v2";
 
 export const PERFORMANCE_METRICS = [
   { id: "timeToHealthReadyMs", title: "Health Ready", unit: "ms", regressionKey: "startupRegressionPercent" },
@@ -48,6 +49,7 @@ export function buildPerformanceSummary(records, options = {}) {
 
   return {
     schemaVersion: PERFORMANCE_SCHEMA,
+    resourceMeasurementScope: RESOURCE_MEASUREMENT_SCOPE,
     resourceHeadlineContract: RESOURCE_HEADLINE_CONTRACT,
     generatedAt: new Date().toISOString(),
     repeat: options.repeat ?? null,
@@ -168,6 +170,7 @@ function summarizeGroup(records, options) {
     resourceInterpretation: records.some((record) => record.profiling?.enabled === true)
       ? "instrumented"
       : "normal",
+    resourceMeasurementScope: RESOURCE_MEASUREMENT_SCOPE,
     resourceHeadlineContract: RESOURCE_HEADLINE_CONTRACT,
     statuses: statusCounts(records),
     repeatIndexes: records.map((record) => record.repeat?.index ?? null).filter((value) => value !== null),

--- a/src/registries/scenarios.mjs
+++ b/src/registries/scenarios.mjs
@@ -1,4 +1,5 @@
 import { scenariosDir } from "../paths.mjs";
+import { MEASUREMENT_SCOPES } from "../measurement-contract.mjs";
 import { assertNoShapeErrors, loadJsonRegistry, requireArray, requireKebabId, requireObject, requireString } from "./validate.mjs";
 
 export async function loadScenarios(selectedId) {
@@ -119,6 +120,9 @@ function validatePhases(phases, errors) {
 
     validateStringArray(phase.commands, `${prefix}.commands`, errors);
     validateStringArray(phase.evidence, `${prefix}.evidence`, errors);
+    if (phase.measurementScope !== undefined && !MEASUREMENT_SCOPES.has(phase.measurementScope)) {
+      errors.push(`${prefix}.measurementScope must be one of ${[...MEASUREMENT_SCOPES].join(", ")}`);
+    }
     if (phase.expectedAgentFailure !== undefined && typeof phase.expectedAgentFailure !== "boolean") {
       errors.push(`${prefix}.expectedAgentFailure must be a boolean when set`);
     }

--- a/src/reporting/compare.mjs
+++ b/src/reporting/compare.mjs
@@ -44,11 +44,20 @@ const defaultThresholds = {
   nodeProfileTopFunctionMs: 5000
 };
 
+const resourceComparisonMetrics = new Set([
+  "peakRssMb",
+  "cpuPercentMax",
+  "resourcePeakCommandTreeRssMb",
+  "resourcePeakGatewayRssMb"
+]);
+
 export function compareReports(baseline, current, options = {}) {
   const thresholds = resolveThresholds(options.thresholds);
   const baselineRecords = indexRecords(baseline.records ?? []);
   const currentRecords = current.records ?? [];
   const scenarios = [];
+  let skippedMetricCount = 0;
+  let resourceContractMismatchCount = 0;
 
   for (const currentRecord of currentRecords) {
     const key = recordKey(currentRecord);
@@ -61,6 +70,12 @@ export function compareReports(baseline, current, options = {}) {
         status: "NEW",
         currentStatus: currentRecord.status,
         baselineStatus: null,
+        resourceComparison: {
+          baseline: null,
+          current: resourceIdentity(current, currentRecord),
+          compatible: null
+        },
+        skippedMetrics: [],
         regressions: [],
         metrics: metricDeltas(null, currentRecord.measurements ?? {})
       });
@@ -68,6 +83,17 @@ export function compareReports(baseline, current, options = {}) {
     }
 
     const regressions = [];
+    const resourceComparison = compareResourceIdentity(
+      resourceIdentity(baseline, baselineRecord),
+      resourceIdentity(current, currentRecord)
+    );
+    const skippedMetrics = resourceComparison.compatible
+      ? []
+      : [...resourceComparisonMetrics];
+    if (!resourceComparison.compatible) {
+      resourceContractMismatchCount += 1;
+      skippedMetricCount += skippedMetrics.length;
+    }
     if (statusRank(currentRecord.status) > statusRank(baselineRecord.status)) {
       regressions.push({
         kind: "status",
@@ -78,7 +104,12 @@ export function compareReports(baseline, current, options = {}) {
       });
     }
 
-    regressions.push(...metricRegressions(baselineRecord.measurements ?? {}, currentRecord.measurements ?? {}, thresholds));
+    regressions.push(...metricRegressions(
+      baselineRecord.measurements ?? {},
+      currentRecord.measurements ?? {},
+      thresholds,
+      { skippedMetrics }
+    ));
 
     scenarios.push({
       key,
@@ -87,8 +118,14 @@ export function compareReports(baseline, current, options = {}) {
       status: regressions.length > 0 ? "REGRESSED" : "OK",
       currentStatus: currentRecord.status,
       baselineStatus: baselineRecord.status,
+      resourceComparison,
+      skippedMetrics,
       regressions,
-      metrics: metricDeltas(baselineRecord.measurements ?? {}, currentRecord.measurements ?? {})
+      metrics: metricDeltas(
+        baselineRecord.measurements ?? {},
+        currentRecord.measurements ?? {},
+        { skippedMetrics }
+      )
     });
   }
 
@@ -103,6 +140,12 @@ export function compareReports(baseline, current, options = {}) {
       status: "MISSING",
       currentStatus: null,
       baselineStatus: baselineRecord.status,
+      resourceComparison: {
+        baseline: resourceIdentity(baseline, baselineRecord),
+        current: null,
+        compatible: null
+      },
+      skippedMetrics: [],
       regressions: [{
         kind: "coverage",
         metric: "scenario",
@@ -126,6 +169,8 @@ export function compareReports(baseline, current, options = {}) {
     sourceRelease,
     ok: regressionCount === 0 && sourceReleaseBlockingCount === 0,
     regressionCount,
+    skippedMetricCount,
+    resourceContractMismatchCount,
     scenarios
   };
 }
@@ -140,6 +185,7 @@ export function renderCompareFixerSummary(comparison) {
     ""
   ];
 
+  appendResourceComparisonSummary(lines, comparison);
   if (comparison.ok) {
     lines.push("No blocking regressions were detected.");
     return lines.join("\n");
@@ -172,12 +218,18 @@ export function renderCompareSummary(comparison) {
     `Current: ${comparison.current.runId ?? "unknown"} (${comparison.current.target ?? "unknown"})`,
     `Result: ${comparison.ok ? "OK" : "REGRESSED"}`,
     `Regressions: ${comparison.regressionCount}`,
+    `Resource contract mismatches: ${comparison.resourceContractMismatchCount ?? 0}`,
+    `Skipped resource metrics: ${comparison.skippedMetricCount ?? 0}`,
     "",
     "Scenarios:"
   ];
 
   for (const scenario of comparison.scenarios) {
     lines.push(`- ${scenario.status} ${scenario.key}`);
+    if (scenario.resourceComparison?.compatible === false) {
+      lines.push(`  resource metrics skipped: ${scenario.skippedMetrics.join(", ")}`);
+      lines.push(`  resource contract: ${formatResourceIdentity(scenario.resourceComparison.baseline)} -> ${formatResourceIdentity(scenario.resourceComparison.current)}`);
+    }
     for (const regression of scenario.regressions) {
       lines.push(`  ${regression.message}`);
     }
@@ -195,6 +247,57 @@ export function renderCompareSummary(comparison) {
   }
 
   return lines.join("\n");
+}
+
+function appendResourceComparisonSummary(lines, comparison) {
+  if ((comparison.resourceContractMismatchCount ?? 0) === 0) {
+    return;
+  }
+  lines.push(`Resource contract mismatches: ${comparison.resourceContractMismatchCount}`);
+  lines.push(`Skipped resource metrics: ${comparison.skippedMetricCount ?? 0}`);
+  for (const scenario of comparison.scenarios.filter((item) => item.resourceComparison?.compatible === false).slice(0, 6)) {
+    lines.push(`- ${scenario.key}: ${formatResourceIdentity(scenario.resourceComparison.baseline)} -> ${formatResourceIdentity(scenario.resourceComparison.current)}; skipped ${scenario.skippedMetrics.join(", ")}`);
+  }
+  lines.push("");
+}
+
+function formatResourceIdentity(identity) {
+  if (!identity) {
+    return "missing";
+  }
+  return `${identity.measurementScope ?? "unknown-scope"}/${identity.headlineContract ?? "unknown-contract"}`;
+}
+
+function resourceIdentity(report, record) {
+  const group = (report.performance?.groups ?? []).find((candidate) =>
+    candidate.scenario === record?.scenario &&
+    candidate.state === (record?.state?.id ?? null) &&
+    candidate.surface === (record?.surface ?? null)
+  );
+  return {
+    measurementScope:
+      record?.measurements?.resourceMeasurementScope ??
+      group?.resourceMeasurementScope ??
+      report.performance?.resourceMeasurementScope ??
+      null,
+    headlineContract:
+      record?.measurements?.resourceHeadlineContract ??
+      group?.resourceHeadlineContract ??
+      report.performance?.resourceHeadlineContract ??
+      null
+  };
+}
+
+function compareResourceIdentity(baseline, current) {
+  return {
+    baseline,
+    current,
+    compatible:
+      typeof baseline.measurementScope === "string" &&
+      baseline.measurementScope === current.measurementScope &&
+      typeof baseline.headlineContract === "string" &&
+      baseline.headlineContract === current.headlineContract
+  };
 }
 
 function indexRecords(records) {
@@ -217,6 +320,8 @@ function reportSummary(report) {
     target: report.target ?? null,
     targetKind: targetKind(report.target),
     generatedAt: report.generatedAt ?? null,
+    resourceMeasurementScope: report.performance?.resourceMeasurementScope ?? null,
+    resourceHeadlineContract: report.performance?.resourceHeadlineContract ?? null,
     statuses: report.summary?.statuses ?? {}
   };
 }
@@ -350,9 +455,13 @@ function statusRank(status) {
   return ranks[status] ?? 2;
 }
 
-function metricRegressions(baseline, current, thresholds) {
+function metricRegressions(baseline, current, thresholds, options = {}) {
   const regressions = [];
+  const skippedMetrics = new Set(options.skippedMetrics ?? []);
   for (const [metric, tolerance] of Object.entries(thresholds)) {
+    if (skippedMetrics.has(metric)) {
+      continue;
+    }
     addIncreaseRegression(regressions, baseline, current, metric, tolerance);
   }
   return regressions;
@@ -381,8 +490,9 @@ function addIncreaseRegression(regressions, baseline, current, metric, tolerance
   });
 }
 
-function metricDeltas(baseline, current) {
+function metricDeltas(baseline, current, options = {}) {
   const metrics = {};
+  const skippedMetrics = new Set(options.skippedMetrics ?? []);
   for (const metric of [
     "peakRssMb",
     "cpuPercentMax",
@@ -443,10 +553,14 @@ function metricDeltas(baseline, current) {
   ]) {
     const currentValue = current?.[metric] ?? null;
     const baselineValue = baseline?.[metric] ?? null;
+    const comparable = !skippedMetrics.has(metric);
     metrics[metric] = {
       baseline: baselineValue,
       current: currentValue,
-      delta: typeof baselineValue === "number" && typeof currentValue === "number" ? currentValue - baselineValue : null
+      comparable,
+      delta: comparable && typeof baselineValue === "number" && typeof currentValue === "number"
+        ? currentValue - baselineValue
+        : null
     };
   }
   return metrics;

--- a/src/reporting/report.mjs
+++ b/src/reporting/report.mjs
@@ -93,6 +93,8 @@ export function renderMarkdownReport(report) {
     lines.push(`- Objective: ${record.objective}`);
     if (record.measurements) {
       lines.push(`- ${resourceHeadlineText(record.measurements)}: ${record.measurements.peakRssMb ?? "unknown"} MB`);
+      lines.push(`- Resource measurement scope: ${record.measurements.resourceMeasurementScope ?? "unknown"}`);
+      lines.push(`- Resource headline contract: \`${record.measurements.resourceHeadlineContract ?? "unknown"}\``);
       lines.push(`- Tracked total peak RSS: ${record.measurements.resourcePeakTrackedRssMb ?? "unknown"} MB`);
       lines.push(`- Max CPU: ${record.measurements.cpuPercentMax ?? "unknown"}%`);
       lines.push(`- Resource samples: ${record.measurements.resourceSampleCount ?? "unknown"}`);
@@ -522,6 +524,11 @@ function formatResourceRoleSection(records = []) {
   }
 
   const lines = ["## Resource Roles", ""];
+  const identity = records.find((record) => record.measurements?.resourceHeadlineContract)?.measurements;
+  if (identity) {
+    lines.push(`- Measurement scope: ${identity.resourceMeasurementScope ?? "unknown"}`);
+    lines.push(`- Headline contract: \`${identity.resourceHeadlineContract}\``);
+  }
   for (const role of roles) {
     lines.push(`- ${role.role}: RSS ${role.peakRssMb ?? "unknown"} MB; CPU ${role.maxCpuPercent ?? "unknown"}%; scenario ${role.scenario}${role.state ? `/${role.state}` : ""}`);
   }
@@ -656,6 +663,9 @@ function summarizeMeasurements(measurements) {
   return {
     peakRssMb: measurements.peakRssMb ?? null,
     cpuPercentMax: measurements.cpuPercentMax ?? null,
+    resourceMeasurementScope: measurements.resourceMeasurementScope ?? null,
+    resourceHeadlineContract: measurements.resourceHeadlineContract ?? null,
+    measurementScopeSummary: measurements.measurementScopeSummary ?? null,
     resourcePrimaryRole: measurements.resourcePrimaryRole ?? null,
     resourceGateKind: measurements.resourceGateKind ?? null,
     resourcePeakTrackedRssMb: measurements.resourcePeakTrackedRssMb ?? null,
@@ -754,12 +764,19 @@ function formatPerformanceSection(performance, baseline) {
     `- Repeat: ${performance.repeat ?? "unknown"}`,
     `- Groups: ${performance.groupCount ?? 0}`,
     `- Unstable groups: ${performance.unstableGroupCount ?? 0}`,
-    `- Profiled runs: ${performance.profiledRunCount ?? 0}`
+    `- Profiled runs: ${performance.profiledRunCount ?? 0}`,
+    `- Resource measurement scope: ${performance.resourceMeasurementScope ?? "unknown"}`,
+    `- Resource headline contract: \`${performance.resourceHeadlineContract ?? "unknown"}\``
   ];
 
   if (baseline?.comparison) {
     lines.push(`- Baseline regressions: ${baseline.comparison.regressionCount}`);
     lines.push(`- Missing baselines: ${baseline.comparison.missingBaselineCount}`);
+    lines.push(`- Resource contract mismatches: ${baseline.comparison.resourceContractMismatchCount ?? 0}`);
+    lines.push(`- Skipped resource metrics: ${baseline.comparison.skippedMetricCount ?? 0}`);
+    for (const group of (baseline.comparison.groups ?? []).filter((item) => item.resourceComparison?.compatible === false).slice(0, 4)) {
+      lines.push(`- Resource baseline skipped: ${group.scenario}/${group.state ?? "none"} ${formatResourceComparison(group.resourceComparison)}`);
+    }
     for (const regression of baseline.comparison.regressions.slice(0, 6)) {
       lines.push(`- Regression: ${regression.scenario}/${regression.state ?? "none"} ${regression.message}`);
     }
@@ -786,18 +803,28 @@ function formatPerformanceSection(performance, baseline) {
   return lines;
 }
 
+function formatResourceComparison(comparison) {
+  const baseline = `${comparison.baselineMeasurementScope ?? "unknown-scope"}/${comparison.baselineHeadlineContract ?? "unknown-contract"}`;
+  const current = `${comparison.currentMeasurementScope ?? "unknown-scope"}/${comparison.currentHeadlineContract ?? "unknown-contract"}`;
+  return `${baseline} -> ${current}`;
+}
+
 function summarizePerformance(performance, baseline) {
   if (!performance) {
     return null;
   }
   return {
     schemaVersion: performance.schemaVersion,
+    resourceMeasurementScope: performance.resourceMeasurementScope ?? null,
+    resourceHeadlineContract: performance.resourceHeadlineContract ?? null,
     repeat: performance.repeat ?? null,
     groupCount: performance.groupCount ?? 0,
     unstableGroupCount: performance.unstableGroupCount ?? 0,
     profiledRunCount: performance.profiledRunCount ?? 0,
     baselineRegressionCount: baseline?.comparison?.regressionCount ?? null,
     missingBaselineCount: baseline?.comparison?.missingBaselineCount ?? null,
+    resourceContractMismatchCount: baseline?.comparison?.resourceContractMismatchCount ?? null,
+    skippedMetricCount: baseline?.comparison?.skippedMetricCount ?? null,
     baselineReviewOk: baseline?.review?.ok ?? null,
     baselineReviewBlockerCount: baseline?.review?.blockerCount ?? null,
     savedBaselinePath: baseline?.saved?.path ?? null,
@@ -996,6 +1023,9 @@ function quoteCliValue(value) {
 
 function briefEvidence(measurements, violations) {
   const items = [];
+  if (measurements.resourceMeasurementScope || measurements.resourceHeadlineContract) {
+    items.push(`resourceScope: ${measurements.resourceMeasurementScope ?? "unknown"}; resourceContract: ${measurements.resourceHeadlineContract ?? "unknown"}`);
+  }
   if (measurements.timeToHealthReadyMs !== null && measurements.timeToHealthReadyMs !== undefined) {
     items.push(`timeToHealthReadyMs: ${measurements.timeToHealthReadyMs}`);
   }
@@ -1117,7 +1147,7 @@ function compactRolePeaks(measurements) {
 function pushMeasurementBrief(lines, measurements, { compact }) {
   lines.push("Measurements:");
   lines.push(`- startup: listening ${valueMs(measurements.timeToListeningMs)}; health ${valueMs(measurements.timeToHealthReadyMs)}; readiness ${measurements.readinessClassification ?? "unknown"}; gateway ${measurements.finalGatewayState ?? "unknown"}; restarts ${measurements.gatewayRestartCount ?? "unknown"}`);
-  lines.push(`- resources: ${resourceHeadlineText(measurements)} ${valueMb(measurements.peakRssMb)}; tracked total ${valueMb(measurements.resourcePeakTrackedRssMb)}; max CPU ${valuePercent(measurements.cpuPercentMax)}; samples ${measurements.resourceSampleCount ?? "unknown"}; roles ${rolePeakText(measurements)}`);
+  lines.push(`- resources: scope ${measurements.resourceMeasurementScope ?? "unknown"}; contract ${measurements.resourceHeadlineContract ?? "unknown"}; ${resourceHeadlineText(measurements)} ${valueMb(measurements.peakRssMb)}; tracked total ${valueMb(measurements.resourcePeakTrackedRssMb)}; max CPU ${valuePercent(measurements.cpuPercentMax)}; samples ${measurements.resourceSampleCount ?? "unknown"}; roles ${rolePeakText(measurements)}`);
   lines.push(`- agent: turn ${valueMs(measurements.agentTurnMs, "not-run")}; cold/warm ${valueMs(measurements.coldAgentTurnMs)}/${valueMs(measurements.warmAgentTurnMs)}; cold-warm delta ${valueMs(measurements.agentColdWarmDeltaMs)}; pre-provider ${valueMs(measurements.agentPreProviderMs)}; provider ${valueMs(measurements.agentProviderFinalMs)}; cleanup ${valueMs(measurements.agentCleanupMaxMs)}; diagnosis ${measurements.agentLatencyDiagnosis?.kind ?? "unknown"}; leaks ${measurements.agentProcessLeakCount ?? "unknown"}`);
   lines.push(`- plugins/runtime: missing deps ${measurements.missingDependencyErrors ?? "unknown"}; plugin failures ${measurements.pluginLoadFailures ?? "unknown"}; runtime deps ${valueMs(measurements.runtimeDepsStagingMs)}${runtimeDepsPluginText(measurements)}; warm restages ${measurements.warmRuntimeDepsRestageCount ?? "unknown"}; warm reuse ${measurements.runtimeDepsWarmReuseOk ?? "unknown"}`);
 
@@ -1252,6 +1282,11 @@ function formatGateSection(gate) {
     lines.push("");
     lines.push(`- Regressions: ${gate.baseline.regressionCount}`);
     lines.push(`- Missing baselines: ${gate.baseline.missingBaselineCount}`);
+    lines.push(`- Resource contract mismatches: ${gate.baseline.resourceContractMismatchCount ?? 0}`);
+    lines.push(`- Skipped resource metrics: ${gate.baseline.skippedMetricCount ?? 0}`);
+    for (const group of (gate.baseline.resourceContractMismatches ?? []).slice(0, 4)) {
+      lines.push(`- Resource baseline skipped: ${group.scenario}/${group.state ?? "none"} ${formatResourceComparison(group.resourceComparison)}`);
+    }
     if (gate.baseline.regressedGroups?.length > 0) {
       for (const group of gate.baseline.regressedGroups.slice(0, 4)) {
         lines.push(`- ${group.scenario}/${group.state ?? "none"}: ${group.regressionCount} regression(s)`);

--- a/src/runner.mjs
+++ b/src/runner.mjs
@@ -80,6 +80,7 @@ export async function executeScenario(scenario, context) {
     if (setupResults.length > 0) {
       record.phases.push({
         id: "target-setup",
+        measurementScope: "harness",
         title: "Target Runtime Setup",
         intent: "Prepare the target OpenClaw runtime selector for the scenario.",
         commands: setupResults.map((result) => result.command),
@@ -140,6 +141,7 @@ export async function executeScenario(scenario, context) {
 
         record.phases.push({
           id: phase.id,
+          measurementScope: phase.measurementScope,
           title: phase.title,
           intent: phase.intent,
           expectedAgentFailure: phase.expectedAgentFailure === true,
@@ -345,6 +347,7 @@ function buildPlannedPhases(scenario, context, envName, artifactDir, authPolicy)
     }
     phases.push({
       id: phase.id,
+      measurementScope: phase.measurementScope,
       title: phase.title,
       intent: phase.intent,
       expectedAgentFailure: phase.expectedAgentFailure === true,
@@ -384,6 +387,7 @@ function buildPlannedPhases(scenario, context, envName, artifactDir, authPolicy)
     }
     phases.push({
       id: "env-cleanup",
+      measurementScope: "cleanup",
       title: "Environment Cleanup",
       intent: "Destroy the disposable Kova env after the scenario finishes.",
       commands: [ocmEnvDestroy(envName)],
@@ -401,6 +405,7 @@ function buildTargetSetupPhase(context, envName) {
 
   return {
     id: "target-setup",
+    measurementScope: "harness",
     title: "Target Runtime Setup",
     intent: "Prepare the target OpenClaw runtime selector for the scenario.",
     commands: [targetSetupCommand(context.targetPlan)],
@@ -422,6 +427,7 @@ function buildStateLifecyclePhase(context, envName, scenario, kind, steps, artif
 
   return {
     id: kind,
+    measurementScope: kind === "cleanup" ? "cleanup" : "harness",
     title: stateLifecycleTitle(context.state?.id, kind, phaseId),
     intent: stateLifecycleIntent(context.state?.id, kind, phaseId),
     commands,
@@ -455,6 +461,7 @@ async function executeStateLifecycleSteps(context, envName, scenario, kind, step
 
   return {
     id: kind,
+    measurementScope: kind === "cleanup" ? "cleanup" : "harness",
     title: stateLifecycleTitle(context.state?.id, kind, phaseId),
     intent: stateLifecycleIntent(context.state?.id, kind, phaseId),
     commands,

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -45,7 +45,7 @@ import {
   summarizeResourceSamples
 } from "./collectors/resources.mjs";
 import { renderMarkdownReport, renderPasteSummary, renderReportSummary } from "./reporting/report.mjs";
-import { compareReports, renderCompareSummary } from "./reporting/compare.mjs";
+import { compareReports, renderCompareFixerSummary, renderCompareSummary } from "./reporting/compare.mjs";
 import {
   ocmAt,
   ocmEnvDestroy,
@@ -174,6 +174,9 @@ export async function runSelfCheck(flags = {}) {
       const commands = (record?.phases ?? []).flatMap((phase) => phase.commands ?? []);
       assertEqual(commands.some((command) => command.includes("ocm start") && command.includes("--channel stable")), true, "stable start command present");
       assertEqual(commands.some((command) => command.includes("ocm upgrade") && /--channel '?beta'?/.test(command)), true, "beta upgrade command present");
+      assertEqual(record?.phases?.find((phase) => phase.id === "start")?.measurementScope, "harness", "stable source start scope");
+      assertEqual(record?.phases?.find((phase) => phase.id === "upgrade")?.measurementScope, "product", "candidate upgrade scope");
+      assertEqual(record?.phases?.find((phase) => phase.id === "post-upgrade")?.measurementScope, "product", "post-upgrade scope");
     }));
     checks.push(await jsonCommandCheck("durable-clone-local-build-dry-run-json", `node bin/kova.mjs run --target local-build:/tmp/openclaw --scenario upgrade-durable-clone-to-local-build --state plugin-index --source-env 'Team Env' --report-dir ${quoteShell(tmp)} --json`, async (data) => {
       const report = JSON.parse(await readFile(data.jsonPath, "utf8"));
@@ -181,6 +184,8 @@ export async function runSelfCheck(flags = {}) {
       const commands = (record?.phases ?? []).flatMap((phase) => phase.commands ?? []);
       assertEqual(commands.some((command) => command.includes("ocm env clone 'Team Env'")), true, "quoted source env clone command present");
       assertEqual(commands.some((command) => command.includes("ocm upgrade") && /--runtime '?kova-local-/.test(command)), true, "local-build runtime upgrade command present");
+      assertEqual(record?.phases?.find((phase) => phase.id === "clone")?.measurementScope, "harness", "durable clone scope");
+      assertEqual(record?.phases?.find((phase) => phase.id === "upgrade")?.measurementScope, "product", "durable candidate upgrade scope");
     }));
     checks.push(await jsonCommandCheck("run-auth-default-mock-json", `node bin/kova.mjs run --target runtime:stable --scenario fresh-install --report-dir ${quoteShell(tmp)} --json`, async (data) => {
       const report = JSON.parse(await readFile(data.jsonPath, "utf8"));
@@ -409,6 +414,11 @@ export async function runSelfCheck(flags = {}) {
         if (!command.includes("ocm env clone 'Team Env'")) {
           throw new Error(`source env was not shell-quoted: ${command}`);
         }
+        const phases = report.records?.[0]?.phases ?? [];
+        assertEqual(phases.find((phase) => phase.id === "clone")?.measurementScope, "harness", "clone scope roundtrip");
+        assertEqual(phases.find((phase) => phase.id === "source-runtime")?.measurementScope, "harness", "source runtime scope roundtrip");
+        assertEqual(phases.find((phase) => phase.id === "upgrade")?.measurementScope, "product", "upgrade scope roundtrip");
+        assertEqual(phases.find((phase) => phase.id === "post-upgrade")?.measurementScope, "product", "post-upgrade scope roundtrip");
       }
     ));
     checks.push(await localBuildRuntimeCleanupCheck(tmp));
@@ -422,6 +432,8 @@ export async function runSelfCheck(flags = {}) {
         assertEqual(data.mode, "dry-run", "run mode");
         assertEqual(data.summary?.statuses?.["DRY-RUN"], 2, "dry-run repeat count");
         assertEqual(data.performance?.repeat, 2, "run receipt repeat");
+        assertEqual(data.performance?.resourceMeasurementScope, "product", "run receipt resource scope");
+        assertEqual(data.performance?.resourceHeadlineContract, "primary-role-product-scope-v2", "run receipt resource contract");
         assertString(data.jsonPath, "json report path");
       }
     );
@@ -435,6 +447,8 @@ export async function runSelfCheck(flags = {}) {
         assertEqual(data.mode, "dry-run", "matrix dry-run mode");
         assertString(data.jsonPath, "matrix json report path");
         assertString(data.bundlePath, "matrix bundle path");
+        assertEqual(data.performance?.resourceMeasurementScope, "product", "matrix receipt resource scope");
+        assertEqual(data.performance?.resourceHeadlineContract, "primary-role-product-scope-v2", "matrix receipt resource contract");
         if (!data.bundlePath.startsWith(tmp)) {
           throw new Error(`matrix bundle path should use report dir: ${data.bundlePath}`);
         }
@@ -665,14 +679,20 @@ function setupResourceExclusionCheck() {
       status: "PASS",
       phases: [
         {
+          id: "provision",
+          commands: ["ocm start kova-self-check --runtime stable --no-service --json"],
+          results: []
+        },
+        {
           id: "auth-setup",
           results: [
             {
               command: "npm install",
               status: 0,
               durationMs: 100,
+              measurementScope: "product",
               resourceSamples: syntheticResourceSamples({
-                peakRssMb: 1600,
+                peakRssMb: 1548.2,
                 maxCpuPercent: 200,
                 role: "command-tree"
               })
@@ -682,58 +702,25 @@ function setupResourceExclusionCheck() {
               status: 0,
               durationMs: 100,
               resourceSamples: syntheticResourceSamples({
-                peakRssMb: 950,
+                peakRssMb: 834.8,
                 maxCpuPercent: 180,
                 role: "package-manager"
               })
             }
-          ],
-          metrics: {
-            process: {
-              pid: 1,
-              rssMb: 1400,
-              cpuPercent: 220,
-              command: "openclaw-gateway"
-            }
-          }
+          ]
         },
         {
-          id: "state-provision",
+          id: "cold-agent-turn",
           results: [{
-            command: "node setup-fixture.mjs",
+            command: "node support/kova-agent-resource-helper.mjs",
             status: 0,
             durationMs: 100,
             resourceSamples: syntheticResourceSamples({
-              peakRssMb: 1300,
-              maxCpuPercent: 150,
-              role: "command-tree"
+              peakRssMb: 855.1,
+              maxCpuPercent: 30,
+              roles: ["agent-cli", "agent-process", "command-tree"]
             })
           }]
-        },
-        {
-          id: "scenario-command",
-          results: [
-            {
-              command: "ocm @kova-self-check -- status",
-              status: 0,
-              durationMs: 100,
-              resourceSamples: syntheticResourceSamples({
-                peakRssMb: 100,
-                maxCpuPercent: 20,
-                role: "gateway"
-              })
-            },
-            {
-              command: "node support/kova-helper.mjs",
-              status: 0,
-              durationMs: 100,
-              resourceSamples: syntheticResourceSamples({
-                peakRssMb: 600,
-                maxCpuPercent: 30,
-                role: "command-tree"
-              })
-            }
-          ]
         },
         {
           id: "auth-cleanup",
@@ -765,41 +752,76 @@ function setupResourceExclusionCheck() {
         calibration: {
           roles: {
             "command-tree": { peakRssMb: 1200 },
-            "package-manager": { peakRssMb: 900 }
+            "package-manager": { peakRssMb: 900 },
+            "agent-cli": { peakRssMb: 900 },
+            "agent-process": { peakRssMb: 900 }
           }
         }
       },
-      surface: { thresholds: {}, resourcePrimaryRole: "gateway" }
+      surface: {
+        thresholds: {},
+        resourcePrimaryRole: "agent-cli",
+        roleThresholds: {
+          "agent-cli": { peakRssMb: 900 },
+          "agent-process": { peakRssMb: 900 }
+        }
+      }
     };
     evaluateRecord(record, { thresholds: { peakRssMb: 900 } }, options);
     assertEqual(record.status, "PASS", "setup resources do not fail runtime gates");
-    assertEqual(record.measurements.peakRssMb, 100, "final product gateway remains headline RSS");
-    assertEqual(record.measurements.resourcePeakTrackedRssMb, 600, "product command tree remains tracked");
-    assertEqual(record.measurements.resourceByRole["command-tree"].peakRssMb, 600, "setup command tree is excluded");
+    assertEqual(record.measurements.peakRssMb, 855.1, "product agent remains headline RSS");
+    assertEqual(record.measurements.resourcePeakTrackedRssMb, 855.1, "product agent command tree remains tracked");
+    assertEqual(record.measurements.resourcePrimaryRole, "agent-cli", "agent CLI is the primary resource role");
+    assertEqual(record.measurements.resourceByRole["agent-cli"].peakRssMb, 855.1, "agent CLI RSS retained");
+    assertEqual(record.measurements.resourceByRole["agent-process"].peakRssMb, 855.1, "agent process RSS retained");
+    assertEqual(record.measurements.resourceByRole["command-tree"].peakRssMb, 855.1, "setup command tree is excluded");
     assertEqual(record.measurements.resourceByRole["package-manager"], undefined, "setup package manager is excluded");
     assertEqual(record.measurements.resourceMeasurementScope, "product", "resource gate scope is explicit");
+    assertEqual(record.measurements.resourceHeadlineContract, "primary-role-product-scope-v2", "resource contract is explicit");
     assertEqual(record.measurements.measurementScopeSummary.productPhaseCount, 1, "product phase count");
     assertEqual(record.measurements.measurementScopeSummary.harnessPhaseCount, 2, "harness phase count");
     assertEqual(record.measurements.measurementScopeSummary.cleanupPhaseCount, 1, "cleanup phase count");
-    assertEqual(record.measurements.measurementScopeSummary.harnessCommandCount, 3, "harness command count");
-    assertEqual(record.phases[0].results[0].resourceSamples.peakTotalRssMb, 1600, "raw setup RSS remains available");
+    assertEqual(record.measurements.measurementScopeSummary.productCommandCount, 1, "product command count is phase-owned");
+    assertEqual(record.measurements.measurementScopeSummary.harnessCommandCount, 2, "harness command count is phase-owned");
+    assertEqual(record.measurements.measurementScopeSummary.cleanupCommandCount, 1, "cleanup command count");
+    assertEqual(record.phases[1].results[0].resourceSamples.peakTotalRssMb, 1548.2, "raw setup RSS remains available");
+    assertEqual(record.violations, undefined, "setup RSS does not create product violations");
 
     const runtimeRegression = structuredClone(record);
     runtimeRegression.status = "PASS";
     delete runtimeRegression.measurements;
     delete runtimeRegression.violations;
-    runtimeRegression.phases.find((phase) => phase.id === "scenario-command").results[1].resourceSamples =
+    const agentResult = runtimeRegression.phases.find((phase) => phase.id === "cold-agent-turn").results[0];
+    agentResult.measurementScope = "harness";
+    agentResult.resourceSamples =
       syntheticResourceSamples({
-        peakRssMb: 1300,
+        peakRssMb: 950,
         maxCpuPercent: 30,
-        role: "command-tree"
+        roles: ["agent-cli", "agent-process", "command-tree"]
       });
     evaluateRecord(runtimeRegression, { thresholds: { peakRssMb: 900 } }, options);
     assertEqual(runtimeRegression.status, "FAIL", "product runtime resources still fail closed");
+    assertEqual(runtimeRegression.measurements.peakRssMb, 950, "product agent regression remains headline RSS");
+    assertEqual(runtimeRegression.measurements.measurementScopeSummary.productCommandCount, 1, "result scope cannot bypass phase ownership");
+    assertEqual(
+      runtimeRegression.violations.some((violation) => violation.metric === "peakRssMb"),
+      true,
+      "headline agent RSS threshold remains active"
+    );
+    assertEqual(
+      runtimeRegression.violations.some((violation) => violation.metric === "resourceByRole.agent-cli.peakRssMb"),
+      true,
+      "agent CLI role threshold remains active"
+    );
+    assertEqual(
+      runtimeRegression.violations.some((violation) => violation.metric === "resourceByRole.agent-process.peakRssMb"),
+      true,
+      "agent process role threshold remains active"
+    );
     assertEqual(
       runtimeRegression.violations.some((violation) => violation.metric === "resourceByRole.command-tree.peakRssMb"),
-      true,
-      "product command tree threshold remains active"
+      false,
+      "command tree remains below its separate cap"
     );
     return {
       id: "setup-resource-exclusion",
@@ -1093,22 +1115,23 @@ async function releaseResourceCalibrationCheck() {
   }
 }
 
-function syntheticResourceSamples({ peakRssMb, maxCpuPercent, role }) {
+function syntheticResourceSamples({ peakRssMb, maxCpuPercent, role, roles = role ? [role] : [] }) {
   return {
     sampleCount: 1,
     peakTotalRssMb: peakRssMb,
     maxTotalCpuPercent: maxCpuPercent,
     peakCommandTreeRssMb: peakRssMb,
-    peakGatewayRssMb: role === "gateway" ? peakRssMb : 0,
-    byRole: {
-      [role]: {
+    peakGatewayRssMb: roles.includes("gateway") ? peakRssMb : 0,
+    byRole: Object.fromEntries(roles.map((entry) => [
+      entry,
+      {
         peakRssMb,
         maxCpuPercent,
         peakProcessCount: 1
       }
-    },
-    topRolesByRss: [{ role, peakRssMb, maxCpuPercent }],
-    topRolesByCpu: [{ role, peakRssMb, maxCpuPercent }],
+    ])),
+    topRolesByRss: roles.map((entry) => ({ role: entry, peakRssMb, maxCpuPercent })),
+    topRolesByCpu: roles.map((entry) => ({ role: entry, peakRssMb, maxCpuPercent })),
     topByRss: [],
     topByCpu: []
   };
@@ -1396,10 +1419,77 @@ async function performanceBaselineCheck(tmp) {
     const loadedStore = await loadBaselineStore(baselinePath);
     assertEqual(Object.keys(loadedStore.entries).length, 1, "baseline entry count");
     assertEqual(
+      Object.values(loadedStore.entries)[0]?.aggregate?.resourceMeasurementScope,
+      "product",
+      "baseline stores resource measurement scope"
+    );
+    assertEqual(
       Object.values(loadedStore.entries)[0]?.aggregate?.resourceHeadlineContract,
-      "primary-role-v1",
+      "primary-role-product-scope-v2",
       "baseline stores resource headline contract"
     );
+
+    const productResourceRegressionReport = syntheticPerformanceReport({
+      runId: "product-resource-regression",
+      platform,
+      target: "local-build:/tmp/openclaw",
+      records: [
+        syntheticPerformanceRecord(1, { timeToHealthReadyMs: 1000, peakRssMb: 500, resourcePeakGatewayRssMb: 500, cpuPercentMax: 20, eventLoopDelayMs: 100, agentTurnMs: 2000 }),
+        syntheticPerformanceRecord(2, { timeToHealthReadyMs: 1200, peakRssMb: 520, resourcePeakGatewayRssMb: 520, cpuPercentMax: 22, eventLoopDelayMs: 110, agentTurnMs: 2200 }),
+        syntheticPerformanceRecord(3, { timeToHealthReadyMs: 1100, peakRssMb: 510, resourcePeakGatewayRssMb: 510, cpuPercentMax: 21, eventLoopDelayMs: 105, agentTurnMs: 2100 })
+      ]
+    });
+    productResourceRegressionReport.performance = buildPerformanceSummary(productResourceRegressionReport.records, { repeat: 3 });
+    const productResourceComparison = comparePerformanceToBaseline(productResourceRegressionReport, loadedStore, {
+      targetPlan,
+      regressionThresholds: { rssRegressionPercent: 10 }
+    });
+    assertEqual(productResourceComparison.ok, false, "same-scope product resource regression blocks");
+    assertEqual(productResourceComparison.resourceContractMismatchCount, 0, "same-scope resource contract mismatch count");
+    assertEqual(productResourceComparison.skippedMetricCount, 0, "same-scope skipped resource metric count");
+    assertEqual(productResourceComparison.groups[0]?.resourceComparison?.compatible, true, "same-scope resource comparison compatible");
+    assertEqual(
+      productResourceComparison.regressions.some((regression) => regression.metric === "peakRssMb"),
+      true,
+      "same-scope primary RSS regression present"
+    );
+    assertEqual(
+      productResourceComparison.regressions.some((regression) => regression.metric === "resourcePeakGatewayRssMb"),
+      true,
+      "same-scope gateway RSS regression present"
+    );
+
+    const preProductScopeStore = structuredClone(loadedStore);
+    Object.values(preProductScopeStore.entries)[0].aggregate.resourceHeadlineContract = "primary-role-v1";
+    delete Object.values(preProductScopeStore.entries)[0].aggregate.resourceMeasurementScope;
+    const preProductScopeComparison = comparePerformanceToBaseline(productResourceRegressionReport, preProductScopeStore, {
+      targetPlan,
+      regressionThresholds: { rssRegressionPercent: 10 }
+    });
+    assertEqual(preProductScopeComparison.ok, true, "pre-product-scope resource baseline is ignored");
+    assertEqual(preProductScopeComparison.regressionCount, 0, "pre-product-scope resource regression count");
+    assertEqual(preProductScopeComparison.resourceContractMismatchCount, 1, "pre-product-scope contract mismatch count");
+    assertEqual(preProductScopeComparison.skippedMetricCount, 3, "pre-product-scope skipped resource metric count");
+    assertEqual(preProductScopeComparison.groups[0]?.resourceComparison?.compatible, false, "pre-product-scope comparison incompatible");
+    assertEqual(preProductScopeComparison.groups[0]?.resourceComparison?.baselineMeasurementScope, null, "pre-product-scope baseline scope");
+    assertEqual(preProductScopeComparison.groups[0]?.resourceComparison?.baselineHeadlineContract, "primary-role-v1", "pre-product-scope baseline contract");
+    assertEqual(
+      preProductScopeComparison.groups[0]?.skippedMetrics?.includes("peakRssMb") &&
+        preProductScopeComparison.groups[0]?.skippedMetrics?.includes("resourcePeakGatewayRssMb") &&
+        preProductScopeComparison.groups[0]?.skippedMetrics?.includes("cpuPercentMax"),
+      true,
+      "pre-product-scope resource metrics are reported as skipped"
+    );
+
+    const wrongScopeStore = structuredClone(loadedStore);
+    Object.values(wrongScopeStore.entries)[0].aggregate.resourceMeasurementScope = "harness";
+    const wrongScopeComparison = comparePerformanceToBaseline(productResourceRegressionReport, wrongScopeStore, {
+      targetPlan,
+      regressionThresholds: { rssRegressionPercent: 10 }
+    });
+    assertEqual(wrongScopeComparison.ok, true, "same headline with different resource scope is ignored");
+    assertEqual(wrongScopeComparison.resourceContractMismatchCount, 1, "resource scope mismatch count");
+    assertEqual(wrongScopeComparison.skippedMetricCount, 3, "resource scope mismatch skipped metrics");
 
     const currentReport = syntheticPerformanceReport({
       runId: "current",
@@ -1437,6 +1527,7 @@ async function performanceBaselineCheck(tmp) {
 
     const legacyStore = structuredClone(loadedStore);
     delete Object.values(legacyStore.entries)[0].aggregate.resourceHeadlineContract;
+    delete Object.values(legacyStore.entries)[0].aggregate.resourceMeasurementScope;
     const legacyComparison = comparePerformanceToBaseline(currentReport, legacyStore, {
       targetPlan,
       regressionThresholds: { rssRegressionPercent: 10 }
@@ -1463,6 +1554,118 @@ async function performanceBaselineCheck(tmp) {
       true,
       "legacy resource contract mismatch is reported"
     );
+    assertEqual(legacyComparison.ok, false, "non-resource regressions still block with legacy resource baseline");
+    assertEqual(
+      legacyComparison.regressions.some((regression) => regression.metric === "timeToHealthReadyMs"),
+      true,
+      "startup regression remains comparable with legacy resource baseline"
+    );
+
+    const reportCompareBaseline = syntheticPerformanceReport({
+      runId: "report-compare-baseline",
+      platform,
+      target: "local-build:/tmp/openclaw",
+      records: [
+        syntheticPerformanceRecord(1, {
+          timeToHealthReadyMs: 1000,
+          peakRssMb: 400,
+          cpuPercentMax: 20,
+          resourcePeakCommandTreeRssMb: 400,
+          resourcePeakGatewayRssMb: 400
+        })
+      ]
+    });
+    reportCompareBaseline.performance = buildPerformanceSummary(reportCompareBaseline.records, { repeat: 1 });
+    const reportCompareCurrent = syntheticPerformanceReport({
+      runId: "report-compare-current",
+      platform,
+      target: "local-build:/tmp/openclaw",
+      records: [
+        syntheticPerformanceRecord(1, {
+          timeToHealthReadyMs: 1000,
+          peakRssMb: 550,
+          cpuPercentMax: 50,
+          resourcePeakCommandTreeRssMb: 550,
+          resourcePeakGatewayRssMb: 550
+        })
+      ]
+    });
+    reportCompareCurrent.performance = buildPerformanceSummary(reportCompareCurrent.records, { repeat: 1 });
+    const sameContractReportComparison = compareReports(reportCompareBaseline, reportCompareCurrent);
+    assertEqual(sameContractReportComparison.ok, false, "same-contract report resource regression blocks");
+    assertEqual(sameContractReportComparison.regressionCount, 4, "same-contract report resource regression count");
+    assertEqual(sameContractReportComparison.resourceContractMismatchCount, 0, "same-contract report mismatch count");
+
+    const preScopeReport = structuredClone(reportCompareBaseline);
+    preScopeReport.performance.resourceMeasurementScope = null;
+    preScopeReport.performance.resourceHeadlineContract = "primary-role-v1";
+    preScopeReport.performance.groups[0].resourceMeasurementScope = null;
+    preScopeReport.performance.groups[0].resourceHeadlineContract = "primary-role-v1";
+    const incompatibleReportComparison = compareReports(preScopeReport, reportCompareCurrent);
+    assertEqual(incompatibleReportComparison.ok, true, "pre-scope report resource metrics are ignored");
+    assertEqual(incompatibleReportComparison.regressionCount, 0, "pre-scope report regression count");
+    assertEqual(incompatibleReportComparison.resourceContractMismatchCount, 1, "pre-scope report mismatch count");
+    assertEqual(incompatibleReportComparison.skippedMetricCount, 4, "pre-scope report skipped metric count");
+    assertEqual(incompatibleReportComparison.scenarios[0]?.resourceComparison?.compatible, false, "pre-scope report incompatible");
+    assertEqual(incompatibleReportComparison.scenarios[0]?.metrics?.peakRssMb?.comparable, false, "pre-scope RSS delta incomparable");
+    assertEqual(incompatibleReportComparison.scenarios[0]?.metrics?.peakRssMb?.delta, null, "pre-scope RSS delta omitted");
+    assertEqual(
+      renderCompareSummary(incompatibleReportComparison).includes("Resource contract mismatches: 1"),
+      true,
+      "compare summary reports resource contract mismatch"
+    );
+    assertEqual(
+      renderCompareFixerSummary(incompatibleReportComparison).includes("Skipped resource metrics: 4"),
+      true,
+      "compare fixer summary reports skipped resource metrics"
+    );
+
+    const nonResourceRegressionReport = structuredClone(reportCompareCurrent);
+    nonResourceRegressionReport.records[0].measurements.timeToHealthReadyMs = 7001;
+    nonResourceRegressionReport.performance = buildPerformanceSummary(nonResourceRegressionReport.records, { repeat: 1 });
+    const incompatibleNonResourceComparison = compareReports(preScopeReport, nonResourceRegressionReport);
+    assertEqual(incompatibleNonResourceComparison.ok, false, "non-resource report regression still blocks");
+    assertEqual(incompatibleNonResourceComparison.regressionCount, 1, "non-resource report regression count");
+    assertEqual(incompatibleNonResourceComparison.scenarios[0]?.regressions[0]?.metric, "timeToHealthReadyMs", "non-resource report regression metric");
+
+    const wrongScopeReport = structuredClone(reportCompareBaseline);
+    wrongScopeReport.performance.resourceMeasurementScope = "harness";
+    wrongScopeReport.performance.groups[0].resourceMeasurementScope = "harness";
+    const wrongScopeReportComparison = compareReports(wrongScopeReport, reportCompareCurrent);
+    assertEqual(wrongScopeReportComparison.ok, true, "same report contract with different scope is ignored");
+    assertEqual(wrongScopeReportComparison.skippedMetricCount, 4, "report scope mismatch skipped metric count");
+
+    const evidenceReport = structuredClone(productResourceRegressionReport);
+    evidenceReport.summary = { total: evidenceReport.records.length, statuses: { PASS: evidenceReport.records.length } };
+    evidenceReport.baseline = { path: baselinePath, comparison: preProductScopeComparison };
+    for (const record of evidenceReport.records) {
+      record.measurements.resourceMeasurementScope = "product";
+      record.measurements.resourceHeadlineContract = "primary-role-product-scope-v2";
+      record.measurements.measurementScopeSummary = {
+        schemaVersion: "kova.measurementScopeSummary.v1",
+        productPhaseCount: 1,
+        harnessPhaseCount: 2,
+        cleanupPhaseCount: 1,
+        productCommandCount: 1,
+        harnessCommandCount: 2,
+        cleanupCommandCount: 1
+      };
+    }
+    const structuredEvidence = renderReportSummary(evidenceReport, { structured: true });
+    assertEqual(structuredEvidence.performance?.resourceMeasurementScope, "product", "structured performance resource scope");
+    assertEqual(structuredEvidence.performance?.resourceHeadlineContract, "primary-role-product-scope-v2", "structured performance resource contract");
+    assertEqual(structuredEvidence.performance?.resourceContractMismatchCount, 1, "structured performance mismatch count");
+    assertEqual(structuredEvidence.scenarios[0]?.measurements?.resourceMeasurementScope, "product", "structured scenario resource scope");
+    assertEqual(
+      structuredEvidence.scenarios[0]?.measurements?.measurementScopeSummary?.harnessPhaseCount,
+      2,
+      "structured scenario scope summary"
+    );
+    const markdownEvidence = renderMarkdownReport(evidenceReport);
+    assertEqual(markdownEvidence.includes("- Resource measurement scope: product"), true, "Markdown resource scope");
+    assertEqual(markdownEvidence.includes("primary-role-product-scope-v2"), true, "Markdown resource contract");
+    assertEqual(markdownEvidence.includes("- Resource contract mismatches: 1"), true, "Markdown resource mismatch count");
+
     const regressedReview = reviewBaselineUpdate({
       ...currentReport,
       baseline: { path: baselinePath, comparison }
@@ -1487,6 +1690,25 @@ async function performanceBaselineCheck(tmp) {
     assertEqual(gate.baseline?.regressionCount, comparison.regressionCount, "gate baseline regression count");
     assertEqual(gate.baseline?.regressedGroups?.[0]?.scenario, "fresh-install", "gate baseline group scenario");
     assertEqual(gate.cards.some((card) => card.kind === "performance-regression"), true, "performance regression gate card");
+
+    const mismatchGate = evaluateGate({
+      mode: "execution",
+      controls: {},
+      platform,
+      baseline: { path: baselinePath, comparison: preProductScopeComparison },
+      records: productResourceRegressionReport.records
+    }, {
+      id: "perf-gate",
+      gate: {
+        id: "perf-gate",
+        blocking: [{ scenario: "fresh-install", state: "fresh" }]
+      }
+    });
+    assertEqual(mismatchGate.baseline?.resourceMeasurementScope, "product", "gate resource scope");
+    assertEqual(mismatchGate.baseline?.resourceHeadlineContract, "primary-role-product-scope-v2", "gate resource contract");
+    assertEqual(mismatchGate.baseline?.resourceContractMismatchCount, 1, "gate resource mismatch count");
+    assertEqual(mismatchGate.baseline?.skippedMetricCount, 3, "gate skipped resource metric count");
+    assertEqual(mismatchGate.baseline?.resourceContractMismatches?.length, 1, "gate resource mismatch evidence");
 
     return {
       id: "performance-baseline-regression",
@@ -5191,6 +5413,29 @@ function scenarioCloneFirstValidationCheck() {
     }
     assertEqual(rejectedSecondSourceUse, true, "second source env reference rejected");
 
+    let rejectedInvalidMeasurementScope = false;
+    try {
+      validateScenarioShape({
+        id: "bad-measurement-scope",
+        surface: "fresh-install",
+        title: "Bad Measurement Scope",
+        objective: "Uses an unsupported measurement scope.",
+        tags: ["test"],
+        thresholds: {},
+        phases: [{
+          id: "start",
+          measurementScope: "setup",
+          title: "Start",
+          intent: "Use an invalid scope.",
+          commands: ["ocm start {env} --runtime stable --json"],
+          evidence: ["start"]
+        }]
+      }, "bad-measurement-scope.json");
+    } catch (error) {
+      rejectedInvalidMeasurementScope = /measurementScope must be one of product, harness, cleanup/.test(error.message);
+    }
+    assertEqual(rejectedInvalidMeasurementScope, true, "invalid measurement scope rejected");
+
     validateScenarioShape({
       id: "good-existing-user",
       surface: "upgrade-existing-user",
@@ -5200,12 +5445,14 @@ function scenarioCloneFirstValidationCheck() {
       thresholds: {},
       phases: [{
         id: "clone",
+        measurementScope: "harness",
         title: "Clone",
         intent: "Clone source.",
         commands: ["ocm env clone {sourceEnv} {env} --json"],
         evidence: ["clone"]
       }, {
         id: "upgrade",
+        measurementScope: "product",
         title: "Upgrade",
         intent: "Upgrade disposable clone.",
         commands: ["ocm upgrade {env} --channel beta --json"],


### PR DESCRIPTION
## What Problem This Solves

PR #18 separated setup and product resource measurements, but retained the
`primary-role-v1` baseline identity. Historical setup-inflated RSS/CPU values
could therefore remain comparable with product-only measurements and mask a
real resource regression.

The generic `kova report compare` path also compared those resource values
without checking the measurement contract.

## Why This Change Was Made

- Make the phase the canonical owner of `product`, `harness`, or `cleanup`
  measurement scope.
- Classify clone, source-runtime, stable-source startup, auth, fixture, and
  target-build phases as harness work while keeping candidate upgrade and
  post-upgrade phases product-scoped.
- Version resource accounting as
  `primary-role-product-scope-v2` with explicit `product` scope.
- Require both scope and headline contract to match before comparing RSS/CPU
  metrics in baseline and generic report comparison.
- Keep non-resource comparisons active and expose all skipped metrics and
  contract mismatches in structured, compact, and Markdown output.

## User Impact

Release performance gates no longer fail on setup-only package-manager RSS, and
old resource baselines cannot silently hide regressions under the new
product-only accounting contract.

## Evidence

- `git diff --check`
- `node --check` for all 11 changed `.mjs` files
- JSON parse for all 7 changed scenario files
- `node bin/kova.mjs plan --json` (42 scenarios)
- `node bin/kova.mjs self-check`
  - all resource-scope, baseline, compare, runner, receipt, and report checks
    pass
  - expected local prerequisite-only failures remain for setup/credential
    checks and cleanup because `ocm` is unavailable in this checkout
- Replayed OpenClaw Performance run
  https://github.com/openclaw/openclaw/actions/runs/29059635824:
  - live OpenAI candidate: 1/1 pass, product headline RSS 855.1 MB
  - mock-provider matrix: 18/18 pass
  - setup RSS 1548.2 MB remains recorded but excluded from product gates
- Exact self-check proves 1548.2 MB setup plus 855.1 MB agent passes, while a
  950 MB agent sample fails.
- Fresh structured autoreview: no accepted/actionable findings; confidence
  0.82.

Follow-up to https://github.com/openclaw/Kova/pull/18.
