### PR TITLE
fix(release): restore Kova matrix contracts

### DIFF
--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -40,6 +40,7 @@ kova.report.v1
   "auth": {
     "schemaVersion": "kova.auth.report.v1",
     "requestedMode": "mock",
+    "modelId": null,
     "credentialStore": {
       "schemaVersion": "kova.credentials.summary.v1",
       "home": "/Users/example/.kova/credentials"
@@ -200,6 +201,10 @@ OpenClaw env:
 - `fixture-config-patch`: Kova patched disposable env config directly for a
   live path that has no stable non-interactive OpenClaw command path. Treat this
   as runtime validation only, not proof that OpenClaw onboarding/auth UX passed.
+
+For live runs, `auth.modelId` records the explicit `--model` override. Kova
+applies it through `openclaw models set` after onboarding and before the first
+real service start.
 
 ## Metrics
 

--- a/scenarios/fresh-install.json
+++ b/scenarios/fresh-install.json
@@ -15,7 +15,7 @@
     "statusMs": 10000,
     "pluginsListMs": 10000,
     "modelsListMs": 20000,
-    "peakRssMb": 900
+    "peakRssMb": 1050
   },
   "phases": [
     {

--- a/scenarios/gateway-performance.json
+++ b/scenarios/gateway-performance.json
@@ -13,7 +13,7 @@
   "thresholds": {
     "coldReadyMs": 30000,
     "warmReadyMs": 15000,
-    "peakRssMb": 900,
+    "peakRssMb": 1050,
     "eventLoopMaxMs": 500,
     "postReadyHealthP95Ms": 1000
   },

--- a/src/auth.mjs
+++ b/src/auth.mjs
@@ -83,10 +83,17 @@ export async function resolveRunAuthContext(flags = {}) {
   if (!authModes.includes(requestedMode)) {
     throw new Error(`--auth must be one of ${authModes.join(", ")}`);
   }
+  const modelId = normalizeModelId(flags.model);
+  if (modelId && requestedMode !== "live") {
+    throw new Error("--model requires --auth live");
+  }
 
   const store = await loadCredentialStore();
   const live = await verifyLiveCredentialStatus(liveCredentialStatus(store));
   if (requestedMode === "live" && !live.available && flags.source_env) {
+    if (modelId) {
+      throw new Error("--model cannot override auth inherited through --source-env");
+    }
     const inheritedLive = {
       available: true,
       providerId: null,
@@ -103,6 +110,7 @@ export async function resolveRunAuthContext(flags = {}) {
     return {
       schemaVersion: "kova.auth.context.v1",
       requestedMode,
+      modelId,
       credentialStore: credentialStoreSummary(store),
       liveEnv: store.liveEnv,
       live: inheritedLive,
@@ -116,6 +124,7 @@ export async function resolveRunAuthContext(flags = {}) {
   return {
     schemaVersion: "kova.auth.context.v1",
     requestedMode,
+    modelId,
     credentialStore: credentialStoreSummary(store),
     liveEnv: store.liveEnv,
     live,
@@ -157,6 +166,7 @@ export function scenarioAuthPolicy(context, scenario, state) {
       throw new Error(`live auth requested but credentials are unavailable: ${live?.reason ?? "not configured"}`);
     }
     const providerId = live.providerId;
+    const modelId = context.auth?.modelId ?? null;
     const env = live.envVars.reduce((values, envVar) => {
       if (context.auth.liveEnv[envVar]) {
         values[envVar] = context.auth.liveEnv[envVar];
@@ -169,6 +179,7 @@ export function scenarioAuthPolicy(context, scenario, state) {
       schemaVersion: "kova.auth.policy.v1",
       mode: "live",
       providerId,
+      modelId,
       source: live.method,
       externalCli: live.externalCli ?? null,
       setup: live.method !== "source-env",
@@ -178,6 +189,7 @@ export function scenarioAuthPolicy(context, scenario, state) {
       summary: authDisplay({
         mode: "live",
         providerId,
+        modelId,
         source: live.method,
         externalCli: live.externalCli ?? null,
         setup: live.method !== "source-env",
@@ -247,7 +259,7 @@ export function buildAuthSetupPhase(authPolicy, envName, artifactDir) {
     title: "Auth Setup",
     intent: liveAuthSetupIntent(authPolicy),
     collectionIntent: "service-only",
-    commands: [configureLiveAuthCommand(authPolicy, envName)],
+    commands: configureLiveAuthCommands(authPolicy, envName),
     evidence: liveAuthSetupEvidence(authPolicy)
   };
 }
@@ -273,6 +285,7 @@ export function authDisplay(policy) {
     schemaVersion: "kova.auth.summary.v1",
     mode: policy.mode,
     providerId: policy.providerId ?? null,
+    modelId: policy.modelId ?? null,
     source: policy.source,
     externalCli: policy.externalCli ?? null,
     setup: policy.setup === true,
@@ -289,6 +302,7 @@ export function authReportSummary(authContext) {
   return {
     schemaVersion: "kova.auth.report.v1",
     requestedMode: authContext.requestedMode,
+    modelId: authContext.modelId ?? null,
     credentialStore: authContext.credentialStore,
     live: {
       available: authContext.live.available,
@@ -650,10 +664,28 @@ function configureMockAuthCommand(envName, dir, mockProvider = {}) {
   return ocmEnvExec(envName, args);
 }
 
-function configureLiveAuthCommand(authPolicy, envName) {
-  if (authPolicy.setupKind === "openclaw-onboard") {
-    return configureLiveAuthViaOpenClawOnboardCommand(authPolicy, envName);
+function configureLiveAuthCommands(authPolicy, envName) {
+  const commands = authPolicy.setupKind === "openclaw-onboard"
+    ? [configureLiveAuthViaOpenClawOnboardCommand(authPolicy, envName)]
+    : [configureLiveAuthConfigPatchCommand(authPolicy, envName)];
+  if (authPolicy.modelId) {
+    commands.push(ocmAt(envName, ["models", "set", `${liveModelProviderId(authPolicy)}/${authPolicy.modelId}`]));
   }
+  return commands;
+}
+
+function liveModelProviderId(authPolicy) {
+  if (
+    authPolicy.providerId === "openai" &&
+    authPolicy.source === "external-cli" &&
+    authPolicy.externalCli === "codex"
+  ) {
+    return "codex";
+  }
+  return authPolicy.providerId;
+}
+
+function configureLiveAuthConfigPatchCommand(authPolicy, envName) {
   const envVar = authPolicy.summary.envVars?.[0] ?? defaultEnvVarForProvider(authPolicy.providerId);
   const args = [
     "node",
@@ -712,10 +744,11 @@ function liveAuthSetupIntent(authPolicy) {
 }
 
 function liveAuthSetupEvidence(authPolicy) {
+  const modelEvidence = authPolicy.modelId ? [`requested model ${authPolicy.modelId} selected`] : [];
   if (authPolicy.setupKind === "openclaw-onboard") {
-    return ["OpenClaw onboard command completed", "OpenClaw config references live auth env vars or selected external CLI", "live auth is environment-dependent"];
+    return ["OpenClaw onboard command completed", "OpenClaw config references live auth env vars or selected external CLI", ...modelEvidence, "live auth is environment-dependent"];
   }
-  return ["fixture auth config applied", "OpenClaw config references live auth env vars or selected external CLI", "live auth is environment-dependent"];
+  return ["fixture auth config applied", "OpenClaw config references live auth env vars or selected external CLI", ...modelEvidence, "live auth is environment-dependent"];
 }
 
 function liveOnboardConfig(authPolicy) {
@@ -745,6 +778,16 @@ function defaultEnvVarForProvider(providerId) {
     return "ANTHROPIC_API_KEY";
   }
   return "OPENAI_API_KEY";
+}
+
+function normalizeModelId(value) {
+  if (value === undefined) {
+    return null;
+  }
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("--model requires a non-empty model id");
+  }
+  return value.trim();
 }
 
 async function pathExists(path) {

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -59,9 +59,9 @@ Usage:
   kova plan [--scenario <id>] [--json|--plain]
   kova inventory plan [--openclaw-bin <path>] [--openclaw-repo <path>] [--subcommands <a,b>] [--require-modeled <capability[,capability]>] [--script-scope <product|all|none>] [--max-subcommands <n>] [--max-warnings <n>] [--timeout-ms <n>] [--json|--plain]
   kova inventory repeated-work [--json|--plain]
-  kova run --target <selector> [--from <selector>] [--source-env <env>] [--scenario <id>] [--state <id>] [--auth <mock|live|skip>] [--repeat <n>] [--baseline [path]] [--save-baseline [path] --reviewed-good] [--regression-thresholds <json>] [--network-frontage <port|loopback|loopback-frontage>] [--worker-id <n>] [--report-dir <path>] [--health-samples <n>] [--readiness-interval-ms <n>] [--resource-sample-interval-ms <n>] [--deep-profile] [--node-profile] [--heap-snapshot] [--profile-on-failure] [--execute] [--keep-env] [--retain-on-failure] [--json]
+  kova run --target <selector> [--from <selector>] [--source-env <env>] [--scenario <id>] [--state <id>] [--auth <mock|live|skip>] [--model <id>] [--repeat <n>] [--baseline [path]] [--save-baseline [path] --reviewed-good] [--regression-thresholds <json>] [--network-frontage <port|loopback|loopback-frontage>] [--worker-id <n>] [--report-dir <path>] [--health-samples <n>] [--readiness-interval-ms <n>] [--resource-sample-interval-ms <n>] [--deep-profile] [--node-profile] [--heap-snapshot] [--profile-on-failure] [--execute] [--keep-env] [--retain-on-failure] [--json]
   kova matrix plan --profile <id> --target <selector> [--from <selector>] [--include <filter>] [--exclude <filter>] [--parallel <n>] [--json|--plain]
-  kova matrix run --profile <id> --target <selector> [--from <selector>] [--source-env <env>] [--include <filter>] [--exclude <filter>] [--auth <mock|live|skip>] [--parallel <n>] [--repeat <n>] [--baseline [path]] [--save-baseline [path] --reviewed-good] [--regression-thresholds <json>] [--network-frontage <port|loopback|loopback-frontage>] [--worker-id <n>] [--fail-fast] [--gate] [--report-dir <path>] [--health-samples <n>] [--readiness-interval-ms <n>] [--resource-sample-interval-ms <n>] [--deep-profile] [--node-profile] [--heap-snapshot] [--profile-on-failure] [--execute] [--allow-exhaustive] [--keep-env] [--retain-on-failure] [--json]
+  kova matrix run --profile <id> --target <selector> [--from <selector>] [--source-env <env>] [--include <filter>] [--exclude <filter>] [--auth <mock|live|skip>] [--model <id>] [--parallel <n>] [--repeat <n>] [--baseline [path]] [--save-baseline [path] --reviewed-good] [--regression-thresholds <json>] [--network-frontage <port|loopback|loopback-frontage>] [--worker-id <n>] [--fail-fast] [--gate] [--report-dir <path>] [--health-samples <n>] [--readiness-interval-ms <n>] [--resource-sample-interval-ms <n>] [--deep-profile] [--node-profile] [--heap-snapshot] [--profile-on-failure] [--execute] [--allow-exhaustive] [--keep-env] [--retain-on-failure] [--json]
   kova reports [--limit <n>] [--json|--plain]
   kova report <runId|report.json> [--json|--plain]
   kova report list [--limit <n>] [--json|--plain]
@@ -96,6 +96,7 @@ Notes:
   Report commands accept either full JSON paths or run IDs from kova reports.
   --repeat records independent samples and computes aggregate performance stats.
   --auth defaults to mock so every disposable env has deliberate model auth unless a scenario opts out.
+  --model pins the live-auth model id and is rejected unless --auth live is selected.
   setup provider/auth choices accept prompt numbers in the interactive menu or canonical names such as openai, anthropic, env-only, api-key.
   external-cli setup derives Codex for OpenAI and Claude CLI for Anthropic, then verifies the CLI and auth evidence.
   --baseline compares executed aggregates against a Kova baseline store; without a path it uses the default store.

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -4616,6 +4616,11 @@ function extractAgentResponse(result) {
     // diagnostics alongside JSON in integration environments.
   }
 
+  const payloadText = findPayloadText(text);
+  if (typeof payloadText === "string" && payloadText.trim().length > 0 && payloadText.trim() !== "NO_REPLY") {
+    return { usable: true, text: payloadText.trim() };
+  }
+
   const match = text.match(/"finalAssistant(?:Raw|Visible)Text"\s*:\s*"([^"]+)"/);
   const finalText = match?.[1] ?? null;
   return {
@@ -4648,6 +4653,22 @@ function findFirstString(value, keys) {
     }
   }
   return null;
+}
+
+function findPayloadText(text) {
+  const payloadIndex = text.indexOf('"payloads"');
+  if (payloadIndex < 0) {
+    return null;
+  }
+  const payloadText = text.slice(payloadIndex).match(/"text"\s*:\s*"((?:\\.|[^"\\])*)"/)?.[1];
+  if (typeof payloadText !== "string") {
+    return null;
+  }
+  try {
+    return JSON.parse(`"${payloadText}"`);
+  } catch {
+    return payloadText;
+  }
 }
 
 function countMissingDependencyErrors(results) {

--- a/src/reporting/render-help.mjs
+++ b/src/reporting/render-help.mjs
@@ -78,7 +78,7 @@ const COMMANDS = [
     id: "run", title: "kova run",
     blurb: "Run one OpenClaw scenario. Dry-run unless --execute.",
     usage: [
-      "kova run --target <selector> [--scenario <id>] [--state <id>] [--auth <method>] [--repeat <n>] [--network-frontage <mode>] [--worker-id <n>] [--execute] [--json|--plain]",
+      "kova run --target <selector> [--scenario <id>] [--state <id>] [--auth <method>] [--model <id>] [--repeat <n>] [--network-frontage <mode>] [--worker-id <n>] [--execute] [--json|--plain]",
     ],
     flags: [
       ["--target <selector>", "npm:<v> | release:<n> | runtime:<n> | local-build:<path>"],
@@ -86,6 +86,7 @@ const COMMANDS = [
       ["--scenario <id>", "scenario id (default: fresh-install)"],
       ["--state <id>", "state id"],
       ["--auth <method>", "mock|live|skip (default mock)"],
+      ["--model <id>", "live-auth model id override"],
       ["--repeat <n>", "independent samples"],
       ["--execute", "actually provision and run; otherwise dry-run"],
       ["--baseline [path]", "compare against baseline store"],
@@ -112,7 +113,7 @@ const COMMANDS = [
     blurb: "Profile-driven multi-scenario plan / run with optional gate.",
     usage: [
       "kova matrix plan --profile <id> --target <selector> [--include <f>] [--exclude <f>] [--json|--plain]",
-      "kova matrix run --profile <id> --target <selector> [--parallel <n>] [--network-frontage <mode>] [--worker-id <n>] [--gate] [--execute] [--json|--plain]",
+      "kova matrix run --profile <id> --target <selector> [--auth <method>] [--model <id>] [--parallel <n>] [--network-frontage <mode>] [--worker-id <n>] [--gate] [--execute] [--json|--plain]",
     ],
     flags: [
       ["--profile <id>", "smoke|release|release-upgrade|… (see kova plan)"],
@@ -120,6 +121,8 @@ const COMMANDS = [
       ["--include/--exclude <f>", "scenario:<id>, state:<id>, tag:<t>, or bare value"],
       ["--parallel <n>", "concurrent scenarios (default 1)"],
       ["--repeat <n>", "samples per scenario"],
+      ["--auth <method>", "mock|live|skip (default mock)"],
+      ["--model <id>", "live-auth model id override"],
       ["--fail-fast", "abort on first failure"],
       ["--gate", "evaluate matrix against the profile gate policy"],
       ["--network-frontage <mode>", "port|loopback; loopback cannot combine with --parallel > 1"],
@@ -231,6 +234,7 @@ const NOTES = [
   "run/matrix run are dry-run unless --execute is passed.",
   "--repeat records independent samples and computes aggregate performance stats.",
   "--auth defaults to mock so every disposable env has deliberate model auth.",
+  "--model pins the model id for live-auth runs.",
   "--deep-profile enables Node CPU/heap/trace + diagnostic report + denser sampling.",
   "Human-facing commands render dashboards by default; --plain renders compact text.",
   "Report commands accept either full JSON paths or run IDs from kova reports.",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -195,6 +195,11 @@ export async function runSelfCheck(flags = {}) {
       `KOVA_HOME=${quoteShell(join(tmp, "empty-auth-home"))} node bin/kova.mjs run --target runtime:stable --scenario fresh-install --auth live --json`,
       "--auth live requires configured live credentials"
     ));
+    checks.push(await failingCommandCheck(
+      "model-requires-live-auth",
+      `KOVA_HOME=${quoteShell(join(tmp, "model-with-mock-auth-home"))} node bin/kova.mjs run --target runtime:stable --scenario fresh-install --model gpt-5.6 --json`,
+      "--model requires --auth live"
+    ));
     checks.push(await setupNumericFlagsRejectedCheck(tmp));
     checks.push(await externalCliSetupCheck(tmp));
     checks.push(await externalCliOpenClawConfigCheck(tmp));
@@ -708,6 +713,7 @@ export async function runSelfCheck(flags = {}) {
     checks.push(await resourceRolePollutionCheck());
     checks.push(await gatewaySessionSurfaceContractCheck());
     checks.push(await bundledPluginStartupSurfaceContractCheck());
+    checks.push(await releaseResourceCalibrationCheck());
     checks.push(await releaseRuntimeStartupSurfaceContractCheck());
     checks.push(await officialPluginInstallSurfaceContractCheck());
     checks.push(await agentCliLocalTurnSurfaceContractCheck());
@@ -4315,7 +4321,7 @@ async function liveApiKeyExecutionCheck(tmp) {
     `PATH=${quoteShell(`${binDir}:${process.env.PATH}`)}`,
     `KOVA_FAKE_OPENCLAW_HOME=${quoteShell(openclawHome)}`,
     `KOVA_MOCK_OCM_LOG=${quoteShell(ocmLog)}`,
-    `node bin/kova.mjs run --target runtime:stable --scenario fresh-install --auth live --execute --report-dir ${quoteShell(reportDir)} --json`
+    `node bin/kova.mjs run --target runtime:stable --scenario fresh-install --auth live --model gpt-5.6 --execute --report-dir ${quoteShell(reportDir)} --json`
   ].join(" ");
   const result = await runCommand(command, { shell: "/bin/sh", timeoutMs: 30000, maxOutputChars: 1000000, redactValues: [secret] });
 
@@ -4331,15 +4337,29 @@ async function liveApiKeyExecutionCheck(tmp) {
     const report = JSON.parse(reportText);
     const record = report.records?.[0];
     assertEqual(report.auth?.requestedMode, "live", "report requested live auth");
+    assertEqual(report.auth?.modelId, "gpt-5.6", "report requested live model");
     assertEqual(report.auth?.live?.environmentDependent, true, "top-level live env-dependent flag");
     assertEqual(record?.auth?.mode, "live", "record live auth mode");
     assertEqual(record?.auth?.source, "api-key", "record live auth source");
     assertEqual(record?.auth?.setupKind, "openclaw-onboard", "record live setup kind");
+    assertEqual(record?.auth?.modelId, "gpt-5.6", "record requested live model");
     assertEqual(record?.auth?.environmentDependent, true, "record live env-dependent flag");
     assertEqual(record?.auth?.secretValues, "redacted", "record secret values redacted");
     assertEqual(record?.providerEvidence?.environmentDependent, true, "provider evidence live env-dependent flag");
     const config = JSON.parse(await readFile(join(openclawHome, ".openclaw", "openclaw.json"), "utf8"));
     assertEqual(config.models?.providers?.openai?.apiKey?.id, "OPENAI_API_KEY", "OpenClaw live config env ref");
+    assertEqual(config.agents?.defaults?.model?.primary, "openai/gpt-5.6", "OpenClaw live model override");
+    const authSetupCommands = record.phases
+      ?.find((phase) => phase.id === "auth-setup")
+      ?.commands ?? [];
+    assertEqual(authSetupCommands.length, 2, "live model override runs after OpenClaw onboarding");
+    assertEqual(authSetupCommands[0]?.includes("onboard"), true, "live model override keeps OpenClaw onboarding");
+    assertEqual(
+      authSetupCommands[1]?.includes("models") && authSetupCommands[1]?.includes("set"),
+      true,
+      "live model override uses OpenClaw model selection"
+    );
+    assertEqual(authSetupCommands[1]?.includes("openai/gpt-5.6"), true, "live model override command");
     const serializedConfig = JSON.stringify(config);
     if (serializedConfig.includes(secret)) {
       throw new Error("live API key leaked into OpenClaw config");
@@ -4397,7 +4417,7 @@ async function liveExternalCliDryRunCheck(tmp) {
     `HOME=${quoteShell(home)}`,
     `PATH=${quoteShell(`${fakeBin}:${process.env.PATH}`)}`,
     `KOVA_HOME=${quoteShell(kovaHome)}`,
-    `node bin/kova.mjs run --target runtime:stable --scenario fresh-install --auth live --report-dir ${quoteShell(reportDir)} --json`
+    `node bin/kova.mjs run --target runtime:stable --scenario fresh-install --auth live --model gpt-5.6 --report-dir ${quoteShell(reportDir)} --json`
   ].join(" ");
   const result = await runCommand(command, { shell: "/bin/sh", timeoutMs: 30000, maxOutputChars: 1000000 });
 
@@ -4415,12 +4435,20 @@ async function liveExternalCliDryRunCheck(tmp) {
     assertEqual(record?.auth?.source, "external-cli", "external cli record source");
     assertEqual(record?.auth?.externalCli, "codex", "external cli record name");
     assertEqual(record?.auth?.setupKind, "fixture-config-patch", "codex cli fixture setup kind");
-    const authSetupCommand = record.phases
-      ?.flatMap((phase) => phase.commands ?? [])
-      ?.find((item) => item.includes("configure-openclaw-live-auth.mjs")) ?? "";
+    assertEqual(record?.auth?.modelId, "gpt-5.6", "external cli requested model");
+    const authSetupCommands = record.phases
+      ?.find((phase) => phase.id === "auth-setup")
+      ?.commands ?? [];
+    const authSetupCommand = authSetupCommands
+      .find((item) => item.includes("configure-openclaw-live-auth.mjs")) ?? "";
     if (!/'?--auth-method'?\s+'?external-cli'?/.test(authSetupCommand) || !/'?--external-cli'?\s+'?codex'?/.test(authSetupCommand)) {
       throw new Error(`external-cli auth setup command missing expected args: ${authSetupCommand}`);
     }
+    assertEqual(
+      authSetupCommands.some((item) => item.includes("models") && item.includes("set") && item.includes("codex/gpt-5.6")),
+      true,
+      "external cli model override keeps Codex provider"
+    );
     return {
       id: "live-external-cli-dry-run",
       status: "PASS",
@@ -4547,6 +4575,23 @@ JSON
           ;;
       esac
       echo '{"ok":true}'
+      exit 0
+    fi
+    if [ "$1" = "models" ] && [ "$2" = "set" ]; then
+      node - "$KOVA_FAKE_OPENCLAW_HOME/.openclaw/openclaw.json" "$3" <<'NODE'
+const fs = require("node:fs");
+const path = process.argv[2];
+const model = process.argv[3];
+const config = JSON.parse(fs.readFileSync(path, "utf8"));
+config.agents = config.agents || {};
+config.agents.defaults = config.agents.defaults || {};
+config.agents.defaults.model = {
+  ...(config.agents.defaults.model || {}),
+  primary: model
+};
+fs.writeFileSync(path, JSON.stringify(config, null, 2) + "\\n");
+NODE
+      echo "Default model: $3"
       exit 0
     fi
     echo "live command key=$OPENAI_API_KEY"
@@ -9849,6 +9894,8 @@ function agentColdWarmEvaluationCheck() {
   try {
     const coldCommand = "ocm @kova -- agent --local --agent main --session-id kova-agent-cold-warm --message hi --json";
     const warmCommand = "ocm @kova -- agent --local --agent main --session-id kova-agent-cold-warm --message hi --json";
+    const truncatedPayloadResponse = `{"payloads":[{"text":"KOVA_AGENT_OK"}],"meta":{"details":"${"x".repeat(20000)}
+[truncated 100 chars]`;
     const record = {
       scenario: "agent-cold-warm-message",
       status: "PASS",
@@ -9865,7 +9912,7 @@ function agentColdWarmEvaluationCheck() {
             finishedAt: "2026-04-30T10:01:03.000Z",
             finishedAtEpochMs: 1777543263000,
             durationMs: 62000,
-            stdout: "{\"payloads\":[{\"text\":\"KOVA_AGENT_OK\"}]}",
+            stdout: truncatedPayloadResponse,
             stderr: ""
           }],
           metrics: { logs: zeroLogMetrics(), health: { ok: true } }
@@ -9948,7 +9995,7 @@ function agentColdWarmEvaluationCheck() {
     assertEqual(record.measurements.coldProviderFinalMs, 800, "cold provider final");
     assertEqual(record.measurements.agentLatencyDiagnosis.kind, "cold-pre-provider-stall", "latency diagnosis kind");
     assertEqual(record.measurements.agentTurns[0].responseOk, true, "cold response ok");
-    assertEqual(record.measurements.agentTurns[0].responseText, "KOVA_AGENT_OK", "payload response text");
+    assertEqual(record.measurements.agentTurns[0].responseText, "KOVA_AGENT_OK", "truncated payload response text");
     assertEqual(record.measurements.agentTurns[1].responseText, "KOVA_AGENT_OK", "final assistant response precedence");
     assertEqual(record.measurements.agentTurns[1].providerRoutes[0].value, "/v1/responses", "warm provider route evidence");
     assertEqual(
@@ -11915,6 +11962,90 @@ async function bundledPluginStartupSurfaceContractCheck() {
       id: "bundled-plugin-startup-surface-contract",
       status: "FAIL",
       command: "validate bundled plugin startup readiness and resource caps",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function releaseResourceCalibrationCheck() {
+  try {
+    const [
+      freshScenario,
+      gatewayScenario,
+      freshSurface,
+      gatewaySurface,
+      bundledRuntimeSurface,
+      bundledPluginSurface,
+      releaseProfile
+    ] = await Promise.all([
+      readFile("scenarios/fresh-install.json", "utf8").then(JSON.parse),
+      readFile("scenarios/gateway-performance.json", "utf8").then(JSON.parse),
+      readFile("surfaces/fresh-install.json", "utf8").then(JSON.parse),
+      readFile("surfaces/gateway-performance.json", "utf8").then(JSON.parse),
+      readFile("surfaces/bundled-runtime-deps.json", "utf8").then(JSON.parse),
+      readFile("surfaces/bundled-plugin-startup.json", "utf8").then(JSON.parse),
+      readFile("profiles/release.json", "utf8").then(JSON.parse)
+    ]);
+
+    const contracts = [
+      {
+        id: "fresh-install",
+        scenario: freshScenario,
+        surface: freshSurface,
+        primaryRssMb: 1050,
+        roles: { gateway: 1050, "status-cli": 850, "plugin-cli": 800 }
+      },
+      {
+        id: "gateway-performance",
+        scenario: gatewayScenario,
+        surface: gatewaySurface,
+        primaryRssMb: 1050,
+        roles: { gateway: 1050, "gateway-tree": 1200, "status-cli": 850, "plugin-cli": 800 }
+      },
+      {
+        id: "bundled-runtime-deps",
+        scenario: null,
+        surface: bundledRuntimeSurface,
+        primaryRssMb: null,
+        roles: { gateway: 1050 }
+      },
+      {
+        id: "bundled-plugin-startup",
+        scenario: null,
+        surface: bundledPluginSurface,
+        primaryRssMb: null,
+        roles: { gateway: 950, "plugin-cli": 800 }
+      }
+    ];
+
+    for (const contract of contracts) {
+      const policy = resolveThresholdPolicy({
+        profile: releaseProfile,
+        surface: contract.surface,
+        scenario: contract.scenario
+      });
+      if (contract.primaryRssMb !== null) {
+        assertEqual(contract.scenario?.thresholds?.peakRssMb, contract.primaryRssMb, `${contract.id} scenario primary RSS cap`);
+        assertEqual(contract.surface?.thresholds?.peakRssMb, contract.primaryRssMb, `${contract.id} surface primary RSS cap`);
+      }
+      for (const [role, peakRssMb] of Object.entries(contract.roles)) {
+        assertEqual(contract.surface?.processRoles?.includes(role), true, `${contract.id} declares ${role}`);
+        assertEqual(policy.roleThresholds?.[role]?.peakRssMb, peakRssMb, `${contract.id} ${role} RSS cap`);
+      }
+    }
+
+    return {
+      id: "release-resource-calibration",
+      status: "PASS",
+      command: "validate release resource calibration scope",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "release-resource-calibration",
+      status: "FAIL",
+      command: "validate release resource calibration scope",
       durationMs: 0,
       message: error.message
     };

--- a/surfaces/bundled-runtime-deps.json
+++ b/surfaces/bundled-runtime-deps.json
@@ -18,7 +18,7 @@
   },
   "roleThresholds": {
     "gateway": {
-      "peakRssMb": 800,
+      "peakRssMb": 1050,
       "maxCpuPercent": 250
     },
     "runtime-staging": {

--- a/surfaces/fresh-install.json
+++ b/surfaces/fresh-install.json
@@ -14,19 +14,19 @@
   "thresholds": {
     "gatewayReadyMs": 30000,
     "statusMs": 10000,
-    "peakRssMb": 900
+    "peakRssMb": 1050
   },
   "roleThresholds": {
     "gateway": {
-      "peakRssMb": 800,
+      "peakRssMb": 1050,
       "maxCpuPercent": 250
     },
     "status-cli": {
-      "peakRssMb": 500,
+      "peakRssMb": 850,
       "maxCpuPercent": 200
     },
     "plugin-cli": {
-      "peakRssMb": 600,
+      "peakRssMb": 800,
       "maxCpuPercent": 250
     },
     "model-cli": {

--- a/surfaces/gateway-performance.json
+++ b/surfaces/gateway-performance.json
@@ -7,27 +7,32 @@
     "gateway",
     "gateway-tree",
     "command-tree",
-    "status-cli"
+    "status-cli",
+    "plugin-cli"
   ],
   "resourcePrimaryRole": "gateway",
   "thresholds": {
     "coldReadyMs": 30000,
     "warmReadyMs": 15000,
-    "peakRssMb": 900,
+    "peakRssMb": 1050,
     "postReadyHealthP95Ms": 1000
   },
   "roleThresholds": {
     "gateway": {
-      "peakRssMb": 800,
+      "peakRssMb": 1050,
       "maxCpuPercent": 250
     },
     "gateway-tree": {
-      "peakRssMb": 1000,
+      "peakRssMb": 1200,
       "maxCpuPercent": 300
     },
     "status-cli": {
-      "peakRssMb": 500,
+      "peakRssMb": 850,
       "maxCpuPercent": 200
+    },
+    "plugin-cli": {
+      "peakRssMb": 800,
+      "maxCpuPercent": 250
     }
   },
   "diagnostics": {

--- a/tests/render-snapshots.mjs
+++ b/tests/render-snapshots.mjs
@@ -15,7 +15,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync, existsSync, mkdtempSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { homedir, tmpdir } from "node:os";
+import { homedir, release, tmpdir } from "node:os";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..");
@@ -66,7 +66,9 @@ function normalize(out) {
     .replaceAll(SNAPSHOT_KOVA_HOME, "<kova-home>")
     .replaceAll(repoRoot, "<repo>")
     .replaceAll(home, "<home>")
+    .replaceAll(release(), "<os-release>")
     .replaceAll(process.version, "<node>")
+    .replace(/("node"\s*:\s*")v\d+\.\d+\.\d+(")/g, "$1<node>$2")
     // ISO-like timestamps in the meta strip, e.g. "2026-05-17 02:23 UTC".
     .replace(/\b\d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\b/g, "<ts>")
     // generatedAt-style ISO timestamps in plan output.

--- a/tests/snapshots/help-default.snap
+++ b/tests/snapshots/help-default.snap
@@ -28,6 +28,7 @@
   • run/matrix run are dry-run unless --execute is passed.
   • --repeat records independent samples and computes aggregate performance stats.
   • --auth defaults to mock so every disposable env has deliberate model auth.
+  • --model pins the model id for live-auth runs.
   • --deep-profile enables Node CPU/heap/trace + diagnostic report + denser sampling.
   • Human-facing commands render dashboards by default; --plain renders compact text.
   • Report commands accept either full JSON paths or run IDs from kova reports.

--- a/tests/snapshots/matrix-plan-json.snap
+++ b/tests/snapshots/matrix-plan-json.snap
@@ -4,7 +4,7 @@
   "platform": {
     "os": "darwin",
     "arch": "arm64",
-    "release": "25.5.0",
+    "release": "<os-release>",
     "node": "<node>"
   },
   "profile": {

--- a/tests/snapshots/plan-default.snap
+++ b/tests/snapshots/plan-default.snap
@@ -1,7 +1,7 @@
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║  KOVA  ·  plan                                                               ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
-   61 scenarios · 41 surfaces                    darwin 25.5.0 · arm64 · <node>
+   61 scenarios · 41 surfaces                    darwin <os-release> · arm64 · <node>
 
   Scenarios 61   ·   States 43   ·   Profiles 12   ·   Surfaces 41
 

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -4,7 +4,7 @@
   "platform": {
     "os": "darwin",
     "arch": "arm64",
-    "release": "25.5.0",
+    "release": "<os-release>",
     "node": "<node>"
   },
   "surfaces": [
@@ -408,7 +408,7 @@
       },
       "roleThresholds": {
         "gateway": {
-          "peakRssMb": 800,
+          "peakRssMb": 1050,
           "maxCpuPercent": 250
         },
         "runtime-staging": {
@@ -1063,19 +1063,19 @@
       "thresholds": {
         "gatewayReadyMs": 30000,
         "statusMs": 10000,
-        "peakRssMb": 900
+        "peakRssMb": 1050
       },
       "roleThresholds": {
         "gateway": {
-          "peakRssMb": 800,
+          "peakRssMb": 1050,
           "maxCpuPercent": 250
         },
         "status-cli": {
-          "peakRssMb": 500,
+          "peakRssMb": 850,
           "maxCpuPercent": 200
         },
         "plugin-cli": {
-          "peakRssMb": 600,
+          "peakRssMb": 800,
           "maxCpuPercent": 250
         },
         "model-cli": {
@@ -1133,27 +1133,32 @@
         "gateway",
         "gateway-tree",
         "command-tree",
-        "status-cli"
+        "status-cli",
+        "plugin-cli"
       ],
       "resourcePrimaryRole": "gateway",
       "thresholds": {
         "coldReadyMs": 30000,
         "warmReadyMs": 15000,
-        "peakRssMb": 900,
+        "peakRssMb": 1050,
         "postReadyHealthP95Ms": 1000
       },
       "roleThresholds": {
         "gateway": {
-          "peakRssMb": 800,
+          "peakRssMb": 1050,
           "maxCpuPercent": 250
         },
         "gateway-tree": {
-          "peakRssMb": 1000,
+          "peakRssMb": 1200,
           "maxCpuPercent": 300
         },
         "status-cli": {
-          "peakRssMb": 500,
+          "peakRssMb": 850,
           "maxCpuPercent": 200
+        },
+        "plugin-cli": {
+          "peakRssMb": 800,
+          "maxCpuPercent": 250
         }
       },
       "diagnostics": {
@@ -12005,7 +12010,7 @@
         "statusMs": 10000,
         "pluginsListMs": 10000,
         "modelsListMs": 20000,
-        "peakRssMb": 900
+        "peakRssMb": 1050
       },
       "phases": [
         {
@@ -12115,7 +12120,7 @@
       "thresholds": {
         "coldReadyMs": 30000,
         "warmReadyMs": 15000,
-        "peakRssMb": 900,
+        "peakRssMb": 1050,
         "eventLoopMaxMs": 500,
         "postReadyHealthP95Ms": 1000
       },

--- a/tests/snapshots/report-fail-json.snap
+++ b/tests/snapshots/report-fail-json.snap
@@ -8,9 +8,9 @@
   "from": null,
   "platform": {
     "os": "darwin",
-    "release": "25.4.0",
+    "release": "<os-release>",
     "arch": "arm64",
-    "node": "v26.0.0"
+    "node": "<node>"
   },
   "decision": {
     "verdict": "FAIL",

--- a/tests/snapshots/report-pass-json.snap
+++ b/tests/snapshots/report-pass-json.snap
@@ -8,9 +8,9 @@
   "from": null,
   "platform": {
     "os": "darwin",
-    "release": "25.4.0",
+    "release": "<os-release>",
     "arch": "arm64",
-    "node": "v26.0.0"
+    "node": "<node>"
   },
   "decision": {
     "verdict": "PASS",


### PR DESCRIPTION
## What Problem This Solves

Kova `main` lost three release-validation contracts during history reconciliation: truncated `payloads[].text` recovery, calibrated process resource caps, and auth/model configuration before the first real OpenClaw service start. That made OpenClaw beta release performance fail despite successful agent turns and expected resource use.

Fixes #22.

## Why This Change Was Made

- restore the bounded truncated-payload parser used by agent-turn evaluation
- restore the reviewed release resource thresholds and lock them with a self-check
- apply live auth and an explicit `--model` selection before the first service start
- preserve the Codex provider when OpenAI auth uses the external Codex CLI
- normalize host OS and Node versions in snapshots

The explicit model option replaces OpenClaw workflow-time source rewriting and lets callers request GPT 5.6 through Kova public CLI.

## User Impact

OpenClaw release performance can distinguish product regressions from harness regressions again. Live runs select the intended model before startup, and successful truncated agent responses no longer become false failures.

## Evidence

- `npm run check` (208/208)
- `npm run test:snapshots` (21/21)
- `npm run check:web-payload` (1/1)
- `node --check` on changed modules
- `git diff --check`
- fresh Codex autoreview: no accepted/actionable findings
- signed commit `2f48202248a37aad357bd70a6953475cd4816f81`