### PR TITLE
fix(audit): harden baseline persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 All notable changes to Kova are documented in this file.
 
 ## [Unreleased]
+
+### Fixed
+
+- Hardened performance baseline persistence, unstable-group detection, and repeated-work audit isolation.

--- a/src/audits/repeated-work.mjs
+++ b/src/audits/repeated-work.mjs
@@ -2,8 +2,6 @@ import { loadRegistryContext } from "../registries/context.mjs";
 
 export const REPEATED_WORK_AUDIT_SCHEMA = "kova.repeatedWorkAudit.v1";
 
-const commandReceiptLocks = [];
-
 export async function buildRepeatedWorkAudit(options = {}) {
   const registry = options.registry ?? await loadRegistryContext();
   const phaseUses = collectPhaseUses(registry.scenarios);
@@ -19,7 +17,7 @@ export async function buildRepeatedWorkAudit(options = {}) {
     duplicatePhaseIds: duplicatePhaseIdAudit(phaseUses),
     healthScopes: countHealthScopes(phaseUses),
     explicitEvidenceCommands: explicitEvidenceCommandAudit(phaseUses),
-    commandReceiptLocks
+    commandReceiptLocks: []
   };
 }
 

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -1,5 +1,6 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { lstat, mkdir, open, readFile, readlink, rename, rm, stat } from "node:fs/promises";
+import { dirname, join, posix, resolve, win32 } from "node:path";
 import { baselinesDir } from "../paths.mjs";
 import {
   DEFAULT_REGRESSION_THRESHOLDS,
@@ -29,7 +30,8 @@ export function resolveBaselinePath(value) {
   if (value === true || value === "default") {
     return defaultBaselinePath();
   }
-  return String(value).startsWith("/") ? String(value) : join(process.cwd(), String(value));
+  const path = String(value);
+  return posix.isAbsolute(path) || win32.isAbsolute(path) ? path : join(process.cwd(), path);
 }
 
 export async function loadBaselineStore(path) {
@@ -59,20 +61,81 @@ export async function saveBaselineStore(path, store) {
   if (!path) {
     return null;
   }
-  await mkdir(dirname(path), { recursive: true });
+  const writePath = await resolveBaselineWritePath(path);
+  const directory = dirname(writePath);
+  await mkdir(directory, { recursive: true });
   const output = {
     schemaVersion: BASELINE_SCHEMA,
     createdAt: store.createdAt ?? new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     entries: store.entries ?? {}
   };
-  await writeFile(path, `${JSON.stringify(output, null, 2)}\n`, "utf8");
+  const payload = `${JSON.stringify(output, null, 2)}\n`;
+  const existingMetadata = await stat(writePath).catch((error) => {
+    if (error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+  if (existingMetadata) {
+    // Existing stores keep their inode so ACLs, hard links, and platform security
+    // descriptors survive, including in directories where only the file is writable.
+    const destination = await open(writePath, "w");
+    try {
+      await destination.writeFile(payload, "utf8");
+      await destination.sync();
+    } finally {
+      await destination.close();
+    }
+    return baselineSaveReceipt(path, output);
+  }
+
+  const tempPath = join(directory, `.kova-baseline-${randomUUID()}.tmp`);
+  let tempFile = null;
+  try {
+    tempFile = await open(tempPath, "wx", 0o600);
+    await tempFile.writeFile(payload, "utf8");
+    await tempFile.sync();
+    await tempFile.close();
+    tempFile = null;
+    await rename(tempPath, writePath);
+  } finally {
+    await tempFile?.close().catch(() => {});
+    await rm(tempPath, { force: true });
+  }
+  return baselineSaveReceipt(path, output);
+}
+
+function baselineSaveReceipt(path, output) {
   return {
     schemaVersion: "kova.baselineSave.v1",
     path,
     entryCount: Object.keys(output.entries).length,
     updatedAt: output.updatedAt
   };
+}
+
+async function resolveBaselineWritePath(path) {
+  let current = path;
+  const visited = new Set();
+  while (true) {
+    if (visited.has(current)) {
+      throw Object.assign(new Error(`baseline symlink cycle: ${path}`), { code: "ELOOP" });
+    }
+    visited.add(current);
+    try {
+      const entry = await lstat(current);
+      if (!entry.isSymbolicLink()) {
+        return current;
+      }
+      current = resolve(dirname(current), await readlink(current));
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        return current;
+      }
+      throw error;
+    }
+  }
 }
 
 export function updateBaselineStore(store, report, options = {}) {
@@ -192,17 +255,17 @@ export function reviewBaselineUpdate(report, options = {}) {
   }
 
   const unstableGroups = groups.filter(hasUnstableMetric);
-  if ((performance?.unstableGroupCount ?? unstableGroups.length) > 0) {
+  if (unstableGroups.length > 0) {
     blockers.push({
       kind: "unstable-performance",
-      count: performance?.unstableGroupCount ?? unstableGroups.length,
+      count: unstableGroups.length,
       examples: unstableGroups.slice(0, 5).map((group) => ({
         scenario: group.scenario ?? null,
         surface: group.surface ?? null,
         state: group.state ?? null,
         unstableMetrics: unstableMetricIds(group)
       })),
-      message: `baseline updates require stable performance samples (${performance?.unstableGroupCount ?? unstableGroups.length} unstable groups)`
+      message: `baseline updates require stable performance samples (${unstableGroups.length} unstable groups)`
     });
   }
 

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, readdir, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,6 +23,7 @@ import { declaredCapabilityProofRows } from "../support/channel-conformance/capa
 import {
   comparePerformanceToBaseline,
   loadBaselineStore,
+  resolveBaselinePath,
   reviewBaselineUpdate,
   saveBaselineStore,
   updateBaselineStore
@@ -3645,6 +3646,9 @@ async function performanceBaselineCheck(tmp) {
     baselineReport.performance = buildPerformanceSummary(baselineReport.records, { repeat: 3 });
 
     const baselinePath = join(tmp, "baselines.json");
+    assertEqual(resolveBaselinePath("/tmp/kova-baselines.json"), "/tmp/kova-baselines.json", "POSIX absolute baseline path");
+    assertEqual(resolveBaselinePath("C:\\kova\\baselines.json"), "C:\\kova\\baselines.json", "Windows drive baseline path");
+    assertEqual(resolveBaselinePath("\\\\server\\share\\baselines.json"), "\\\\server\\share\\baselines.json", "Windows UNC baseline path");
     const unreviewed = reviewBaselineUpdate(baselineReport, { reviewedGood: false });
     assertEqual(unreviewed.ok, false, "baseline update requires review");
     assertEqual(unreviewed.blockers.some((blocker) => blocker.kind === "review-required"), true, "baseline review-required blocker");
@@ -3694,6 +3698,90 @@ async function performanceBaselineCheck(tmp) {
     const storedAggregate = Object.values(loadedStore.entries)[0]?.aggregate;
     assertEqual(storedAggregate?.resourceMeasurementScope, RESOURCE_MEASUREMENT_SCOPE, "baseline stores resource scope");
     assertEqual(storedAggregate?.resourceHeadlineContract, RESOURCE_HEADLINE_CONTRACT, "baseline stores resource contract");
+    const sharedBaselinePath = join(tmp, "shared-baselines.json");
+    const linkedBaselinePath = join(tmp, "linked-baselines.json");
+    let symlinkSupported = true;
+    try {
+      await symlink("shared-baselines.json", linkedBaselinePath);
+    } catch (error) {
+      if (process.platform === "win32" && (error.code === "EPERM" || error.code === "EACCES")) {
+        symlinkSupported = false;
+      } else {
+        throw error;
+      }
+    }
+    if (symlinkSupported) {
+      await saveBaselineStore(linkedBaselinePath, savedStore);
+      assertEqual((await lstat(linkedBaselinePath)).isSymbolicLink(), true, "baseline save preserves symlink");
+      assertEqual(
+        Object.keys((await loadBaselineStore(sharedBaselinePath)).entries).length,
+        1,
+        "baseline save updates symlink target"
+      );
+      const chainedBaselinePath = join(tmp, "chained-baselines.json");
+      const missingBaselinePath = join(tmp, "missing-baselines.json");
+      await rm(sharedBaselinePath);
+      await symlink("missing-baselines.json", sharedBaselinePath);
+      await symlink("shared-baselines.json", chainedBaselinePath);
+      await saveBaselineStore(chainedBaselinePath, savedStore);
+      assertEqual((await lstat(chainedBaselinePath)).isSymbolicLink(), true, "baseline save preserves symlink chain head");
+      assertEqual((await lstat(sharedBaselinePath)).isSymbolicLink(), true, "baseline save preserves symlink chain");
+      assertEqual(
+        Object.keys((await loadBaselineStore(missingBaselinePath)).entries).length,
+        1,
+        "baseline save follows dangling symlink chain"
+      );
+    }
+    if (process.platform !== "win32") {
+      await chmod(baselinePath, 0o600);
+      await saveBaselineStore(baselinePath, savedStore);
+      assertEqual((await stat(baselinePath)).mode & 0o777, 0o600, "baseline save preserves file permissions");
+      await chmod(baselinePath, 0o200);
+      await saveBaselineStore(baselinePath, savedStore);
+      await chmod(baselinePath, 0o600);
+      assertEqual(
+        Object.keys((await loadBaselineStore(baselinePath)).entries).length,
+        1,
+        "baseline save supports write-only files"
+      );
+      const lockedDirectory = join(tmp, "locked-baseline-dir");
+      const lockedBaselinePath = join(lockedDirectory, "baselines.json");
+      await mkdir(lockedDirectory);
+      await writeFile(lockedBaselinePath, "{}\n");
+      await chmod(lockedBaselinePath, 0o600);
+      await chmod(lockedDirectory, 0o500);
+      try {
+        await saveBaselineStore(lockedBaselinePath, savedStore);
+      } finally {
+        await chmod(lockedDirectory, 0o700);
+      }
+      assertEqual(
+        Object.keys((await loadBaselineStore(lockedBaselinePath)).entries).length,
+        1,
+        "existing baseline saves without directory create permission"
+      );
+    }
+    const longBaselinePath = join(tmp, `${"b".repeat(240)}.json`);
+    await saveBaselineStore(longBaselinePath, savedStore);
+    assertEqual(
+      Object.keys((await loadBaselineStore(longBaselinePath)).entries).length,
+      1,
+      "baseline save supports long destination names"
+    );
+    const failedSavePath = join(tmp, "baseline-save-target");
+    await mkdir(failedSavePath);
+    let failedSaveRejected = false;
+    try {
+      await saveBaselineStore(failedSavePath, savedStore);
+    } catch {
+      failedSaveRejected = true;
+    }
+    assertEqual(failedSaveRejected, true, "failed baseline replacement is rejected");
+    assertEqual(
+      (await readdir(tmp)).some((entry) => entry.startsWith(".kova-baseline-") && entry.endsWith(".tmp")),
+      false,
+      "failed baseline replacement removes temporary file"
+    );
     const otherTargetComparison = comparePerformanceToBaseline(baselineReport, loadedStore, {
       targetPlan: { kind: "local-build", value: "/tmp/other-openclaw" }
     });
@@ -3711,6 +3799,17 @@ async function performanceBaselineCheck(tmp) {
     const parallelReview = reviewBaselineUpdate(parallelReport, { reviewedGood: true });
     assertEqual(parallelReview.ok, false, "parallel report rejected for baseline");
     assertEqual(parallelReview.blockers.some((blocker) => blocker.kind === "parallel-performance"), true, "parallel-performance blocker");
+
+    const staleStableCountReport = structuredClone(baselineReport);
+    staleStableCountReport.performance.unstableGroupCount = 0;
+    staleStableCountReport.performance.groups[0].metrics.readinessHealthReadyMs.classification = "unstable";
+    const staleStableCountReview = reviewBaselineUpdate(staleStableCountReport, { reviewedGood: true });
+    assertEqual(staleStableCountReview.ok, false, "derived unstable group rejects baseline despite stale count");
+    assertEqual(
+      staleStableCountReview.blockers.find((blocker) => blocker.kind === "unstable-performance")?.count,
+      1,
+      "derived unstable group count is authoritative"
+    );
 
     const currentReport = syntheticPerformanceReport({
       runId: "current",
@@ -11097,6 +11196,7 @@ export const channelMessageReceiveAckPolicies = [
 
 async function repeatedWorkAuditCheck() {
   const audit = await buildRepeatedWorkAudit();
+  const freshAudit = await buildRepeatedWorkAudit();
   assertEqual(audit.schemaVersion, "kova.repeatedWorkAudit.v1", "repeated work audit schema");
   assertEqual(audit.scenarioCount > 0, true, "repeated work audit scenarios");
   assertEqual(audit.phaseCount > 0, true, "repeated work audit phases");
@@ -11142,6 +11242,9 @@ async function repeatedWorkAuditCheck() {
     0,
     "repeated work audit command receipt locks empty"
   );
+  audit.commandReceiptLocks.push({ scenario: "mutation-probe" });
+  assertEqual(audit.commandReceiptLocks === freshAudit.commandReceiptLocks, false, "repeated work audit receipt locks are fresh");
+  assertEqual(freshAudit.commandReceiptLocks.length, 0, "repeated work audit receipt locks do not leak mutations");
   return {
     id: "repeated-work-audit",
     status: "PASS"


### PR DESCRIPTION
## What Problem This Solves

Kova baseline saves could lose audit isolation, accept stale instability summaries, mishandle cross-platform paths, or leave unsafe persistence edge cases around symlinks and existing file protections.

## Why This Change Was Made

The clawpatch sweep identified baseline and audit-integrity defects. This keeps existing baseline inodes and protections intact, atomically publishes new stores, follows symlink chains, and derives instability from report evidence.

## User Impact

Baseline updates are safer across POSIX/Windows paths, shared files, symlinks, and repeated audit calls.

## Evidence

- `npm run check` (219/219)
- `git diff --check origin/main...HEAD`
- autoreview: clean, gpt-5.6-sol/high, confidence 0.88