### PR TITLE
fix(web): preserve report presentation integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ All notable changes to Kova are documented in this file.
 ### Fixed
 
 - Hardened performance baseline persistence, unstable-group detection, and repeated-work audit isolation.
+- Fixed web reports to reset matrix deltas across missing samples, preserve scenario breach status, render blocked OG verdicts safely, revalidate mutable OG images, and normalize rounded minute durations.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
+        "@types/node": "^24.10.1",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "npm:@typescript/typescript6@^6.0.2"
       }
@@ -1930,6 +1931,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/unist": {
@@ -5492,6 +5503,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "check": "astro check"
+    "check": "astro check",
+    "test": "node --experimental-strip-types --test tests/*.test.ts"
   },
   "dependencies": {
     "@resvg/resvg-js": "^2.6.2",
@@ -15,6 +16,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@types/node": "^24.10.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2"
   }

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,0 +1,2 @@
+/og/*
+  Cache-Control: public, max-age=0, must-revalidate

--- a/web/src/lib/http.ts
+++ b/web/src/lib/http.ts
@@ -1,0 +1,5 @@
+/**
+ * OG images can change when release data or card rendering is corrected.
+ * Require caches to revalidate the stable URL instead of pinning stale bytes.
+ */
+export const MUTABLE_IMAGE_CACHE_CONTROL = "public, max-age=0, must-revalidate";

--- a/web/src/lib/matrix-core.ts
+++ b/web/src/lib/matrix-core.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure matrix calculations kept separate from Astro content loading so the
+ * continuity and status contracts can be tested directly.
+ */
+
+type ScenarioState = "pass" | "fail" | "block";
+
+interface HeadlineSource {
+  headline?: Array<{
+    metric?: string;
+    scenarioId?: string;
+    value: number;
+  }>;
+  scenarios?: Array<{
+    id: string;
+    state: ScenarioState;
+  }>;
+}
+
+export function pctDelta(curr: number | null, prev: number | null): number | null {
+  if (curr == null || prev == null || prev === 0) return null;
+  return ((curr - prev) / prev) * 100;
+}
+
+/**
+ * Compare each value only with the immediately preceding chronological slot.
+ * Missing releases and blocked/null samples break the comparison chain.
+ */
+export function chronologicalDeltas(values: Array<number | null>): Array<number | null> {
+  return values.map((value, index) =>
+    pctDelta(value, index === 0 ? null : values[index - 1] ?? null),
+  );
+}
+
+export function headlineMetric(
+  release: HeadlineSource,
+  metrics: string[],
+): { value: number | null; breach: boolean } | null {
+  const hit = release.headline?.find((headline) => metrics.includes(headline.metric ?? ""));
+  if (!hit) return null;
+  const scenario = hit.scenarioId
+    ? release.scenarios?.find((candidate) => candidate.id === hit.scenarioId)
+    : undefined;
+  return { value: hit.value, breach: scenario?.state === "fail" };
+}

--- a/web/src/lib/matrix.ts
+++ b/web/src/lib/matrix.ts
@@ -11,7 +11,13 @@
 
 import { scenarioSampleSummary, stableReleases } from "./releases";
 import { scenarioHistories, type ScenarioHistory, type TrendPoint } from "./scenarios";
