### PR TITLE
fix(matrix): enforce executed gate coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,5 @@ All notable changes to Kova are documented in this file.
 
 - Hardened performance baseline persistence, unstable-group detection, and repeated-work audit isolation.
 - Fixed web reports to reset matrix deltas across missing samples, preserve scenario breach status, render blocked OG verdicts safely, revalidate mutable OG images, and normalize rounded minute durations.
+- Made matrix gates honor scenario-wide policies and validate all seven coverage dimensions only from records that actually executed.
+- Stopped parallel matrix workers from scheduling new scenarios after a rejection, drained active workers before rethrowing, and made lifecycle command indexes phase-wide to prevent artifact overwrites.

--- a/src/matrix/gate.mjs
+++ b/src/matrix/gate.mjs
@@ -50,7 +50,7 @@ export function evaluateGate(report, profile, options = {}) {
   }
 
   for (const required of policy.blocking) {
-    if (!records.some((record) => policyEntryMatchesRecord(required, record))) {
+    if (!records.some((record) => isExecutedRecord(record) && policyEntryMatchesRecord(required, record))) {
       missingRequired.push(required);
       cards.push({
         severity: partial ? "info" : "blocking",

--- a/src/matrix/gate.mjs
+++ b/src/matrix/gate.mjs
@@ -49,9 +49,8 @@ export function evaluateGate(report, profile, options = {}) {
     });
   }
 
-  const recordKeys = new Set(records.map(recordKey));
   for (const required of policy.blocking) {
-    if (!recordKeys.has(policyKey(required))) {
+    if (!records.some((record) => policyEntryMatchesRecord(required, record))) {
       missingRequired.push(required);
       cards.push({
         severity: partial ? "info" : "blocking",
@@ -165,7 +164,7 @@ function normalizeGatePolicy(profile, options = {}) {
   const entries = Array.isArray(profile?.entries) ? profile.entries : [];
   const warning = normalizePolicyEntries(gate.warning ?? []);
   const blocking = normalizePolicyEntries(gate.blocking ?? entries)
-    .filter((entry) => !warning.some((warningEntry) => policyKey(warningEntry) === policyKey(entry)));
+    .filter((entry) => !warning.some((warningEntry) => warningOverridesBlocking(warningEntry, entry)));
 
   return {
     id: typeof gate.id === "string" && gate.id ? gate.id : `${profile?.id ?? "matrix"}-gate`,
@@ -178,28 +177,83 @@ function normalizeGatePolicy(profile, options = {}) {
 function buildCoverageCards(report, policy, partial, options = {}) {
   const cards = [];
   const resolvedCoverage = options.resolvedCoverage ?? null;
-  const platformKeys = platformCoverageKeys(report.platform);
-  const requirementKeys = new Set((resolvedCoverage?.obligations ?? [])
-    .filter((obligation) => obligation.status === "planned")
+  const observed = observedCoverage(report, resolvedCoverage);
+
+  for (const [policyKey, kind] of [
+    ["surfaces", "surface"],
+    ["platforms", "platform"],
+    ["states", "state"],
+    ["traits", "trait"],
+    ["scenarios", "scenario"],
+    ["stateSurfaces", "state-surface"],
+    ["requirements", "requirement"]
+  ]) {
+    addCoverageCards(cards, {
+      kind,
+      expected: policy.coverage[policyKey],
+      observed: observed[policyKey],
+      partial,
+      statusText: `${observed[policyKey].size} ${kind} coverage item(s) executed`
+    });
+  }
+
+  return cards;
+}
+
+function observedCoverage(report, resolvedCoverage) {
+  const records = (report.records ?? []).filter(isExecutedRecord);
+  const surfaces = new Set();
+  const states = new Set();
+  const traits = new Set();
+  const scenarios = new Set();
+  const stateSurfaces = new Set();
+
+  for (const record of records) {
+    const surface = record.surface;
+    const state = record.state?.id;
+    if (surface) {
+      surfaces.add(surface);
+    }
+    if (state) {
+      states.add(state);
+    }
+    if (record.scenario) {
+      scenarios.add(record.scenario);
+    }
+    if (surface && state) {
+      stateSurfaces.add(`${surface}:${state}`);
+    }
+    for (const trait of record.state?.traits ?? []) {
+      traits.add(trait);
+    }
+  }
+
+  const requirements = new Set((resolvedCoverage?.obligations ?? [])
+    .filter((obligation) =>
+      obligation.status === "planned" &&
+      records.some((record) => obligationMatchesRecord(obligation, record))
+    )
     .map((obligation) => `${obligation.surface}:${obligation.requirement}`)
     .filter((value) => !value.endsWith(":null")));
 
-  addCoverageCards(cards, {
-    kind: "platform",
-    expected: policy.coverage.platforms,
-    observed: platformKeys,
-    partial,
-    statusText: report.platform ? `${report.platform.os}/${report.platform.arch}` : "unknown platform"
-  });
-  addCoverageCards(cards, {
-    kind: "requirement",
-    expected: policy.coverage.requirements,
-    observed: requirementKeys,
-    partial,
-    statusText: `${requirementKeys.size} requirement obligation(s) present`
-  });
+  return {
+    surfaces,
+    platforms: records.length > 0 ? platformCoverageKeys(report.platform) : new Set(),
+    states,
+    traits,
+    scenarios,
+    stateSurfaces,
+    requirements
+  };
+}
 
-  return cards;
+function isExecutedRecord(record) {
+  return record.status !== RECORD_STATUS.DRY_RUN && record.status !== RECORD_STATUS.SKIPPED;
+}
+
+function obligationMatchesRecord(obligation, record) {
+  return obligation.scenario === record.scenario &&
+    (obligation.state === null || obligation.state === undefined || obligation.state === record.state?.id);
 }
 
 function addCoverageCards(cards, { kind, expected, observed, partial, statusText }) {
@@ -241,10 +295,10 @@ function coverageCard({ severity, kind, value, partial, statusText }) {
 }
 
 function stateFromCoverage(kind, value) {
-  if (kind !== "state-surface") {
-    return null;
+  if (kind === "state") {
+    return value;
   }
-  return String(value).split(":")[1] ?? null;
+  return kind === "state-surface" ? String(value).split(":")[1] ?? null : null;
 }
 
 function normalizePolicyEntries(entries) {
@@ -260,8 +314,7 @@ function normalizePolicyEntries(entries) {
 }
 
 function severityForRecord(record, policy) {
-  const key = recordKey(record);
-  if (policy.warning.some((entry) => policyKey(entry) === key)) {
+  if (policy.warning.some((entry) => policyEntryMatchesRecord(entry, record))) {
     return "warning";
   }
   return "blocking";
@@ -514,12 +567,14 @@ function cardRank(card) {
   return severity + kind;
 }
 
-function recordKey(record) {
-  return `${record.scenario}:${record.state?.id ?? ""}`;
+function policyEntryMatchesRecord(entry, record) {
+  return entry.scenario === record.scenario &&
+    (!entry.state || entry.state === record.state?.id);
 }
 
-function policyKey(entry) {
-  return `${entry.scenario}:${entry.state ?? ""}`;
+function warningOverridesBlocking(warning, blocking) {
+  return warning.scenario === blocking.scenario &&
+    (!warning.state || warning.state === blocking.state);
 }
 
 function formatPolicyEntry(entry) {

--- a/src/run/engine.mjs
+++ b/src/run/engine.mjs
@@ -67,14 +67,26 @@ export async function runEntries({ entries, runEntry, execute, controls }) {
 
   const records = new Array(entries.length);
   let nextIndex = 0;
+  let rejected = false;
+  let firstError;
   async function worker() {
-    while (nextIndex < entries.length) {
+    while (!rejected && nextIndex < entries.length) {
       const index = nextIndex;
       nextIndex += 1;
-      records[index] = await runEntry(entries[index]);
+      try {
+        records[index] = await runEntry(entries[index]);
+      } catch (error) {
+        if (!rejected) {
+          rejected = true;
+          firstError = error;
+        }
+      }
     }
   }
 
   await Promise.all(Array.from({ length: controls.parallel }, () => worker()));
+  if (rejected) {
+    throw firstError;
+  }
   return records.filter(Boolean).flat();
 }

--- a/src/run/state-lifecycle.mjs
+++ b/src/run/state-lifecycle.mjs
@@ -2,9 +2,6 @@ import { collectEnvMetrics } from "../metrics.mjs";
 import { phaseResultStatus } from "../measurement-contract.mjs";
 import { metricOptions } from "./metric-options.mjs";
 import {
-  materializeLifecycleStepCommands
-} from "./phase-commands.mjs";
-import {
   buildStateLifecyclePhase,
   stateLifecycleCollectionIntent,
   stateLifecycleCommandScope,
@@ -30,11 +27,8 @@ export async function executeStateLifecycleSteps(context, envName, scenario, kin
   const phase = buildStateLifecyclePhase(context, envName, scenario, kind, steps, artifactDir, phaseId);
   const commands = phase.commands;
 
-  for (const step of steps) {
-    const stepCommands = materializeLifecycleStepCommands(step, context, envName, artifactDir);
-    for (const [commandIndex, command] of stepCommands.entries()) {
-      results.push(await runScenarioCommand(command, context, envName, artifactDir, phase, commandIndex, authPolicy));
-    }
+  for (const [commandIndex, command] of commands.entries()) {
+    results.push(await runScenarioCommand(command, context, envName, artifactDir, phase, commandIndex, authPolicy));
   }
 
   return {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -48,6 +48,7 @@ import {
   validateChannelWorkflowCaseInventoryReferences
 } from "./registries/channel-workflow-cases.mjs";
 import { runScenarioCommand } from "./run/command-executor.mjs";
+import { runEntries } from "./run/engine.mjs";
 import { executeStateLifecycleSteps } from "./run/state-lifecycle.mjs";
 import { executeTargetSetup } from "./run/target-setup.mjs";
 import { loadProcessRoles } from "./registries/process-roles.mjs";
@@ -907,6 +908,7 @@ export async function runSelfCheck(flags = {}) {
         assertEqual(data.summary?.statuses?.["DRY-RUN"], 6, "filtered matrix dry-run count");
       }
     ));
+    checks.push(await matrixWorkerRejectionCheck());
     checks.push(await gateDryRunCheck(tmp));
     checks.push(gatePartialFailureCheck());
     checks.push(gatePartialPassCheck());
@@ -3289,6 +3291,65 @@ async function stateLifecycleCommandIndexesCheck(tmp) {
       id: "state-lifecycle-command-indexes",
       status: "FAIL",
       command: "execute multi-step state lifecycle with phase-wide command indexes",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function matrixWorkerRejectionCheck() {
+  const firstError = new Error("synthetic matrix worker failure");
+  const started = [];
+  const completed = [];
+  try {
+    let caught;
+    try {
+      await runEntries({
+        entries: [0, 1, 2, 3],
+        execute: true,
+        controls: { parallel: 2, failFast: false },
+        runEntry: async (entry) => {
+          started.push(entry);
+          if (entry === 0) {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            throw firstError;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          completed.push(entry);
+          return [{ status: "PASS" }];
+        }
+      });
+    } catch (error) {
+      caught = error;
+    }
+    assertEqual(caught, firstError, "parallel matrix rethrows first worker error");
+    assertEqual(started.join(","), "0,1", "parallel matrix stops assigning new entries after rejection");
+    assertEqual(completed.join(","), "1", "parallel matrix drains active workers before rejecting");
+
+    const serialStarted = [];
+    const serialRecords = await runEntries({
+      entries: [0, 1],
+      execute: true,
+      controls: { parallel: 1, failFast: true },
+      runEntry: async (entry) => {
+        serialStarted.push(entry);
+        return [{ status: entry === 0 ? "FAIL" : "PASS" }];
+      }
+    });
+    assertEqual(serialStarted.join(","), "0", "serial fail-fast stops after first non-passing record");
+    assertEqual(serialRecords.length, 1, "serial fail-fast returns completed records");
+
+    return {
+      id: "matrix-worker-rejection",
+      status: "PASS",
+      command: "reject parallel matrix worker and drain active work",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "matrix-worker-rejection",
+      status: "FAIL",
+      command: "reject parallel matrix worker and drain active work",
       durationMs: 0,
       message: error.message
     };

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3661,6 +3661,34 @@ function gateScenarioWildcardCheck() {
     assertEqual(passingGate.verdict, "SHIP", "scenario-only blocking entry matches stateful record");
     assertEqual(passingGate.missingRequiredCount, 0, "scenario-only blocking entry is not missing");
 
+    for (const status of ["DRY-RUN", "SKIPPED"]) {
+      const unexecutedGate = evaluateGate({
+        mode: "execution",
+        controls: { include: [], exclude: [] },
+        records: [{
+          scenario: "doctor-repair-upgrade",
+          surface: "upgrade-existing-user",
+          state: { id: "legacy-core-config", traits: ["legacy-config"] },
+          status,
+          title: "Doctor Repair Upgrade",
+          likelyOwner: "Kova",
+          phases: []
+        }]
+      }, {
+        id: "doctor-upgrade",
+        gate: {
+          id: "doctor-upgrade-gate",
+          blocking: [{ scenario: "doctor-repair-upgrade" }]
+        }
+      });
+      assertEqual(unexecutedGate.missingRequiredCount, 1, `scenario-only blocking entry ignores ${status} records`);
+      assertEqual(
+        unexecutedGate.cards.some((card) => card.kind === "missing-required-scenario"),
+        true,
+        `${status} record leaves required scenario missing`
+      );
+    }
+
     const warningGate = evaluateGate({
       mode: "execution",
       controls: { include: [], exclude: [] },

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -911,6 +911,8 @@ export async function runSelfCheck(flags = {}) {
     checks.push(gatePlatformCoverageCheck());
     checks.push(gateNonReleaseOutcomeCheck());
     checks.push(gateRequirementCoverageCheck());
+    checks.push(gateScenarioWildcardCheck());
+    checks.push(gateExecutedCoverageDimensionsCheck());
     checks.push(await doctorUpgradeGatePolicyCheck());
     checks.push(gateSubsystemSummaryCheck());
     checks.push(safetyGuardCheck());
@@ -3503,6 +3505,143 @@ function gateRequirementCoverageCheck() {
       id: "gate-requirement-coverage",
       status: "FAIL",
       command: "evaluate synthetic release gate requirement coverage",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function gateScenarioWildcardCheck() {
+  try {
+    const passingGate = evaluateGate({
+      mode: "execution",
+      controls: { include: [], exclude: [] },
+      records: [{
+        scenario: "doctor-repair-upgrade",
+        surface: "upgrade-existing-user",
+        state: { id: "legacy-core-config", traits: ["legacy-config"] },
+        status: "PASS",
+        title: "Doctor Repair Upgrade",
+        likelyOwner: "OpenClaw",
+        phases: []
+      }]
+    }, {
+      id: "doctor-upgrade",
+      gate: {
+        id: "doctor-upgrade-gate",
+        blocking: [{ scenario: "doctor-repair-upgrade" }]
+      }
+    });
+    assertEqual(passingGate.verdict, "SHIP", "scenario-only blocking entry matches stateful record");
+    assertEqual(passingGate.missingRequiredCount, 0, "scenario-only blocking entry is not missing");
+
+    const warningGate = evaluateGate({
+      mode: "execution",
+      controls: { include: [], exclude: [] },
+      records: [{
+        scenario: "agent-provider-timeout",
+        surface: "agent-cli-local-turn",
+        state: { id: "mock-openai-provider", traits: ["mock-provider"] },
+        status: "FAIL",
+        title: "Agent Provider Timeout",
+        likelyOwner: "OpenClaw",
+        phases: []
+      }]
+    }, {
+      id: "provider-warning",
+      gate: {
+        id: "provider-warning-gate",
+        blocking: [],
+        warning: [{ scenario: "agent-provider-timeout" }]
+      }
+    });
+    assertEqual(warningGate.verdict, "SHIP", "scenario-only warning entry matches stateful failure");
+    assertEqual(warningGate.warningCount, 1, "scenario-only warning classifies stateful failure");
+    assertEqual(warningGate.blockingCount, 0, "scenario-only warning does not become blocking");
+
+    return {
+      id: "gate-scenario-wildcard-state",
+      status: "PASS",
+      command: "evaluate scenario-only gate entries against stateful records",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "gate-scenario-wildcard-state",
+      status: "FAIL",
+      command: "evaluate scenario-only gate entries against stateful records",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function gateExecutedCoverageDimensionsCheck() {
+  try {
+    const profile = {
+      id: "release",
+      gate: {
+        id: "executed-coverage-gate",
+        coverage: {
+          platforms: { blocking: ["darwin-arm64"] },
+          requirements: { blocking: ["release-runtime-startup:baseline"] }
+        },
+        blocking: [{ scenario: "release-runtime-startup", state: "fresh" }]
+      }
+    };
+    const resolvedCoverage = {
+      obligations: [{
+        surface: "release-runtime-startup",
+        requirement: "baseline",
+        scenario: "release-runtime-startup",
+        state: "fresh",
+        stateTraits: ["fresh-user"],
+        status: "planned"
+      }]
+    };
+    const emptyGate = evaluateGate({
+      mode: "execution",
+      controls: { include: [], exclude: [] },
+      platform: { os: "darwin", arch: "arm64" },
+      records: []
+    }, profile, { resolvedCoverage });
+    const missingDimensions = new Set(emptyGate.cards
+      .filter((card) => card.kind === "missing-required-coverage")
+      .map((card) => card.coverage));
+    assertEqual(
+      [...missingDimensions].sort().join(","),
+      ["platform", "requirement", "scenario", "state", "state-surface", "surface", "trait"].sort().join(","),
+      "gate checks every coverage dimension against executed records"
+    );
+
+    const completeGate = evaluateGate({
+      mode: "execution",
+      controls: { include: [], exclude: [] },
+      platform: { os: "darwin", arch: "arm64" },
+      records: [{
+        scenario: "release-runtime-startup",
+        surface: "release-runtime-startup",
+        state: { id: "fresh", traits: ["fresh-user"] },
+        status: "PASS",
+        title: "Release Runtime Startup",
+        likelyOwner: "OpenClaw",
+        phases: []
+      }]
+    }, profile, { resolvedCoverage });
+    assertEqual(completeGate.verdict, "SHIP", "executed record satisfies all seven coverage dimensions");
+    assertEqual(completeGate.missingRequiredCount, 0, "complete executed coverage has no gaps");
+
+    return {
+      id: "gate-executed-coverage-dimensions",
+      status: "PASS",
+      command: "evaluate all gate coverage dimensions from executed records",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "gate-executed-coverage-dimensions",
+      status: "FAIL",
+      command: "evaluate all gate coverage dimensions from executed records",
       durationMs: 0,
       message: error.message
     };

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -48,6 +48,7 @@ import {
   validateChannelWorkflowCaseInventoryReferences
 } from "./registries/channel-workflow-cases.mjs";
 import { runScenarioCommand } from "./run/command-executor.mjs";
+import { executeStateLifecycleSteps } from "./run/state-lifecycle.mjs";
 import { executeTargetSetup } from "./run/target-setup.mjs";
 import { loadProcessRoles } from "./registries/process-roles.mjs";
 import { validateProfileShape } from "./registries/profiles.mjs";
@@ -809,6 +810,7 @@ export async function runSelfCheck(flags = {}) {
         }
       }
     ));
+    checks.push(await stateLifecycleCommandIndexesCheck(tmp));
     checks.push(await jsonCommandCheck(
       "allowlisted-scenario-omitted-state-falls-back-json",
       `node bin/kova.mjs run --target runtime:stable --scenario official-plugin-install --report-dir ${quoteShell(tmp)} --json`,
@@ -3228,6 +3230,69 @@ function syntheticResourceSamples({ peakRssMb, maxCpuPercent, role }) {
     topByRss: [],
     topByCpu: []
   };
+}
+
+async function stateLifecycleCommandIndexesCheck(tmp) {
+  const artifactDir = join(tmp, "state-lifecycle-command-indexes");
+  try {
+    const phase = await executeStateLifecycleSteps(
+      {
+        target: "runtime:stable",
+        targetPlan: {
+          kind: "runtime",
+          value: "stable",
+          startSelector: "stable",
+          upgradeSelector: "stable"
+        },
+        state: { id: "multi-step-state" },
+        timeoutMs: 30000,
+        resourceSampleIntervalMs: 250,
+        processRoles: []
+      },
+      "kova-self-check",
+      {
+        id: "state-lifecycle-index-check",
+        surface: "fresh-install"
+      },
+      "prepare",
+      [
+        {
+          commands: [
+            "node -e 'process.stdout.write(\"first\")'",
+            "node -e 'process.stdout.write(\"second\")'"
+          ],
+          evidence: [],
+          collectionIntent: "skip-env"
+        },
+        {
+          commands: ["node -e 'process.stdout.write(\"third\")'"],
+          evidence: [],
+          collectionIntent: "skip-env"
+        }
+      ],
+      artifactDir
+    );
+    const artifactPaths = phase.results.map((result) => result.resourceSamples?.artifactPath);
+    assertEqual(phase.results.length, 3, "state lifecycle result count");
+    assertEqual(new Set(artifactPaths).size, 3, "state lifecycle command artifact paths are unique");
+    assertEqual(artifactPaths[0]?.endsWith("prepare-1.jsonl"), true, "first lifecycle command index");
+    assertEqual(artifactPaths[1]?.endsWith("prepare-2.jsonl"), true, "second lifecycle command index");
+    assertEqual(artifactPaths[2]?.endsWith("prepare-3.jsonl"), true, "third lifecycle command index");
+    return {
+      id: "state-lifecycle-command-indexes",
+      status: "PASS",
+      command: "execute multi-step state lifecycle with phase-wide command indexes",
+      durationMs: phase.results.reduce((total, result) => total + result.durationMs, 0)
+    };
+  } catch (error) {
+    return {
+      id: "state-lifecycle-command-indexes",
+      status: "FAIL",
+      command: "execute multi-step state lifecycle with phase-wide command indexes",
+      durationMs: 0,
+      message: error.message
+    };
+  }
 }
 
 function gatePartialFailureCheck() {


### PR DESCRIPTION
## What Problem This Solves

Kova matrix gates could count unexecuted records as coverage, ignore scenario-wide policy entries for stateful records, reset lifecycle command indexes per step, and reject early while still scheduling additional parallel work.

## Why This Change Was Made

Release approval must be based only on records that actually executed. Lifecycle artifacts also need stable phase-wide identities, and parallel rejection must stop new scheduling while draining work already in flight.

## User Impact

- Required scenarios and all seven coverage dimensions are validated from executed records only.
- Scenario-wide policies correctly apply to stateful records.
- Lifecycle command artifacts no longer overwrite each other.
- Matrix failures stop new scheduling and return only after active workers drain.

## Evidence

- Kova self-check: 223/223 before final review correction
- Regression coverage for skipped and dry-run wildcard records
- Codex autoreview with `gpt-5.6-sol`, high reasoning: two findings fixed; final clean, confidence 0.87
- `git diff --check`
