### PR TITLE
perf: reduce sampler and timeline overhead

### DIFF
--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -8,13 +8,17 @@ export const RESOURCE_SAMPLES_SCHEMA = "kova.resourceSamples.v1";
 export const PROCESS_SNAPSHOT_SCHEMA = "kova.processSnapshot.v1";
 export const PROCESS_LEAKS_SCHEMA = "kova.processLeakSummary.v1";
 
+// Gateway PIDs remain stable across most phase commands. Reuse live PIDs so
+// resource sampling does not perturb the workload with repeated OCM launches.
+const gatewayPidsByEnv = new Map();
+
 export function startResourceSampler(rootPid, options = {}) {
   const startedAt = Date.now();
   const intervalMs = Math.max(250, Number(options.intervalMs ?? 1000));
   const roleMatchers = compileRoleMatchers(options.processRoles ?? []);
   const samples = [];
   let gatewayPid = null;
-  let gatewayRefreshSample = 0;
+  let nextGatewayLookupSample = 0;
 
   sample();
   const timer = setInterval(sample, intervalMs);
@@ -40,9 +44,16 @@ export function startResourceSampler(rootPid, options = {}) {
 
   function sample() {
     const allProcesses = listProcesses(options.redactValues ?? []);
-    if (options.envName && (gatewayPid === null || samples.length >= gatewayRefreshSample)) {
-      gatewayPid = resolveGatewayPid(options.envName);
-      gatewayRefreshSample = samples.length + 5;
+    if (options.envName) {
+      const knownGatewayPid = gatewayPid ?? gatewayPidsByEnv.get(options.envName) ?? null;
+      gatewayPid = liveGatewayPid(options.envName, gatewayPid, allProcesses);
+      if (knownGatewayPid !== null && gatewayPid === null) {
+        nextGatewayLookupSample = samples.length;
+      }
+      if (gatewayPid === null && samples.length >= nextGatewayLookupSample) {
+        gatewayPid = lookupGatewayPid(options.envName);
+        nextGatewayLookupSample = samples.length + 5;
+      }
     }
 
     const treePids = collectProcessTreePids(allProcesses, rootPid);
@@ -226,8 +237,10 @@ function roleRss(processes, role) {
 export function captureProcessSnapshot(options = {}) {
   const roleMatchers = compileRoleMatchers(options.processRoles ?? []);
   const envName = options.envName ?? null;
-  const gatewayPid = envName ? resolveGatewayPid(envName) : null;
   const allProcesses = listProcesses();
+  const gatewayPid = envName
+    ? liveGatewayPid(envName, null, allProcesses) ?? lookupGatewayPid(envName)
+    : null;
   const gatewayTreePids = gatewayPid === null ? new Set() : collectProcessTreePids(allProcesses, gatewayPid);
   const scopeTokens = snapshotScopeTokens(options);
   const included = [];
@@ -468,7 +481,19 @@ function collectProcessTreePids(processes, rootPid) {
   return pids;
 }
 
-function resolveGatewayPid(envName) {
+function liveGatewayPid(envName, currentPid, processes) {
+  const candidate = currentPid ?? gatewayPidsByEnv.get(envName) ?? null;
+  if (candidate === null) {
+    return null;
+  }
+  if (processes.some((process) => process.pid === candidate)) {
+    return candidate;
+  }
+  gatewayPidsByEnv.delete(envName);
+  return null;
+}
+
+function lookupGatewayPid(envName) {
   const result = spawnSync(process.env.SHELL || "/bin/sh", ["-lc", ocmServiceStatusJson(envName)], {
     cwd: repoRoot,
     encoding: "utf8",
@@ -480,7 +505,13 @@ function resolveGatewayPid(envName) {
   }
   try {
     const parsed = JSON.parse(result.stdout);
-    return typeof parsed.childPid === "number" ? parsed.childPid : null;
+    const childPid = typeof parsed.childPid === "number" ? parsed.childPid : null;
+    if (childPid === null) {
+      gatewayPidsByEnv.delete(envName);
+    } else {
+      gatewayPidsByEnv.set(envName, childPid);
+    }
+    return childPid;
   } catch {
     return null;
   }

--- a/src/collectors/timeline.mjs
+++ b/src/collectors/timeline.mjs
@@ -46,9 +46,6 @@ export async function collectTimelineMetrics(artifactDir) {
     commandStatus: 0,
     statusLabel: timeline.available ? "PASS" : "INFO",
     durationMs: Date.now() - startedAt,
-    timeline: {
-      ...timeline
-    },
     available: timeline.available,
     eventCount: timeline.eventCount,
     parseErrorCount: timeline.parseErrorCount,

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -3781,16 +3781,31 @@ function compactSampleProcess(process) {
   };
 }
 
-function collectTimelineSummary(record) {
-  const timelines = [];
-  for (const phase of record.phases ?? []) {
-    if (phase.metrics?.timeline) {
-      timelines.push(phase.metrics.timeline);
+export function compactEvaluatedTimelineEvidence(record) {
+  const timelines = recordTimelines(record);
+  const currentTimeline = timelines.findLast((timeline) => timeline.available) ?? null;
+  let attributionTimeline = null;
+  let attributionEventCount = -1;
+  for (const timeline of timelines) {
+    const eventCount = timeline.eventCount ?? timeline.events?.length ?? 0;
+    if (eventCount >= attributionEventCount && Array.isArray(timeline.events)) {
+      attributionTimeline = timeline;
+      attributionEventCount = eventCount;
     }
   }
-  if (record.finalMetrics?.timeline) {
-    timelines.push(record.finalMetrics.timeline);
+
+  const retained = new Set([currentTimeline, attributionTimeline].filter(Boolean));
+  for (const timeline of timelines) {
+    if (retained.has(timeline)) {
+      continue;
+    }
+    delete timeline.events;
+    delete timeline.turnAttributionEvents;
   }
+}
+
+function collectTimelineSummary(record) {
+  const timelines = recordTimelines(record);
 
   const available = timelines.some((timeline) => timeline.available);
   // A rotated final timeline owns terminal span state; the most complete
@@ -3883,6 +3898,19 @@ function collectTimelineSummary(record) {
   };
 }
 
+function recordTimelines(record) {
+  const timelines = [];
+  for (const phase of record.phases ?? []) {
+    if (phase.metrics?.timeline) {
+      timelines.push(phase.metrics.timeline);
+    }
+  }
+  if (record.finalMetrics?.timeline) {
+    timelines.push(record.finalMetrics.timeline);
+  }
+  return timelines;
+}
+
 function mergeSpanTotals(target, source) {
   for (const [name, summary] of Object.entries(source)) {
     const existing = target[name] ?? {
@@ -3894,10 +3922,10 @@ function mergeSpanTotals(target, source) {
       maxDurationMs: null,
       slowest: null
     };
-    existing.count += summary.count ?? 0;
-    existing.errorCount += summary.errorCount ?? 0;
-    existing.openCount += summary.openCount ?? 0;
-    existing.totalDurationMs = roundNumber(existing.totalDurationMs + (summary.totalDurationMs ?? 0));
+    existing.count = Math.max(existing.count, summary.count ?? 0);
+    existing.errorCount = Math.max(existing.errorCount, summary.errorCount ?? 0);
+    existing.openCount = Math.max(existing.openCount, summary.openCount ?? 0);
+    existing.totalDurationMs = Math.max(existing.totalDurationMs, summary.totalDurationMs ?? 0);
     existing.maxDurationMs = maxNullable(existing.maxDurationMs, summary.maxDurationMs);
     if (summary.slowest?.durationMs !== undefined &&
       (!existing.slowest || summary.slowest.durationMs > existing.slowest.durationMs)) {
@@ -3919,9 +3947,9 @@ function mergeKeySpans(target, source, { current = false } = {}) {
       slowest: null,
       open: []
     };
-    existing.count += summary.count ?? 0;
-    existing.errorCount += summary.errorCount ?? 0;
-    existing.totalDurationMs = roundNumber(existing.totalDurationMs + (summary.totalDurationMs ?? 0));
+    existing.count = Math.max(existing.count, summary.count ?? 0);
+    existing.errorCount = Math.max(existing.errorCount, summary.errorCount ?? 0);
+    existing.totalDurationMs = Math.max(existing.totalDurationMs, summary.totalDurationMs ?? 0);
     existing.maxDurationMs = maxNullable(existing.maxDurationMs, summary.maxDurationMs);
     if (summary.slowest?.durationMs !== undefined &&
       (!existing.slowest || summary.slowest.durationMs > existing.slowest.durationMs)) {

--- a/src/run/finalize-record.mjs
+++ b/src/run/finalize-record.mjs
@@ -4,7 +4,7 @@ import {
   attachCleanupEvidence,
   attachEvidenceArtifactBudget
 } from "../evidence/record.mjs";
-import { evaluateRecord } from "../evaluator.mjs";
+import { compactEvaluatedTimelineEvidence, evaluateRecord } from "../evaluator.mjs";
 import { collectEnvMetrics, collectNodeProfileMetrics } from "../metrics.mjs";
 import { collectProviderEvidence } from "../collectors/provider.mjs";
 import { collectStateFixtureAccounting } from "../collectors/state-fixtures.mjs";
@@ -45,6 +45,7 @@ export async function attachPostCleanupEvidence(record, scenario, context, artif
   await attachEvidenceArtifactBudget(record, scenario);
   attachEvidenceLedger(record);
   applyEvidenceLedgerGating(record);
+  compactEvaluatedTimelineEvidence(record);
 }
 
 function shouldCaptureFailureDiagnostics(record, context) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -12,7 +12,7 @@ import { appendChannelCapabilityEvidence, channelCapabilityEvidenceFromResult } 
 import { summarizeCpuProfiles } from "./collectors/node-profiles.mjs";
 import { summarizeHeapProfiles } from "./collectors/heap.mjs";
 import { collectEnvMetrics } from "./metrics.mjs";
-import { evaluateRecord } from "./evaluator.mjs";
+import { compactEvaluatedTimelineEvidence, evaluateRecord } from "./evaluator.mjs";
 import { evaluateWorkflowCase } from "../support/channel-conformance/evaluator.mjs";
 import { assertValidObservationSet } from "../support/channel-conformance/observation-schema.mjs";
 import { planWorkflowCases } from "../support/channel-conformance/planner.mjs";
@@ -10620,6 +10620,34 @@ function diagnosticsTimelineEvaluationCheck() {
     assertEqual(closedSpanRecord.measurements.openclawTimelineEventCount, 3, "historical event-count maximum");
     assertEqual(closedSpanRecord.measurements.openclawEventLoopMaxMs, 500, "historical event-loop maximum");
     assertEqual(closedSpanRecord.measurements.openclawSlowestSpanMs, 6000, "historical slowest span");
+
+    const cumulativeTimelineRecord = {
+      scenario: "diagnostic-cumulative-timeline",
+      status: "PASS",
+      phases: [{
+        id: "gateway-start",
+        metrics: {
+          timeline: parseTimelineText(runtimeDepsStart)
+        }
+      }],
+      finalMetrics: {
+        service: { gatewayState: "running" },
+        logs: zeroLogMetrics(),
+        timeline: closedRuntimeDepsTimeline
+      }
+    };
+    evaluateRecord(cumulativeTimelineRecord, { thresholds: {} }, runtimeDepsTimelineOptions);
+    compactEvaluatedTimelineEvidence(cumulativeTimelineRecord);
+    assertEqual(
+      cumulativeTimelineRecord.phases[0].metrics.timeline.events,
+      undefined,
+      "redundant cumulative timeline events compacted"
+    );
+    assertEqual(
+      cumulativeTimelineRecord.finalMetrics.timeline.events.length,
+      2,
+      "latest cumulative timeline events retained"
+    );
 
     const openSpanRecord = {
       scenario: "diagnostic-open-span",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -85,7 +85,7 @@ import {
   parseProviderRequestLog,
   parseTimelineProviderRequestLog
 } from "./collectors/provider.mjs";
-import { captureProcessSnapshot, classifyRegistryRolesForProcess, classifySnapshotRolesForProcess, diffProcessSnapshots, summarizeResourceSamples } from "./collectors/resources.mjs";
+import { captureProcessSnapshot, classifyRegistryRolesForProcess, classifySnapshotRolesForProcess, diffProcessSnapshots, startResourceSampler, summarizeResourceSamples } from "./collectors/resources.mjs";
 import { captureOpenClawStateSnapshot } from "./collectors/openclaw-state.mjs";
 import { buildReportSummary, renderMarkdownReport, renderPasteSummary, renderReportSummary, summarizeRecords } from "./reporting/report.mjs";
 import { buildRepeatedWorkAudit } from "./audits/repeated-work.mjs";
@@ -747,6 +747,7 @@ export async function runSelfCheck(flags = {}) {
     checks.push(resourceConfiguredRoleMissingCheck());
     checks.push(await resourceRootCommandRoleBoundaryCheck());
     checks.push(await resourceRolePollutionCheck());
+    checks.push(await resourceGatewayPidLookupCheck(tmp));
     checks.push(await startupSurfaceDiagnosticsContractCheck());
     checks.push(await gatewaySessionSurfaceContractCheck());
     checks.push(await bundledPluginStartupSurfaceContractCheck());
@@ -12482,6 +12483,90 @@ async function agentGatewayRpcTurnSurfaceContractCheck() {
       durationMs: 0,
       message: error.message
     };
+  }
+}
+
+async function resourceGatewayPidLookupCheck(tmp) {
+  const binDir = join(tmp, "resource-gateway-pid-bin");
+  const lookupLog = join(tmp, "resource-gateway-pid-lookups.log");
+  const fakeOcm = join(binDir, "ocm");
+  const fakeShell = join(binDir, "shell");
+  await mkdir(binDir, { recursive: true });
+  await writeFile(fakeOcm, `#!/bin/sh
+printf '%s\\n' "$*" >> "$KOVA_MOCK_OCM_LOG"
+if [ "$3" = "kova-resource-running" ]; then
+  printf '{"childPid":%s}\\n' "$KOVA_MOCK_GATEWAY_PID"
+else
+  printf '{"childPid":null}\\n'
+fi
+`, "utf8");
+  await writeFile(fakeShell, `#!/bin/sh
+exec /bin/sh -c "$2"
+`, "utf8");
+  await chmod(fakeOcm, 0o755);
+  await chmod(fakeShell, 0o755);
+
+  const previousPath = process.env.PATH;
+  const previousLog = process.env.KOVA_MOCK_OCM_LOG;
+  const previousPid = process.env.KOVA_MOCK_GATEWAY_PID;
+  const previousShell = process.env.SHELL;
+  process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+  process.env.KOVA_MOCK_OCM_LOG = lookupLog;
+  process.env.KOVA_MOCK_GATEWAY_PID = String(process.pid);
+  process.env.SHELL = fakeShell;
+
+  try {
+    const first = startResourceSampler(process.pid, {
+      envName: "kova-resource-running",
+      intervalMs: 250
+    });
+    await first.stop();
+    const second = startResourceSampler(process.pid, {
+      envName: "kova-resource-running",
+      intervalMs: 250
+    });
+    await second.stop();
+
+    const missing = startResourceSampler(process.pid, {
+      envName: "kova-resource-missing",
+      intervalMs: 250
+    });
+    await sleep(600);
+    const missingSummary = await missing.stop();
+
+    const lookups = (await readFile(lookupLog, "utf8")).trim().split("\n").filter(Boolean);
+    assertEqual(
+      lookups.filter((line) => line.includes("kova-resource-running")).length,
+      1,
+      "live gateway pid reused across samplers"
+    );
+    assertEqual(
+      lookups.filter((line) => line.includes("kova-resource-missing")).length,
+      1,
+      "missing gateway pid lookup backs off"
+    );
+    assertEqual(missingSummary.sampleCount >= 3, true, "missing gateway sampler collected repeated samples");
+    return {
+      id: "resource-gateway-pid-lookups",
+      status: "PASS",
+      command: "reuse live gateway pid and back off missing pid lookups",
+      durationMs: 600
+    };
+  } catch (error) {
+    return {
+      id: "resource-gateway-pid-lookups",
+      status: "FAIL",
+      command: "reuse live gateway pid and back off missing pid lookups",
+      durationMs: 600,
+      message: error.message
+    };
+  } finally {
+    restoreEnv({
+      PATH: previousPath,
+      KOVA_MOCK_OCM_LOG: previousLog,
+      KOVA_MOCK_GATEWAY_PID: previousPid,
+      SHELL: previousShell
+    });
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Kova's resource sampler repeatedly shells out to `ocm service status` while a run is active, including once per sample when no gateway PID is available. Its report collector also serializes cumulative timeline evidence into multiple phase snapshots, making release reports much larger than the unique evidence they contain.

## Why This Change Was Made

- Cache live gateway PID lookups for the process lifetime and refresh immediately when the PID exits.
- Retry missing gateway PID discovery every five samples instead of every sample.
- Reuse the same cache for process snapshots.
- Keep the current and most-complete attribution timelines while removing duplicate raw event arrays from redundant snapshots.
- Merge cumulative span counts by maximum observed value instead of summing repeated snapshots.

## User Impact

Performance runs perform fewer hidden control-plane commands and produce substantially smaller reports without dropping derived metrics, attribution evidence, or required release proofs.

## Evidence

- `npm run check`: 219 tests passed.
- Kova CI: Ubuntu and macOS passed.
- Fresh branch autoreview: no actionable findings, correctness confidence 0.84.
- OpenClaw release proof: https://github.com/openclaw/openclaw/actions/runs/29171181864
  - Tested OpenClaw ref `release/2026.7.1`, SHA `058484a52e560e7a2fe43a11572f63f07cd14f29`.
  - Tested Kova SHA `775bfd01a8d1bf9ca0657c84f3c9903ef4400fd9`.
  - 18/18 release records passed; 241/241 required proofs were present.
  - Full JSON report: 43,150,522 -> 15,263,543 bytes, 64.63% smaller.
  - Actions artifact: 6,926,810 -> 3,795,675 bytes, 45.20% smaller.
  - Repeated embedded timeline events: 28,056 -> 3,084, 89.01% fewer.