-import type { Release, Scenario } from "../content.config";
+import {
+  chronologicalDeltas,
+  headlineMetric,
+} from "./matrix-core";
+import type { Scenario } from "../content.config";
+
+export { pctDelta } from "./matrix-core";
 
 export interface MatrixRelease {
   ver: string;
@@ -72,30 +78,27 @@ function rowFromHistory(h: ScenarioHistory, releases: MatrixRelease[]): MatrixRo
   const cells: MatrixCell[] = [];
   let breaches = 0;
   let blocks = 0;
-  let lastSeenValue: number | null = null;
   let latest: TrendPoint | null = null;
+  const deltas = chronologicalDeltas(
+    releases.map((release) => byVer.get(release.ver)?.value ?? null),
+  );
 
-  for (const rel of releases) {
+  for (const [index, rel] of releases.entries()) {
     const p = byVer.get(rel.ver);
     if (!p) {
       cells.push({ value: null, state: null, threshold: 0, deltaPct: null, blocked: false });
       continue;
     }
     if (p.value != null) latest = p;
-    let deltaPct: number | null = null;
-    if (p.value != null && lastSeenValue != null && lastSeenValue !== 0) {
-      deltaPct = ((p.value - lastSeenValue) / lastSeenValue) * 100;
-    }
     cells.push({
       value: p.value,
       state: p.state,
       threshold: p.threshold,
-      deltaPct,
+      deltaPct: deltas[index] ?? null,
       blocked: p.value == null,
     });
     if (p.state === "fail") breaches++;
     if (p.value == null) blocks++;
-    if (p.value != null) lastSeenValue = p.value;
   }
 
   return {
@@ -171,12 +174,6 @@ function compareScenarioOrder(a: ScenarioHistory, b: ScenarioHistory, rank: Map<
   return a.id.localeCompare(b.id);
 }
 
-function headlineMetric(r: Release, metrics: string[]): { value: number | null; breach: boolean } | null {
-  const hit = r.headline?.find((h) => metrics.includes(h.metric ?? ""));
-  if (!hit) return null;
-  return { value: hit.value, breach: false };
-}
-
 function scenarioMetric(s: Scenario | undefined, unit: "s" | "ms"): { value: number | null; breach: boolean } | null {
   if (!s) return null;
   const divisor = unit === "s" && s.unit === "ms" ? 1000 : 1;
@@ -184,10 +181,4 @@ function scenarioMetric(s: Scenario | undefined, unit: "s" | "ms"): { value: num
     value: s.value == null ? null : s.value / divisor,
     breach: s.state === "fail",
   };
-}
-
-/** Returns Δ% between two consecutive non-null values in a sequence. */
-export function pctDelta(curr: number | null, prev: number | null): number | null {
-  if (curr == null || prev == null || prev === 0) return null;
-  return ((curr - prev) / prev) * 100;
 }

--- a/web/src/lib/og-card.ts
+++ b/web/src/lib/og-card.ts
@@ -40,7 +40,7 @@ function escapeXml(s: string): string {
     .replace(/'/g, "&apos;");
 }
 
-interface CardData {
+export interface CardData {
   /** Top-left eyebrow, e.g. "kova · OpenClaw performance". */
   eyebrow: string;
   /** Big headline, e.g. "OpenClaw 2026.5.16-beta.7". */
@@ -52,15 +52,15 @@ interface CardData {
   /** Short fact line at the bottom-left. */
   fact?: string;
   /** Right-side hero fact, e.g. worst metric. null = hide. */
-  hero?: { label: string; value: string; breach: boolean } | null;
+  hero?: { label: string; value: string; tone: "pass" | "fail" | "warn" } | null;
 }
 
 /** Build a 1200×630 OG card SVG from card data. Pure function. */
 export function cardSvg(d: CardData): string {
-  const eyebrow = escapeXml(d.eyebrow);
+  const eyebrow = escapeXml(d.eyebrow.toUpperCase());
   const headline = escapeXml(d.headline);
   const subhead = d.subhead ? escapeXml(d.subhead) : "";
-  const fact = d.fact ? escapeXml(d.fact) : "";
+  const fact = d.fact ? escapeXml(d.fact.toUpperCase()) : "";
 
   // Counts strip
   let countsBlock = "";
@@ -83,7 +83,7 @@ export function cardSvg(d: CardData): string {
   // Hero (right-side)
   let heroBlock = "";
   if (d.hero) {
-    const heroColor = d.hero.breach ? TOKENS.fail : TOKENS.pass;
+    const heroColor = TOKENS[d.hero.tone];
     heroBlock = `
       <g transform="translate(1120, 280)" text-anchor="end" font-family="ui-monospace, monospace">
         <text x="0" y="0" font-size="22" fill="${TOKENS.text3}" letter-spacing="2">${escapeXml(d.hero.label.toUpperCase())}</text>
@@ -106,13 +106,13 @@ export function cardSvg(d: CardData): string {
   <rect x="0" y="0" width="${W}" height="2" fill="${TOKENS.text1}" opacity="0.08" />
   ${brand}
   <text x="80" y="180" font-family="ui-monospace, monospace" font-size="22"
-        fill="${TOKENS.text3}" letter-spacing="3">${eyebrow.toUpperCase()}</text>
+        fill="${TOKENS.text3}" letter-spacing="3">${eyebrow}</text>
   <text x="80" y="280" font-family="ui-sans-serif, system-ui, sans-serif"
         font-size="80" font-weight="700" fill="${TOKENS.text1}">${headline}</text>
   ${subhead ? `<text x="80" y="335" font-family="ui-monospace, monospace" font-size="26" fill="${TOKENS.text2}">${subhead}</text>` : ""}
   ${countsBlock}
   ${heroBlock}
-  ${fact ? `<text x="80" y="580" font-family="ui-monospace, monospace" font-size="22" fill="${TOKENS.text3}" letter-spacing="2">${fact.toUpperCase()}</text>` : ""}
+  ${fact ? `<text x="80" y="580" font-family="ui-monospace, monospace" font-size="22" fill="${TOKENS.text3}" letter-spacing="2">${fact}</text>` : ""}
   <text x="${W - 80}" y="580" text-anchor="end" font-family="ui-monospace, monospace"
         font-size="22" fill="${TOKENS.text3}" letter-spacing="2">KOVA.OPENCLAW.DEV</text>
 </svg>`;
@@ -164,10 +164,14 @@ export function releaseCard(release: Release): CardData {
     hero = {
       label: primary.metric ?? primary.id,
       value: fmtMetricShort(primary.value, primary.unit),
-      breach: primary.state === "fail",
+      tone: primary.state === "fail" ? "fail" : primary.state === "block" ? "warn" : "pass",
     };
-  } else if (scenarios.length > 0 && counts && counts.fail === 0) {
-    hero = { label: "verdict", value: "clean", breach: false };
+  } else if (scenarios.length > 0 && counts) {
+    hero = counts.fail > 0
+      ? { label: "verdict", value: "regressions", tone: "fail" }
+      : counts.block > 0
+        ? { label: "verdict", value: "blocked", tone: "warn" }
+        : { label: "verdict", value: "clean", tone: "pass" };
   }
 
   return {

--- a/web/src/lib/release-format.ts
+++ b/web/src/lib/release-format.ts
@@ -4,8 +4,9 @@
 
 export function fmtMs(ms: number): string {
   if (ms >= 60_000) {
-    const m = Math.floor(ms / 60_000);
-    const s = Math.round((ms - m * 60_000) / 1000);
+    const totalSeconds = Math.round(ms / 1000);
+    const m = Math.floor(totalSeconds / 60);
+    const s = totalSeconds % 60;
     return `${m}m ${s.toString().padStart(2, "0")}s`;
   }
   if (ms >= 1000) return `${(ms / 1000).toFixed(2)} s`;

--- a/web/src/pages/og/[ver].png.ts
+++ b/web/src/pages/og/[ver].png.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from "astro";
 import { allReleases } from "../../lib/releases";
 import { cardSvg, releaseCard, svgToPng } from "../../lib/og-card";
+import { MUTABLE_IMAGE_CACHE_CONTROL } from "../../lib/http";
 
 export async function getStaticPaths() {
   const releases = await allReleases();
@@ -15,7 +16,7 @@ export const GET: APIRoute = async ({ props }) => {
     status: 200,
     headers: {
       "Content-Type": "image/png",
-      "Cache-Control": "public, max-age=31536000, immutable",
+      "Cache-Control": MUTABLE_IMAGE_CACHE_CONTROL,
     },
   });
 };

--- a/web/src/pages/og/default.png.ts
+++ b/web/src/pages/og/default.png.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 import { cardSvg, defaultCard, svgToPng } from "../../lib/og-card";
+import { MUTABLE_IMAGE_CACHE_CONTROL } from "../../lib/http";
 
 export const GET: APIRoute = async () => {
   const png = svgToPng(cardSvg(defaultCard));
@@ -7,7 +8,7 @@ export const GET: APIRoute = async () => {
     status: 200,
     headers: {
       "Content-Type": "image/png",
-      "Cache-Control": "public, max-age=31536000, immutable",
+      "Cache-Control": MUTABLE_IMAGE_CACHE_CONTROL,
     },
   });
 };

--- a/web/tests/web-lib.test.ts
+++ b/web/tests/web-lib.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { MUTABLE_IMAGE_CACHE_CONTROL } from "../src/lib/http.ts";
+import {
+  chronologicalDeltas,
+  headlineMetric,
+} from "../src/lib/matrix-core.ts";
+import { cardSvg, releaseCard, svgToPng } from "../src/lib/og-card.ts";
+import { fmtMs } from "../src/lib/release-format.ts";
+
+test("matrix deltas compare only adjacent chronological releases", () => {
+  assert.deepEqual(
+    chronologicalDeltas([100, 110, null, 130, 143]),
+    [null, 10, null, null, 10],
+  );
+});
+
+test("headline breach follows its matching scenario status", () => {
+  assert.deepEqual(
+    headlineMetric({
+      headline: [{ metric: "agent.turn.s", scenarioId: "turn", value: 1.2 }],
+      scenarios: [{ id: "turn", state: "fail" }],
+    }, ["agent.turn.s"]),
+    { value: 1.2, breach: true },
+  );
+});
+
+test("duration rounding carries seconds into the next minute", () => {
+  assert.equal(fmtMs(119_499), "1m 59s");
+  assert.equal(fmtMs(119_500), "2m 00s");
+  assert.equal(fmtMs(119_501), "2m 00s");
+  assert.equal(fmtMs(60_499), "1m 00s");
+});
+
+test("OG card uppercases raw text before XML escaping", () => {
+  const svg = cardSvg({
+    eyebrow: `a & <b> "c" 'd'`,
+    headline: "test",
+    fact: `ready & <set> "now" 'yes'`,
+  });
+  assert.match(svg, />A &amp; &lt;B&gt; &quot;C&quot; &apos;D&apos;</);
+  assert.match(svg, />READY &amp; &lt;SET&gt; &quot;NOW&quot; &apos;YES&apos;</);
+  assert.doesNotMatch(svg, /&AMP;|&LT;|&GT;/);
+  assert.ok(svgToPng(svg).byteLength > 0);
+});
+
+test("only all-pass releases get a clean OG verdict", () => {
+  const cardFor = (states: Array<"pass" | "fail" | "block">) => releaseCard({
+    ver: "2026.7.1",
+    releaseDate: new Date("2026-07-11"),
+    date: "Jul 11, 2026",
+    sha: "abc1234",
+    passed: states.every((state) => state === "pass"),
+    scenarios: states.map((state, index) => ({
+      id: `provision-${index}`,
+      value: null,
+      unit: "ms",
+      threshold: 1000,
+      state,
+      spark: null,
+    })),
+  });
+
+  const blocked = cardFor(["block"]);
+  assert.deepEqual(blocked.hero, {
+    label: "verdict",
+    value: "blocked",
+    tone: "warn",
+  });
+  assert.deepEqual(cardFor(["pass", "block"]).hero, blocked.hero);
+  assert.deepEqual(cardFor(["pass"]).hero, {
+    label: "verdict",
+    value: "clean",
+    tone: "pass",
+  });
+  assert.deepEqual(cardFor(["fail"]).hero, {
+    label: "verdict",
+    value: "regressions",
+    tone: "fail",
+  });
+  assert.match(cardSvg(blocked), /fill="#f59e0b"[^>]*>blocked</);
+});
+
+test("mutable OG assets require cache revalidation", async () => {
+  assert.equal(
+    MUTABLE_IMAGE_CACHE_CONTROL,
+    "public, max-age=0, must-revalidate",
+  );
+  const headers = await readFile(
+    new URL("../public/_headers", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    headers,
+    /\/og\/\*\s+Cache-Control: public, max-age=0, must-revalidate/,
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Kova web reports could carry comparison deltas across missing samples, lose scenario breach status, render blocked Open Graph verdicts incorrectly, cache mutable OG images, and display rounded durations as `0m 60s`.

## Why This Change Was Made

The report UI and generated social cards must preserve the same evaluation semantics as the release payload. Comparison chains now reset when evidence is missing, breach state survives projection, OG output handles blocked/failed states safely, mutable images revalidate, and duration formatting normalizes minute rollover.

## User Impact

Published reports and social cards no longer show misleading deltas, statuses, or durations. Updated release data is reflected without stale OG caching.

## Evidence

- `npm test` (6/6)
- Astro check
- production build (18 pages)
- focused report presentation tests
- Codex autoreview with `gpt-5.6-sol`, high reasoning: clean, confidence 0.91
- `git diff --check`
