### PR TITLE
perf: reduce Kova validation time

### DIFF
--- a/src/commands/matrix-run.mjs
+++ b/src/commands/matrix-run.mjs
@@ -56,7 +56,7 @@ export async function runMatrixRun(flags) {
   const reportRoot = flags.report_dir ? resolveFromCwd(flags.report_dir) : reportsDir;
   const { runId, outputPaths, lockPath } = await allocateReportOutputPaths(reportRoot, profile.id);
   try {
-  const targetSetup = { completed: false, failed: false, results: [] };
+  const targetSetup = { completed: false, failed: false, results: [], inFlight: null };
   const progress = createRunProgress({ flags, mode: flags.execute === true ? "execution" : "dry-run" });
   progress.runStart({
     scenarioCount: entries.length * (controls.repeat ?? 1),

--- a/src/matrix/controls.mjs
+++ b/src/matrix/controls.mjs
@@ -1,11 +1,11 @@
 import { resolveBaselinePath } from "../performance/baselines.mjs";
 import { parseFilterList } from "./expand.mjs";
 
-export function matrixControlSummary(flags, targetPlan) {
+export function matrixControlSummary(flags) {
   const requestedParallel = positiveIntegerFlag(flags, "parallel", 1);
   const repeat = positiveIntegerFlag(flags, "repeat", 1);
   const failFast = flags.fail_fast === true;
-  const parallel = failFast || targetPlan.kind === "local-build" ? 1 : requestedParallel;
+  const parallel = failFast ? 1 : requestedParallel;
   return {
     include: parseFilterList(flags.include),
     exclude: parseFilterList(flags.exclude),

--- a/src/matrix/plan-resolution.mjs
+++ b/src/matrix/plan-resolution.mjs
@@ -42,7 +42,7 @@ export async function resolveMatrixPlan(flags, options = {}) {
     platform,
     entries,
     resolvedCoverage,
-    controls: matrixControlSummary(flags, targetPlan)
+    controls: matrixControlSummary(flags)
   };
 }
 

--- a/src/run/context.mjs
+++ b/src/run/context.mjs
@@ -13,7 +13,7 @@ export function buildRunContext({
   timeoutMs,
   profile = null,
   controls = null,
-  targetSetup = { completed: false, failed: false, results: [] }
+  targetSetup = { completed: false, failed: false, results: [], inFlight: null }
 }) {
   const networkFrontage = controls?.networkFrontage ?? flags.networkFrontage ?? flags.network_frontage_controls ?? null;
   return {

--- a/src/run/target-setup.mjs
+++ b/src/run/target-setup.mjs
@@ -9,19 +9,47 @@ export async function executeTargetSetup(context, envName, artifactDir) {
   if (!phase) {
     return [];
   }
-  if (context.targetSetup?.completed) {
+  const targetSetup = context.targetSetup;
+  if (targetSetup?.completed) {
     return [];
   }
-  if (context.targetSetup?.failed) {
-    return context.targetSetup.results.map((result) => ({
-      ...result,
-      cached: true,
-      durationMs: 0,
-      originalDurationMs: result.durationMs
-    }));
+  if (targetSetup?.failed) {
+    return cachedFailureResults(targetSetup.results);
+  }
+  if (targetSetup?.inFlight) {
+    const results = await targetSetup.inFlight;
+    return results.every((result) => result.status === 0)
+      ? []
+      : cachedFailureResults(results);
   }
 
-  const results = [
+  const setupPromise = runTargetSetup(phase, context, envName, artifactDir);
+  if (targetSetup) {
+    // Local-build matrices share one runtime. Parallel scenarios wait on the
+    // same build so OCM never races multiple npm pack/install operations.
+    targetSetup.inFlight = setupPromise;
+  }
+
+  try {
+    const results = await setupPromise;
+    if (targetSetup) {
+      targetSetup.results = results;
+      if (results.every((result) => result.status === 0)) {
+        targetSetup.completed = true;
+      } else {
+        targetSetup.failed = true;
+      }
+    }
+    return results;
+  } finally {
+    if (targetSetup) {
+      targetSetup.inFlight = null;
+    }
+  }
+}
+
+async function runTargetSetup(phase, context, envName, artifactDir) {
+  return [
     tagCommandResult(await runCommand(phase.commands[0], {
       timeoutMs: context.timeoutMs,
       env: { KOVA_ENV_NAME: envName },
@@ -33,13 +61,13 @@ export async function executeTargetSetup(context, envName, artifactDir) {
       }
     }), phase)
   ];
-  if (results.every((result) => result.status === 0) && context.targetSetup) {
-    context.targetSetup.completed = true;
-  } else if (context.targetSetup) {
-    // A local-build runtime is shared by the whole matrix. Retrying the same
-    // failed build per scenario only burns time and cannot change the outcome.
-    context.targetSetup.failed = true;
-    context.targetSetup.results = results;
-  }
-  return results;
+}
+
+function cachedFailureResults(results) {
+  return results.map((result) => ({
+    ...result,
+    cached: true,
+    durationMs: 0,
+    originalDurationMs: result.durationMs
+  }));
 }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -155,10 +155,7 @@ export async function runSelfCheck(flags = {}) {
   process.env.KOVA_HOME = join(tmp, "kova-home");
 
   try {
-    checks.push(await commandCheck(
-      "syntax",
-      "for f in bin/kova.mjs $(find src -name '*.mjs' -type f | sort); do node --check \"$f\" || exit 1; done"
-    ));
+    checks.push(await syntaxCheck());
     checks.push(await jsonCommandCheck("version-json", "node bin/kova.mjs version --json", (data) => {
       assertEqual(data.schemaVersion, "kova.version.v1", "version schema");
       assertString(data.version, "version");
@@ -14113,6 +14110,52 @@ async function commandCheck(id, command) {
     durationMs: result.durationMs,
     message: result.status === 0 ? "" : result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`
   };
+}
+
+async function syntaxCheck() {
+  const files = ["bin/kova.mjs", ...(await listModuleFiles("src"))];
+  const workerCount = Math.min(8, files.length);
+  const failures = [];
+  const startedAt = Date.now();
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < files.length) {
+      const file = files[nextIndex];
+      nextIndex += 1;
+      const result = await runCommand(`node --check ${quoteShell(file)}`, { timeoutMs: 30000 });
+      if (result.status !== 0) {
+        failures.push({
+          file,
+          message: result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`
+        });
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  failures.sort((left, right) => left.file.localeCompare(right.file));
+  return {
+    id: "syntax",
+    status: failures.length === 0 ? "PASS" : "FAIL",
+    command: `node --check (${files.length} files, ${workerCount} workers)`,
+    durationMs: Date.now() - startedAt,
+    message: failures.map((failure) => `${failure.file}: ${failure.message}`).join("\n")
+  };
+}
+
+async function listModuleFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listModuleFiles(path));
+    } else if (entry.isFile() && entry.name.endsWith(".mjs")) {
+      files.push(path);
+    }
+  }
+  return files;
 }
 
 async function credentialStoreSelfCheck(tmp) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -856,6 +856,7 @@ export async function runSelfCheck(flags = {}) {
     ));
     checks.push(await localBuildRuntimeCleanupCheck(tmp));
     checks.push(await localBuildRuntimeAlreadyAbsentCleanupCheck(tmp));
+    checks.push(await localBuildParallelSingleFlightCheck(tmp));
     checks.push(defaultGatewayResourceRoleCheck());
     checks.push(gatewayProcessResourceRoleCheck());
     checks.push(compareRepeatAggregationCheck());
@@ -4186,6 +4187,103 @@ exit 2
   } catch (error) {
     return {
       id: "local-build-runtime-already-absent-cleanup",
+      status: "FAIL",
+      command,
+      durationMs: result.durationMs,
+      message: error.message
+    };
+  }
+}
+
+async function localBuildParallelSingleFlightCheck(tmp) {
+  const binDir = join(tmp, "mock-bin-parallel-local-build");
+  const repoDir = join(tmp, "mock-openclaw parallel local build");
+  const reportDir = join(tmp, "local-build-parallel-report");
+  const ocmLog = join(tmp, "mock-ocm-parallel.log");
+  const buildActive = join(tmp, "mock-ocm-build-active");
+  const buildOverlap = join(tmp, "mock-ocm-build-overlap");
+  await mkdir(binDir, { recursive: true });
+  await mkdir(repoDir, { recursive: true });
+  const ocmPath = join(binDir, "ocm");
+  await writeFile(ocmPath, `#!/bin/sh
+printf '%s\\n' "$*" >> "$KOVA_MOCK_OCM_LOG"
+case "$1:$2" in
+  runtime:build-local)
+    if [ -f "$KOVA_MOCK_BUILD_ACTIVE" ]; then
+      : > "$KOVA_MOCK_BUILD_OVERLAP"
+    fi
+    : > "$KOVA_MOCK_BUILD_ACTIVE"
+    sleep 1
+    rm -f "$KOVA_MOCK_BUILD_ACTIVE"
+    echo '{"ok":true}'
+    exit 0
+    ;;
+  runtime:remove) echo '{"removed":true}'; exit 0 ;;
+  service:status) echo '{"running":false,"desiredRunning":false,"childPid":null,"gatewayPort":null,"gatewayState":"stopped","runDir":"/tmp/kova-mock"}'; exit 0 ;;
+  service:install|service:start|service:restart|service:stop) echo '{"ok":true}'; exit 0 ;;
+  env:exec) exit 0 ;;
+  env:destroy) echo '{"destroyed":true}'; exit 0 ;;
+esac
+case "$1" in
+  start) echo '{"ok":true}'; exit 0 ;;
+  logs) exit 0 ;;
+  @*) echo 'ok'; exit 0 ;;
+  --version) echo 'mock-ocm'; exit 0 ;;
+esac
+echo "unhandled mock ocm command: $*" >&2
+exit 2
+`, "utf8");
+  await chmod(ocmPath, 0o755);
+
+  const command = `node bin/kova.mjs matrix run --profile smoke --target local-build:${quoteShell(repoDir)} --include scenario:fresh-install,scenario:bundled-runtime-deps,scenario:bundled-plugin-startup --parallel 3 --auth skip --execute --report-dir ${quoteShell(reportDir)} --json`;
+  const result = await runCommand(command, {
+    shell: "/bin/sh",
+    timeoutMs: 30000,
+    maxOutputChars: 1000000,
+    env: {
+      PATH: `${binDir}:${process.env.PATH}`,
+      KOVA_MOCK_OCM_LOG: ocmLog,
+      KOVA_MOCK_BUILD_ACTIVE: buildActive,
+      KOVA_MOCK_BUILD_OVERLAP: buildOverlap
+    }
+  });
+
+  try {
+    if (result.status !== 0) {
+      throw new Error(result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`);
+    }
+    const receipt = JSON.parse(result.stdout);
+    const report = JSON.parse(await readFile(receipt.jsonPath, "utf8"));
+    const log = await readFile(ocmLog, "utf8");
+    assertEqual(report.controls?.requestedParallel, 3, "local-build requested parallelism");
+    assertEqual(report.controls?.parallel, 3, "local-build effective parallelism");
+    assertEqual(report.controls?.parallelAdjusted, false, "local-build parallelism is not adjusted");
+    assertEqual(
+      log.split("\n").filter((line) => line.startsWith("runtime build-local ")).length,
+      1,
+      "parallel local-build target setup executes once per matrix"
+    );
+    assertEqual(
+      report.records?.filter((record) => record.phases?.some((phase) => phase.id === "target-setup")).length,
+      1,
+      "parallel local-build target setup is recorded once"
+    );
+    let overlapDetected = true;
+    try {
+      await stat(buildOverlap);
+    } catch {
+      overlapDetected = false;
+    }
+    assertEqual(overlapDetected, false, "parallel local-build target setup does not overlap");
+    return {
+      id: "local-build-parallel-single-flight",
+      status: "PASS",
+      command,
+      durationMs: result.durationMs
+    };
+  } catch (error) {
+    return {
+      id: "local-build-parallel-single-flight",
       status: "FAIL",
       command,
       durationMs: result.durationMs,


### PR DESCRIPTION
## What Problem This Solves

Kova serializes every local-build matrix even though each scenario owns a distinct OCM environment, and its self-check starts 155 Node processes one at a time for syntax validation. Both add avoidable wall time.

## Why This Change Was Made

- make the shared local runtime build single-flight so functional local-build matrices can honor `--parallel` without racing OCM package installation
- keep performance lanes free to request `--parallel 1` when concurrent resource use would contaminate measurements
- run the unchanged `node --check` coverage with eight bounded workers and deterministic failure ordering

## User Impact

Functional Kova matrices can finish multiple isolated scenarios concurrently after one shared build. Syntax validation for 155 modules dropped from 24.97s to 2.62s in the measured self-check run.

## Evidence

- `npm run check` - 216/216 passed
- `npm run test:snapshots` - 21/21 passed
- final autoreview - clean, no accepted/actionable findings
- syntax phase: 24,970ms before; 2,616ms after