### PR TITLE
fix(web): aggregate compatible release metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ All notable changes to Kova are documented in this file.
 - Fixed web reports to reset matrix deltas across missing samples, preserve scenario breach status, render blocked OG verdicts safely, revalidate mutable OG images, and normalize rounded minute durations.
 - Made matrix gates honor scenario-wide policies and validate all seven coverage dimensions only from records that actually executed.
 - Stopped parallel matrix workers from scheduling new scenarios after a rejection, drained active workers before rethrowing, and made lifecycle command indexes phase-wide to prevent artifact overwrites.
+- Fixed web release projections to select same-day priors numerically, match headline deltas by scenario, metric, and unit, label comparisons with the measured metric, and median-aggregate repeated turn measurements.

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -141,6 +141,8 @@ import {
 import { resolveThresholdPolicy } from "./evaluation/thresholds.mjs";
 import { createSelfCheckProgress, renderSelfCheckReceipt } from "./reporting/render-selfcheck.mjs";
 import { scriptForMode as buildMockProviderScriptForMode } from "../support/channel-workflow-provider-script.mjs";
+import { projectInternalReport } from "./web-publish/from-internal-report.mjs";
+import { augmentWithDeltas, findImmediatePrior } from "./web-publish/projector.mjs";
 
 export async function runSelfCheck(flags = {}) {
   const progress = createSelfCheckProgress({ flags });
@@ -174,6 +176,107 @@ export async function runSelfCheck(flags = {}) {
       const ids = Array.from({ length: 8 }, () => createRunId());
       assertEqual(new Set(ids).size, ids.length, "same-process run ids are unique");
       assertEqual(ids.every((id) => /^kova-\d{6}-\d{6}-[0-9a-f]{6}$/.test(id)), true, "run id format includes unique suffix");
+    }));
+    checks.push(await inlineCheck("web-publish-prior-version-order", () => {
+      const release = (ver, releaseDate = "2026-05-26") => ({
+        id: ver,
+        data: { ver, releaseDate },
+      });
+      const prior = findImmediatePrior([
+        release("2026.5.9"),
+        release("2026.5.10"),
+        release("2026.5.12"),
+        release("2026.5.99", "2026-05-25"),
+      ], "2026.5.11", "2026-05-26");
+      assertEqual(prior?.data?.ver, "2026.5.10", "same-day prior uses numeric version ordering");
+    }));
+    checks.push(await inlineCheck("web-publish-delta-identity", () => {
+      const augmented = augmentWithDeltas({
+        ver: "2026.5.27",
+        headline: [{
+          label: "agent turn",
+          value: 2,
+          unit: "s",
+          scenarioId: "gateway-session-send-turn",
+          metric: "agent.turn.s",
+        }],
+        scenarios: [{
+          id: "gateway-session-send-turn",
+          metric: "Session Send",
+          value: 2000,
+          unit: "ms",
+          worstMetric: { name: "pre-provider share", value: 90, unit: "%" },
+        }],
+      }, {
+        id: "2026.5.26",
+        data: {
+          ver: "2026.5.26",
+          headline: [
+            {
+              label: "pre-provider",
+              value: 99,
+              unit: "s",
+              scenarioId: "gateway-session-send-turn",
+              metric: "agent.pre_provider.s",
+            },
+            {
+              label: "agent turn",
+              value: 1.6,
+              unit: "s",
+              scenarioId: "gateway-session-send-turn",
+              metric: "agent.turn.s",
+            },
+          ],
+          scenarios: [{
+            id: "gateway-session-send-turn",
+            metric: "Session Send",
+            value: 1600,
+            unit: "ms",
+          }],
+        },
+      });
+      assertEqual(augmented.headline?.[0]?.deltaPct, 25, "headline delta uses matching headline identity");
+      assertEqual(augmented.comparison?.rows?.[0]?.metric, "Session Send", "comparison uses scenario metric");
+    }));
+    checks.push(await inlineCheck("web-publish-turn-median", () => {
+      const turnRecord = (repeat, agentTurnMs, sendDurationMs) => ({
+        scenario: "gateway-session-send-turn",
+        surface: "gateway-session-send-turn",
+        title: "Gateway Session Turns",
+        status: "PASS",
+        repeat: { index: repeat, total: 2 },
+        measurements: {
+          agentTurnMs,
+          coldAgentTurnMs: agentTurnMs,
+          agentTurns: [{
+            label: "cold",
+            gatewaySession: {
+              sendDurationMs,
+              timeToMatchedAssistantMs: sendDurationMs * 2,
+            },
+          }],
+        },
+        thresholds: {
+          agentTurnMs: 1000,
+          coldAgentTurnMs: 1000,
+        },
+      });
+      const projected = projectInternalReport({
+        schemaVersion: "kova.report.v1",
+        generatedAt: "2026-05-27T00:00:00.000Z",
+        runId: "web-publish-turn-median",
+        mode: "execution",
+        target: "npm:2026.5.27",
+        summary: { total: 2, statuses: { PASS: 2 } },
+        records: [
+          turnRecord(1, 100, 10),
+          turnRecord(2, 300, 30),
+        ],
+      });
+      const metrics = projected.runs?.[0]?.scenarios?.[0]?.metrics ?? [];
+      assertEqual(metrics.find((row) => row.name === "full turn")?.value, 200, "primary turn row median");
+      assertEqual(metrics.find((row) => row.name === "↳ cold send rpc")?.value, 20, "child turn row median");
+      assertEqual(metrics.find((row) => row.name === "↳ cold matched assistant")?.value, 40, "child assistant row median");
     }));
     checks.push(await inlineCheck("external-plugin-fixture-manifests", async () => {
       for (const [dir, expectedId] of [

--- a/src/web-publish/from-internal-report.mjs
+++ b/src/web-publish/from-internal-report.mjs
@@ -288,34 +288,33 @@ function projectMetricRows(scenario, records) {
 
 function projectTurnMetricRows(scenario, samples) {
   if (!isAgentTurnScenario(scenario.id) || samples.length === 0) return [];
-  const record = samples[0];
-  const measurements = record.measurements ?? {};
   const rows = [
-    directMetricRow(record, "agentTurnMs", "full turn", "agentTurnMs"),
-    directMetricRow(record, "coldAgentTurnMs", "cold turn", "coldAgentTurnMs"),
-    directMetricRow(record, "warmAgentTurnMs", "warm turn", "warmAgentTurnMs"),
-    directMetricRow(record, "agentPreProviderMs", "pre-provider", "preProviderMs"),
-    directMetricRow(record, "agentProviderFinalMs", "provider", "providerFinalMs"),
-    directMetricRow(record, "agentPostProviderMs", "post-provider", null),
+    aggregateDirectMetricRow(samples, "agentTurnMs", "full turn", "agentTurnMs"),
+    aggregateDirectMetricRow(samples, "coldAgentTurnMs", "cold turn", "coldAgentTurnMs"),
+    aggregateDirectMetricRow(samples, "warmAgentTurnMs", "warm turn", "warmAgentTurnMs"),
+    aggregateDirectMetricRow(samples, "agentPreProviderMs", "pre-provider", "preProviderMs"),
+    aggregateDirectMetricRow(samples, "agentProviderFinalMs", "provider", "providerFinalMs"),
+    aggregateDirectMetricRow(samples, "agentPostProviderMs", "post-provider", null),
   ].filter(Boolean);
 
   if (scenario.id === "gateway-session-send-turn" || scenario.surface === "gateway-session-send-turn") {
-    for (const turn of measurements.agentTurns ?? []) {
-      const label = turn.label ? `${turn.label} ` : "";
-      rows.push(...[
-        sessionTurnRow(`${label}send rpc`, turn.gatewaySession?.sendDurationMs),
-        sessionTurnRow(`${label}matched assistant`, turn.gatewaySession?.timeToMatchedAssistantMs),
-      ].filter(Boolean));
-    }
+    rows.push(...aggregateSessionTurnRows(samples));
   }
 
   return rows;
 }
 
-function directMetricRow(record, metricKey, name, thresholdKey) {
-  const value = numericOrNull(measurementMetricValue(record.measurements ?? {}, metricKey));
-  if (value == null) return null;
-  const threshold = thresholdKey ? numericOrNull(record.thresholds?.[thresholdKey]) : null;
+function aggregateDirectMetricRow(records, metricKey, name, thresholdKey) {
+  const values = records
+    .map((record) => measurementMetricValue(record.measurements ?? {}, metricKey))
+    .map(numericOrNull)
+    .filter((value) => value != null);
+  if (values.length === 0) return null;
+  const value = median(values);
+  const thresholds = thresholdKey
+    ? records.map((record) => numericOrNull(record.thresholds?.[thresholdKey])).filter((threshold) => threshold != null)
+    : [];
+  const threshold = median(thresholds);
   return pruneUndefined({
     name,
     value,
@@ -325,17 +324,31 @@ function directMetricRow(record, metricKey, name, thresholdKey) {
   });
 }
 
-function sessionTurnRow(name, value) {
-  const n = numericOrNull(value);
-  if (n == null) return null;
-  return {
+function aggregateSessionTurnRows(records) {
+  const valuesByName = new Map();
+  for (const record of records) {
+    for (const turn of record.measurements?.agentTurns ?? []) {
+      const label = turn.label ? `${turn.label} ` : "";
+      appendMetricSample(valuesByName, `${label}send rpc`, turn.gatewaySession?.sendDurationMs);
+      appendMetricSample(valuesByName, `${label}matched assistant`, turn.gatewaySession?.timeToMatchedAssistantMs);
+    }
+  }
+  return [...valuesByName].map(([name, values]) => ({
     name: `↳ ${name}`,
-    value: n,
+    value: median(values),
     unit: "ms",
     threshold: null,
     state: "pass",
     child: true,
-  };
+  }));
+}
+
+function appendMetricSample(samplesByName, name, value) {
+  const n = numericOrNull(value);
+  if (n == null) return;
+  const samples = samplesByName.get(name) ?? [];
+  samples.push(n);
+  samplesByName.set(name, samples);
 }
 
 function isAgentTurnScenario(scenarioId) {

--- a/src/web-publish/projector.mjs
+++ b/src/web-publish/projector.mjs
@@ -50,7 +50,7 @@ export async function loadPriorReleases(dir) {
  * @returns {{ id: string; data: any } | null}
  */
 export function findImmediatePrior(releases, targetVer, targetDate) {
-  const t = new Date(targetDate).getTime();
+  const t = releaseDayValue(targetDate);
   if (!Number.isFinite(t)) return null;
   let best = null;
   let bestT = -Infinity;
@@ -58,14 +58,30 @@ export function findImmediatePrior(releases, targetVer, targetDate) {
     const ver = r.data?.ver ?? r.id;
     if (ver === targetVer) continue;
     if (!sameReleaseLane(ver, targetVer)) continue;
-    const d = r.data?.releaseDate ? new Date(r.data.releaseDate).getTime() : NaN;
-    if (!Number.isFinite(d) || d >= t) continue;
-    if (d > bestT) {
+    const d = releaseDayValue(r.data?.releaseDate);
+    const isEarlierVersionOnTargetDay = d === t && compareVersions(ver, targetVer) < 0;
+    if (!Number.isFinite(d) || d > t || (d === t && !isEarlierVersionOnTargetDay)) continue;
+    const bestVer = best?.data?.ver ?? best?.id;
+    if (d > bestT || (d === bestT && compareVersions(ver, bestVer) > 0)) {
       best = r;
       bestT = d;
     }
   }
   return best;
+}
+
+function releaseDayValue(value) {
+  if (!value) return NaN;
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return NaN;
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function compareVersions(a, b) {
+  return String(a ?? "").localeCompare(String(b ?? ""), "en", {
+    numeric: true,
+    sensitivity: "base",
+  });
 }
 
 function isPreReleaseVersion(ver) {
@@ -109,6 +125,11 @@ export function augmentWithDeltas(payload, prior) {
   const priorScenarios = new Map(
     (prior.data.scenarios ?? []).map((s) => [s.id, s]),
   );
+  const priorHeadlines = new Map(
+    (prior.data.headline ?? [])
+      .filter((headline) => headline.scenarioId && headline.metric && headline.unit)
+      .map((headline) => [headlineIdentity(headline), headline]),
+  );
   const currScenarios = new Map(
     (next.scenarios ?? []).map((s) => [s.id, s]),
   );
@@ -123,9 +144,9 @@ export function augmentWithDeltas(payload, prior) {
   if (Array.isArray(next.headline)) {
     next.headline = next.headline.map((h) => {
       if (h.deltaPct != null && h.vsVer != null) return h;
-      if (!h.scenarioId) return h;
-      const ps = priorScenarios.get(h.scenarioId);
-      const dp = pctDelta(h.value ?? null, ps?.value ?? null);
+      if (!h.scenarioId || !h.metric || !h.unit) return h;
+      const priorHeadline = priorHeadlines.get(headlineIdentity(h));
+      const dp = pctDelta(h.value ?? null, priorHeadline?.value ?? null);
       if (dp == null) return h;
       return { ...h, vsVer: prior.data.ver, deltaPct: round1(dp) };
     });
@@ -142,7 +163,7 @@ export function augmentWithDeltas(payload, prior) {
       if (dp == null) continue;
       rows.push({
         scenarioId: id,
-        metric: cs.worstMetric?.name ?? id,
+        metric: cs.metric ?? id,
         before: ps.value,
         after: cs.value,
         unit: cs.unit,
@@ -156,6 +177,10 @@ export function augmentWithDeltas(payload, prior) {
   }
 
   return next;
+}
+
+function headlineIdentity(headline) {
+  return `${headline.scenarioId}\u0000${headline.metric}\u0000${headline.unit}`;
 }
 
 /**

--- a/web/src/content/releases/2026.5.26.json
+++ b/web/src/content/releases/2026.5.26.json
@@ -494,14 +494,14 @@
           "metrics": [
             {
               "name": "full turn",
-              "value": 2023,
+              "value": 1960,
               "unit": "ms",
               "threshold": 45000,
               "state": "pass"
             },
             {
               "name": "cold turn",
-              "value": 2023,
+              "value": 1960,
               "unit": "ms",
               "threshold": 45000,
               "state": "pass"
@@ -515,14 +515,14 @@
             },
             {
               "name": "pre-provider",
-              "value": 1675,
+              "value": 1630,
               "unit": "ms",
               "threshold": 10000,
               "state": "pass"
             },
             {
               "name": "provider",
-              "value": 4,
+              "value": 10,
               "unit": "ms",
               "threshold": 3000,
               "state": "pass"
@@ -536,7 +536,7 @@
             },
             {
               "name": "↳ cold send rpc",
-              "value": 11,
+              "value": 13,
               "unit": "ms",
               "threshold": null,
               "state": "pass",
@@ -544,7 +544,7 @@
             },
             {
               "name": "↳ cold matched assistant",
-              "value": 2023,
+              "value": 1960,
               "unit": "ms",
               "threshold": null,
               "state": "pass",
@@ -552,7 +552,7 @@
             },
             {
               "name": "↳ warm send rpc",
-              "value": 81,
+              "value": 84,
               "unit": "ms",
               "threshold": null,
               "state": "pass",
@@ -649,14 +649,14 @@
           "metrics": [
             {
               "name": "full turn",
-              "value": 5540,
+              "value": 5643,
               "unit": "ms",
               "threshold": 45000,
               "state": "pass"
             },
             {
               "name": "cold turn",
-              "value": 5507,
+              "value": 5643,
               "unit": "ms",
               "threshold": 45000,
               "state": "pass"
@@ -670,21 +670,21 @@
             },
             {
               "name": "pre-provider",
-              "value": 5257,
+              "value": 5332,
               "unit": "ms",
               "threshold": 10000,
               "state": "pass"
             },
             {
               "name": "provider",
-              "value": 7,
+              "value": 9,
               "unit": "ms",
               "threshold": 3000,
               "state": "pass"
             },
             {
               "name": "post-provider",
-              "value": 276,
+              "value": 289,
               "unit": "ms",
               "threshold": null,
               "state": "pass"
@@ -795,35 +795,35 @@
           "metrics": [
             {
               "name": "full turn",
-              "value": 5654,
+              "value": 5833,
               "unit": "ms",
               "threshold": 45000,
               "state": "pass"
             },
             {
               "name": "cold turn",
-              "value": 3232,
+              "value": 3398,
               "unit": "ms",
               "threshold": null,
               "state": "pass"
             },
             {
               "name": "warm turn",
-              "value": 2379,
+              "value": 2431,
               "unit": "ms",
               "threshold": null,
               "state": "pass"
             },
             {
               "name": "pre-provider",
-              "value": 285,
+              "value": 331,
               "unit": "ms",
               "threshold": 10000,
               "state": "pass"
             },
             {
               "name": "provider",
-              "value": 5294,
+              "value": 5431,
               "unit": "ms",
               "threshold": 3000,
               "state": "fail"
@@ -1209,7 +1209,7 @@
             {
               "name": "openai-compatible-turn",
               "elapsedMs": 249,
-              "state": "pass"
+              "state": "fail"
             },
             {
               "name": "auth-cleanup",
@@ -1220,14 +1220,14 @@
           "metrics": [
             {
               "name": "full turn",
-              "value": 276,
+              "value": 249,
               "unit": "ms",
               "threshold": 45000,
               "state": "pass"
             },
             {
               "name": "cold turn",
-              "value": 276,
+              "value": 249,
               "unit": "ms",
               "threshold": null,
               "state": "pass"


### PR DESCRIPTION
## What Problem This Solves

Published Kova releases could choose the wrong same-day prior, compare incompatible metric units, label a scenario delta with the wrong metric, and project only the first repeated turn sample.

## Why This Change Was Made

Release projections now select prior versions numerically, match headlines by scenario/metric/unit identity, use the measured scenario metric as the label, and median-aggregate repeated primary and child turn measurements.

## User Impact

Release pages show trustworthy deltas and representative repeated-run timings. The committed `2026.5.26` payload is regenerated from the corrected deterministic projection.

## Evidence

- web payload contract 1/1
- snapshots 21/21
- web tests 6/6
- Astro check: 0 diagnostics
- Astro build: 18 pages
- deterministic payload SHA-256 `85d4be54fe5b0028e60516b968eb31f81624b5ac2e6dc7fc52043534566189ee`
- Codex autoreview with `gpt-5.6-sol`, high reasoning: clean, confidence 0.91
- `git diff --check`
