### PR TITLE
docs(changelog): establish release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to Kova are documented in this file.
+
+## [Unreleased]


### PR DESCRIPTION
## What Problem This Solves

Kova has no durable changelog, which makes parallel fixes and release preparation harder to review.

## Why This Change Was Made

Adds the minimal shared changelog structure before the audit fix branches land.

## User Impact

Future releases will have one canonical place for scoped release notes.

## Evidence

- `git diff --check`