### PR TITLE
fix(registries): harden catalog and evaluation integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ All notable changes to Kova are documented in this file.
 - Hardened release validation against missing, malformed, misplaced, partial, or incomplete provider, health, snapshot, plugin-security, command-timing, and measurement evidence.
 - Hardened runtime teardown with collision-resistant local-build names, exact OCM missing-resource matching, awaited proxy shutdown, and independent cleanup stages.
 - Centralized disposable environment cleanup in Kova's lifecycle and removed stale scenario cleanup commands and unused raw selector substitutions.
+- Hardened registry and evaluation integrity for capability catalogs, workflow derivation, thresholds, and malformed harness evidence.

--- a/scenarios/cross-platform-smoke.json
+++ b/scenarios/cross-platform-smoke.json
@@ -19,7 +19,7 @@
   "thresholds": {
     "gatewayReadyMs": 45000,
     "healthMs": 5000,
-    "syncFsStallDetected": false
+    "syncFsStallDetected": 0
   },
   "phases": [
     {

--- a/scenarios/failure-injection.json
+++ b/scenarios/failure-injection.json
@@ -11,8 +11,8 @@
     "gateway"
   ],
   "thresholds": {
-    "gatewaySurvives": true,
-    "diagnosticPresent": true,
+    "gatewaySurvives": 1,
+    "diagnosticPresent": 1,
     "statusAfterFailureMs": 10000
   },
   "phases": [

--- a/scenarios/provider-models.json
+++ b/scenarios/provider-models.json
@@ -12,7 +12,7 @@
   "thresholds": {
     "modelsListMs": 20000,
     "statusAfterModelsMs": 10000,
-    "gatewayResponsive": true
+    "gatewayResponsive": 1
   },
   "phases": [
     {

--- a/src/evaluation/thresholds.mjs
+++ b/src/evaluation/thresholds.mjs
@@ -46,7 +46,19 @@ function thresholdSources({ profile, surface, surfaceCalibration, scenario, deri
     sources.push({ kind: "profile-role", id: profile.id, roles: Object.keys(profile.calibration.roles).sort() });
   }
   if (scenario?.thresholds && Object.keys(scenario.thresholds).length > 0) {
-    sources.push({ kind: "scenario", id: scenario.id, thresholds: Object.keys(scenario.thresholds).sort() });
+    const thresholds = Object.keys(scenario.thresholds)
+      .filter((key) => key !== "roleThresholds")
+      .sort();
+    if (thresholds.length > 0) {
+      sources.push({ kind: "scenario", id: scenario.id, thresholds });
+    }
+  }
+  if (scenario?.thresholds?.roleThresholds && Object.keys(scenario.thresholds.roleThresholds).length > 0) {
+    sources.push({
+      kind: "scenario-role",
+      id: scenario.id,
+      roles: Object.keys(scenario.thresholds.roleThresholds).sort()
+    });
   }
   if (derived.length > 0) {
     sources.push({ kind: "derived", id: "health-sample-failures", thresholds: derived });

--- a/src/evaluation/violations.mjs
+++ b/src/evaluation/violations.mjs
@@ -1,10 +1,13 @@
 export function checkDuration(violations, results, metric, threshold, predicate) {
-  if (typeof threshold !== "number") {
+  if (!activeFiniteThreshold(violations, metric, threshold)) {
     return;
   }
 
   for (const result of results) {
     if (!predicate(result.command)) {
+      continue;
+    }
+    if (!finiteNonNegativeMeasurement(violations, metric, result.durationMs, "durationMs")) {
       continue;
     }
     if (result.durationMs > threshold) {
@@ -21,7 +24,10 @@ export function checkDuration(violations, results, metric, threshold, predicate)
 }
 
 export function checkEvidenceThreshold(violations, kind, metric, actual, threshold, label) {
-  if (typeof threshold !== "number" || actual === null) {
+  if (!activeFiniteThreshold(violations, metric, threshold)) {
+    return;
+  }
+  if (!finiteNonNegativeMeasurement(violations, metric, actual, "measurement")) {
     return;
   }
   if (actual > threshold) {
@@ -41,8 +47,16 @@ export function checkRoleThresholds(violations, byRole, roleThresholds) {
     if (!summary) {
       continue;
     }
-    if (typeof thresholds.peakRssMb === "number" && typeof summary.peakRssMb === "number" &&
-      summary.peakRssMb > thresholds.peakRssMb) {
+    if (
+      activeFiniteThreshold(violations, `resourceByRole.${role}.peakRssMb`, thresholds.peakRssMb) &&
+      finiteNonNegativeMeasurement(
+        violations,
+        `resourceByRole.${role}.peakRssMb`,
+        summary.peakRssMb,
+        "measurement"
+      ) &&
+      summary.peakRssMb > thresholds.peakRssMb
+    ) {
       violations.push({
         kind: "resource",
         metric: `resourceByRole.${role}.peakRssMb`,
@@ -54,8 +68,20 @@ export function checkRoleThresholds(violations, byRole, roleThresholds) {
       });
     }
     const peakProcessRssMb = summary.peakRssProcess?.rssMb;
-    if (typeof thresholds.peakProcessRssMb === "number" && typeof peakProcessRssMb === "number" &&
-      peakProcessRssMb > thresholds.peakProcessRssMb) {
+    if (
+      activeFiniteThreshold(
+        violations,
+        `resourceByRole.${role}.peakProcessRssMb`,
+        thresholds.peakProcessRssMb
+      ) &&
+      finiteNonNegativeMeasurement(
+        violations,
+        `resourceByRole.${role}.peakProcessRssMb`,
+        peakProcessRssMb,
+        "measurement"
+      ) &&
+      peakProcessRssMb > thresholds.peakProcessRssMb
+    ) {
       violations.push({
         kind: "resource",
         metric: `resourceByRole.${role}.peakProcessRssMb`,
@@ -66,8 +92,20 @@ export function checkRoleThresholds(violations, byRole, roleThresholds) {
         message: `${role} peak process RSS ${peakProcessRssMb} MB exceeded threshold ${thresholds.peakProcessRssMb} MB`
       });
     }
-    if (typeof thresholds.maxCpuPercent === "number" && typeof summary.maxCpuPercent === "number" &&
-      summary.maxCpuPercent > thresholds.maxCpuPercent) {
+    if (
+      activeFiniteThreshold(
+        violations,
+        `resourceByRole.${role}.maxCpuPercent`,
+        thresholds.maxCpuPercent
+      ) &&
+      finiteNonNegativeMeasurement(
+        violations,
+        `resourceByRole.${role}.maxCpuPercent`,
+        summary.maxCpuPercent,
+        "measurement"
+      ) &&
+      summary.maxCpuPercent > thresholds.maxCpuPercent
+    ) {
       violations.push({
         kind: "resource",
         metric: `resourceByRole.${role}.maxCpuPercent`,
@@ -92,7 +130,10 @@ function resourceAttribution(role, summary) {
 }
 
 export function checkAggregateThreshold(violations, actual, metric, threshold) {
-  if (typeof threshold !== "number" || typeof actual !== "number" || actual <= threshold) {
+  if (!activeFiniteThreshold(violations, metric, threshold)) {
+    return;
+  }
+  if (!finiteNonNegativeMeasurement(violations, metric, actual, "measurement") || actual <= threshold) {
     return;
   }
   violations.push({
@@ -105,7 +146,11 @@ export function checkAggregateThreshold(violations, actual, metric, threshold) {
 }
 
 export function checkBooleanThreshold(violations, kind, metric, actual, threshold, message) {
-  if (typeof threshold !== "number" || actual === null || actual === undefined) {
+  if (!activeFiniteThreshold(violations, metric, threshold)) {
+    return;
+  }
+  if (typeof actual !== "boolean") {
+    malformedEvidence(violations, metric, "boolean measurement", actual);
     return;
   }
   const expected = threshold >= 1;
@@ -121,7 +166,13 @@ export function checkBooleanThreshold(violations, kind, metric, actual, threshol
 }
 
 export function checkTurnThreshold(violations, turn, metric, threshold, message) {
-  if (!turn || typeof threshold !== "number" || typeof turn[metric] !== "number" || turn[metric] <= threshold) {
+  if (!turn || !activeFiniteThreshold(violations, metric, threshold)) {
+    return;
+  }
+  if (
+    !finiteNonNegativeMeasurement(violations, metric, turn[metric], "turn measurement") ||
+    turn[metric] <= threshold
+  ) {
     return;
   }
   violations.push({
@@ -132,4 +183,51 @@ export function checkTurnThreshold(violations, turn, metric, threshold, message)
     actual: turn[metric],
     message: `${message}, over threshold ${threshold}ms`
   });
+}
+
+function activeFiniteThreshold(violations, metric, threshold) {
+  if (threshold === undefined) {
+    return false;
+  }
+  if (!Number.isFinite(threshold) || threshold < 0) {
+    malformedEvidence(violations, metric, "finite non-negative threshold", threshold);
+    return false;
+  }
+  return true;
+}
+
+function finiteNonNegativeMeasurement(violations, metric, actual, label) {
+  if (!Number.isFinite(actual) || actual < 0) {
+    malformedEvidence(violations, metric, `finite non-negative ${label}`, actual);
+    return false;
+  }
+  return true;
+}
+
+function malformedEvidence(violations, metric, expected, actual) {
+  violations.push({
+    kind: "kova-evidence",
+    failureDomain: "kova-harness",
+    metric,
+    expected,
+    actual: describeValue(actual),
+    message: `${metric} contained malformed Kova evidence: expected ${expected}, got ${describeValue(actual)}`
+  });
+}
+
+function describeValue(value) {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -1197,7 +1197,7 @@ export function evaluateRecord(record, scenario, options = {}) {
     const malformedKovaEvidence = violations.some(
       (violation) => violation.failureDomain === "kova-harness"
     );
-    if (malformedKovaEvidence) {
+    if (malformedKovaEvidence && originalStatus === "PASS") {
       record.status = "BLOCKED";
     } else if (originalStatus === "PASS") {
       record.status = "FAIL";

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -1194,7 +1194,12 @@ export function evaluateRecord(record, scenario, options = {}) {
   record.thresholdPolicy = thresholdPolicy.report;
 
   if (violations.length > 0) {
-    if (originalStatus === "PASS") {
+    const malformedKovaEvidence = violations.some(
+      (violation) => violation.failureDomain === "kova-harness"
+    );
+    if (malformedKovaEvidence) {
+      record.status = "BLOCKED";
+    } else if (originalStatus === "PASS") {
       record.status = "FAIL";
     }
     record.violations = violations;

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -1194,13 +1194,11 @@ export function evaluateRecord(record, scenario, options = {}) {
   record.thresholdPolicy = thresholdPolicy.report;
 
   if (violations.length > 0) {
-    const malformedKovaEvidence = violations.some(
-      (violation) => violation.failureDomain === "kova-harness"
-    );
-    if (malformedKovaEvidence && originalStatus === "PASS") {
-      record.status = "BLOCKED";
-    } else if (originalStatus === "PASS") {
-      record.status = "FAIL";
+    if (originalStatus === "PASS") {
+      const targetViolation = violations.some(
+        (violation) => violation.failureDomain !== "kova-harness"
+      );
+      record.status = targetViolation ? "FAIL" : "BLOCKED";
     }
     record.violations = violations;
   } else {

--- a/src/registries/channel-capabilities.mjs
+++ b/src/registries/channel-capabilities.mjs
@@ -45,6 +45,7 @@ export async function loadChannelCapabilities(selectedId) {
     loadChannelWorkflowCaseCatalog()
   ]);
   const catalogMap = channelCapabilityCatalogMap(capabilityCatalogs);
+  validateChannelProofPolicyReferences(proofPolicy, capabilityCatalogs);
   const workflowCases = workflowCatalogs.flatMap((catalog) => catalog.cases ?? []);
   return filtered.map((platform) => channelCapabilityFromPlatform(platform, catalogMap, proofPolicy, workflowCases));
 }
@@ -91,7 +92,7 @@ function channelCapabilityFromPlatform(platform, catalogMap, proofPolicy, workfl
       id,
       group,
       catalogId,
-      title: catalogCapability?.title ?? catalogId,
+      title: catalogCapability?.capability?.title ?? catalogId,
       requiredLevel: proof.requiredLevel,
       proofModes: proof.proofModes,
       declarationSource: declarationSourceFor(platform, group)
@@ -164,6 +165,19 @@ export function validateChannelCapabilityCatalogReferences(channels, catalogs) {
     }
   }
   assertNoShapeErrors(errors, "channel capability catalog references");
+}
+
+export function validateChannelProofPolicyReferences(policy, catalogs) {
+  const catalogMap = channelCapabilityCatalogMap(catalogs);
+  const errors = [];
+  for (const field of ["blockingCapabilities", "liveSmokeCapabilities"]) {
+    for (const key of policy?.[field] ?? []) {
+      if (!catalogMap.has(key)) {
+        errors.push(`${field} references unknown channel capability '${key}'`);
+      }
+    }
+  }
+  assertNoShapeErrors(errors, "channel proof policy references");
 }
 
 export function validateChannelCapabilityWorkflowReferences(channels, workflowCatalogs) {

--- a/src/registries/channel-capability-catalog.mjs
+++ b/src/registries/channel-capability-catalog.mjs
@@ -78,7 +78,14 @@ export function channelCapabilityCatalogMap(catalogs) {
   const map = new Map();
   for (const catalog of catalogs ?? []) {
     for (const capability of catalog.capabilities ?? []) {
-      map.set(`${capability.group}:${capability.id}`, { catalog, capability });
+      const key = `${capability.group}:${capability.id}`;
+      const existing = map.get(key);
+      if (existing) {
+        throw new Error(
+          `duplicate channel capability '${key}' across catalogs '${existing.catalog.id}' and '${catalog.id}'`
+        );
+      }
+      map.set(key, { catalog, capability });
     }
   }
   return map;

--- a/src/registries/channel-workflow-families.mjs
+++ b/src/registries/channel-workflow-families.mjs
@@ -106,7 +106,7 @@ export async function loadChannelWorkflowFamilies(selectedId) {
 }
 
 export function workflowInventoryFromFamilies(families) {
-  return [{
+  const inventories = [{
     schemaVersion: "kova.channelWorkflowInventory.v1",
     id: "openclaw-channel-workflow-inventory",
     title: "OpenClaw Channel Workflow Inventory",
@@ -127,10 +127,14 @@ export function workflowInventoryFromFamilies(families) {
       ...(Array.isArray(family.unsupported) ? { unsupported: family.unsupported } : {})
     }))
   }];
+  for (const inventory of inventories) {
+    validateWorkflowInventoryCatalogShape(inventory, "derived channel workflow inventory");
+  }
+  return inventories;
 }
 
 export function workflowCaseCatalogFromFamilies(families) {
-  return [{
+  const catalogs = [{
     schemaVersion: "kova.channelWorkflowCaseCatalog.v1",
     id: "openclaw-channel-workflow-cases",
     title: "OpenClaw Channel Workflow Cases",
@@ -141,6 +145,10 @@ export function workflowCaseCatalogFromFamilies(families) {
       ownerArea: testCase.ownerArea ?? family.ownerArea
     })))
   }];
+  for (const catalog of catalogs) {
+    validateWorkflowCaseCatalogShape(catalog, "derived channel workflow case catalog");
+  }
+  return catalogs;
 }
 
 export function validateWorkflowInventoryCatalogShape(inventory, sourceName = "channel workflow inventory") {

--- a/src/registries/profiles.mjs
+++ b/src/registries/profiles.mjs
@@ -94,8 +94,8 @@ function validateThresholdMap(map, prefix, errors, options = {}) {
       validateThresholdMap(value, `${prefix}.${key}`, errors);
       continue;
     }
-    if (typeof value !== "number" || !Number.isFinite(value)) {
-      errors.push(`${prefix}.${key} must be a finite number`);
+    if (!Number.isFinite(value) || value < 0) {
+      errors.push(`${prefix}.${key} must be a finite non-negative number`);
     }
   }
 }

--- a/src/registries/surfaces.mjs
+++ b/src/registries/surfaces.mjs
@@ -128,8 +128,8 @@ function validateRoleThresholds(value, prefix, errors) {
       continue;
     }
     for (const key of ["peakRssMb", "peakProcessRssMb", "maxCpuPercent"]) {
-      if (thresholds[key] !== undefined && (typeof thresholds[key] !== "number" || thresholds[key] < 0)) {
-        errors.push(`${prefix}.${role}.${key} must be a non-negative number when set`);
+      if (thresholds[key] !== undefined && (!Number.isFinite(thresholds[key]) || thresholds[key] < 0)) {
+        errors.push(`${prefix}.${role}.${key} must be a finite non-negative number when set`);
       }
     }
   }

--- a/src/registries/validate.mjs
+++ b/src/registries/validate.mjs
@@ -114,7 +114,13 @@ function validateScenarioContract(scenario, surface, refs, errors) {
       errors.push(`scenario '${scenario.id}' proves unknown surface requirement '${surface.id}.${requirement}'`);
     }
   }
-  validateThresholdMetrics(scenario.thresholds ?? {}, refs.metricIds, errors, `scenario '${scenario.id}' thresholds`);
+  validateThresholdMetrics(
+    scenario.thresholds ?? {},
+    refs.metricIds,
+    errors,
+    `scenario '${scenario.id}' thresholds`,
+    refs.processRoleIds
+  );
 }
 
 function validateSurfaceRequirements(surface, refs, errors) {
@@ -147,16 +153,36 @@ function validateMetricList(metrics, metricIds, errors, prefix) {
   }
 }
 
-function validateThresholdMetrics(thresholds, metricIds, errors, prefix) {
+function validateThresholdMetrics(thresholds, metricIds, errors, prefix, processRoleIds) {
   for (const [metric, value] of Object.entries(thresholds ?? {})) {
     if (metric === "roleThresholds") {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        errors.push(`${prefix}.roleThresholds must be an object`);
+        continue;
+      }
       for (const [role, roleThresholds] of Object.entries(value ?? {})) {
-        validateThresholdMetrics(roleThresholds, metricIds, errors, `${prefix}.roleThresholds.${role}`);
+        if (processRoleIds && !processRoleIds.has(role)) {
+          errors.push(`${prefix}.roleThresholds references unknown process role '${role}'`);
+        }
+        if (!roleThresholds || typeof roleThresholds !== "object" || Array.isArray(roleThresholds)) {
+          errors.push(`${prefix}.roleThresholds.${role} must be an object`);
+          continue;
+        }
+        validateThresholdMetrics(
+          roleThresholds,
+          metricIds,
+          errors,
+          `${prefix}.roleThresholds.${role}`,
+          processRoleIds
+        );
       }
       continue;
     }
     if (!metricIds.has(metric)) {
       errors.push(`${prefix} references unknown metric '${metric}'`);
+    }
+    if (!Number.isFinite(value) || value < 0) {
+      errors.push(`${prefix}.${metric} must be a finite non-negative number`);
     }
   }
 }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1391,6 +1391,16 @@ function evaluationViolationHelpersCheck() {
       true,
       "blocked record preserves malformed evidence reason"
     );
+    const failedMalformedRecord = {
+      status: "FAIL",
+      phases: structuredClone(malformedRecord.phases)
+    };
+    evaluateRecord(failedMalformedRecord, { thresholds: { statusMs: 50 } });
+    assertEqual(
+      failedMalformedRecord.status,
+      "FAIL",
+      "malformed Kova evidence does not hide an established target failure"
+    );
     return {
       id: "evaluation-violation-helpers",
       status: "PASS",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1401,6 +1401,27 @@ function evaluationViolationHelpersCheck() {
       "FAIL",
       "malformed Kova evidence does not hide an established target failure"
     );
+    const mixedRecord = {
+      status: "PASS",
+      phases: [{
+        id: "status",
+        results: [{
+          command: "ocm @kova-self-check -- status",
+          status: 0,
+          durationMs: 51
+        }, {
+          command: "ocm @kova-self-check -- status",
+          status: 0,
+          durationMs: "malformed"
+        }]
+      }]
+    };
+    evaluateRecord(mixedRecord, { thresholds: { statusMs: 50 } });
+    assertEqual(
+      mixedRecord.status,
+      "FAIL",
+      "confirmed target violations take precedence over malformed Kova evidence"
+    );
     return {
       id: "evaluation-violation-helpers",
       status: "PASS",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -36,10 +36,15 @@ import {
 import {
   loadChannelCapabilities,
   validateChannelCapabilityCatalogReferences,
+  validateChannelProofPolicyReferences,
   validateChannelCapabilityWorkflowReferences,
   validateChannelCapabilityShape
 } from "./registries/channel-capabilities.mjs";
 import { loadChannelCapabilityCatalog, validateChannelCapabilityCatalogShape } from "./registries/channel-capability-catalog.mjs";
+import {
+  workflowCaseCatalogFromFamilies,
+  workflowInventoryFromFamilies
+} from "./registries/channel-workflow-families.mjs";
 import { loadChannelWorkflowInventory, validateChannelWorkflowInventoryReferences } from "./registries/channel-workflow-inventory.mjs";
 import {
   loadChannelWorkflowCaseCatalog,
@@ -1343,6 +1348,49 @@ function evaluationViolationHelpersCheck() {
     assertEqual(violations.length, 6, "violation helper count");
     assertEqual(violations.some((violation) => violation.metric === "resourceByRole.gateway.peakRssMb"), true, "role RSS violation");
     assertEqual(violations.some((violation) => violation.phaseId === "turn"), true, "turn threshold violation");
+
+    const malformed = [];
+    checkDuration(
+      malformed,
+      [{ command: "openclaw status", durationMs: "51" }],
+      "statusMs",
+      50,
+      (command) => command.includes("status")
+    );
+    checkEvidenceThreshold(malformed, "media", "mediaDescribeMs", Number.NaN, 100, "Media describe");
+    checkAggregateThreshold(malformed, null, "agentTurnP95Ms", 200);
+    checkTurnThreshold(
+      malformed,
+      { phaseId: "turn", preProviderMs: undefined },
+      "preProviderMs",
+      300,
+      "pre-provider latency was malformed"
+    );
+    assertEqual(malformed.length, 4, "malformed helper payload count");
+    assertEqual(
+      malformed.every((violation) => violation.failureDomain === "kova-harness"),
+      true,
+      "malformed helper payloads are Kova harness blockers"
+    );
+
+    const malformedRecord = {
+      status: "PASS",
+      phases: [{
+        id: "status",
+        results: [{
+          command: "ocm @kova-self-check -- status",
+          status: 0,
+          durationMs: "51"
+        }]
+      }]
+    };
+    evaluateRecord(malformedRecord, { thresholds: { statusMs: 50 } });
+    assertEqual(malformedRecord.status, "BLOCKED", "malformed Kova evidence blocks the record");
+    assertEqual(
+      malformedRecord.violations.some((violation) => violation.failureDomain === "kova-harness"),
+      true,
+      "blocked record preserves malformed evidence reason"
+    );
     return {
       id: "evaluation-violation-helpers",
       status: "PASS",
@@ -14127,6 +14175,21 @@ function thresholdPolicyCalibrationCheck() {
       true,
       "profile calibrated role violation"
     );
+    const scenarioRolePolicy = resolveThresholdPolicy({
+      scenario: {
+        id: "scenario-role-policy",
+        thresholds: {
+          coldReadyMs: 100,
+          roleThresholds: {
+            gateway: { peakRssMb: 200 }
+          }
+        }
+      }
+    });
+    const scenarioSource = scenarioRolePolicy.report.sources.find((source) => source.kind === "scenario");
+    const scenarioRoleSource = scenarioRolePolicy.report.sources.find((source) => source.kind === "scenario-role");
+    assertEqual(JSON.stringify(scenarioSource?.thresholds), JSON.stringify(["coldReadyMs"]), "scenario scalar threshold provenance");
+    assertEqual(JSON.stringify(scenarioRoleSource?.roles), JSON.stringify(["gateway"]), "scenario role threshold provenance");
     return {
       id: "threshold-policy-calibration",
       status: "PASS",
@@ -14548,6 +14611,78 @@ function stateRegistryValidationCheck() {
     }
     assertEqual(rejectedMetric, true, "unknown scenario metric rejected");
 
+    for (const value of ["100", true, {}, Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+      let rejectedThresholdValue = false;
+      try {
+        validateRegistryReferences({
+          scenarios: [{
+            id: "scenario",
+            surface: "known-surface",
+            proves: ["baseline"],
+            thresholds: { knownMetric: value },
+            states: [],
+            targetKinds: [],
+            processRoles: []
+          }],
+          states: [],
+          profiles: [],
+          surfaces: [{
+            id: "known-surface",
+            processRoles: [],
+            thresholds: {},
+            requirements: [{
+              id: "baseline",
+              states: [],
+              targetKinds: ["runtime"],
+              metrics: ["knownMetric"]
+            }]
+          }],
+          processRoles: [],
+          metrics: [{ id: "knownMetric" }]
+        });
+      } catch (error) {
+        rejectedThresholdValue = /must be a finite non-negative number/.test(error.message);
+      }
+      assertEqual(rejectedThresholdValue, true, `invalid threshold value ${String(value)} rejected`);
+    }
+
+    let rejectedScenarioRoleThreshold = false;
+    try {
+      validateRegistryReferences({
+        scenarios: [{
+          id: "scenario",
+          surface: "known-surface",
+          proves: ["baseline"],
+          thresholds: {
+            roleThresholds: {
+              gateway: { knownMetric: -1 }
+            }
+          },
+          states: [],
+          targetKinds: [],
+          processRoles: ["gateway"]
+        }],
+        states: [],
+        profiles: [],
+        surfaces: [{
+          id: "known-surface",
+          processRoles: ["gateway"],
+          thresholds: {},
+          requirements: [{
+            id: "baseline",
+            states: [],
+            targetKinds: ["runtime"],
+            metrics: ["knownMetric"]
+          }]
+        }],
+        processRoles: [{ id: "gateway" }],
+        metrics: [{ id: "knownMetric" }]
+      });
+    } catch (error) {
+      rejectedScenarioRoleThreshold = /roleThresholds\.gateway\.knownMetric must be a finite non-negative number/.test(error.message);
+    }
+    assertEqual(rejectedScenarioRoleThreshold, true, "invalid scenario role threshold rejected");
+
     let rejectedCalibration = false;
     try {
       validateRegistryReferences({
@@ -14879,6 +15014,11 @@ async function channelCapabilityRegistryCheck() {
     assertEqual(telegram.capabilities.every((capability) =>
       capability.catalogId === `${capability.group}:${capability.id}`
     ), true, "telegram capabilities reference OpenClaw catalog ids");
+    assertEqual(
+      telegram.capabilities.every((capability) => capability.title !== capability.catalogId),
+      true,
+      "channel capability titles resolve from the OpenClaw catalog"
+    );
     assertEqual(telegram.workflowCaseIds?.includes("source-visible-delivery.media.message-tool-only"), true, "telegram maps to shared source media workflow case");
     assertEqual(telegram.workflowCoverage?.schemaVersion, "kova.channelWorkflowCoverage.v1", "telegram exposes derived workflow coverage");
     assertEqual(telegram.workflowCoverage?.selectedCount, telegram.workflowCaseIds?.length, "telegram workflow coverage selected count matches selected case ids");
@@ -15029,6 +15169,83 @@ async function channelCapabilityRegistryCheck() {
       rejectedCatalogReference = /not defined in the OpenClaw channel capability catalog/.test(error.message);
     }
     assertEqual(rejectedCatalogReference, true, "channel capability must reference OpenClaw catalog");
+
+    let rejectedCatalogCollision = false;
+    try {
+      validateChannelCapabilityCatalogReferences([], [
+        {
+          id: "first-catalog",
+          capabilities: [{ id: "text", group: "durable-final" }]
+        },
+        {
+          id: "second-catalog",
+          capabilities: [{ id: "text", group: "durable-final" }]
+        }
+      ]);
+    } catch (error) {
+      rejectedCatalogCollision = /across catalogs 'first-catalog' and 'second-catalog'/.test(error.message);
+    }
+    assertEqual(rejectedCatalogCollision, true, "cross-catalog capability collisions are rejected");
+
+    for (const field of ["blockingCapabilities", "liveSmokeCapabilities"]) {
+      let rejectedProofPolicyReference = false;
+      try {
+        validateChannelProofPolicyReferences({
+          [field]: ["durable-final:imaginary"]
+        }, catalogs);
+      } catch (error) {
+        rejectedProofPolicyReference = new RegExp(`${field} references unknown channel capability`).test(error.message);
+      }
+      assertEqual(rejectedProofPolicyReference, true, `${field} must reference OpenClaw catalog capabilities`);
+    }
+
+    const duplicateFamily = {
+      id: "duplicate-family",
+      title: "Duplicate Family",
+      userAction: "user sends a message",
+      openclawSurface: "message delivery",
+      ownerArea: "channels",
+      sourceRefs: ["src/channels/message/types.ts#L1"],
+      contentKinds: ["text"],
+      routeKinds: ["direct"],
+      deliveryModes: ["final"],
+      lifecycles: ["success"],
+      atoms: [{ group: "durable-final", id: "text" }],
+      cases: [{
+        id: "duplicate.case",
+        workflow: "duplicate-family",
+        userAction: "user sends a message",
+        openclawSurface: "message delivery",
+        prompt: "reply with a short message",
+        providerScript: {},
+        expects: {},
+        matrix: {
+          content: "text",
+          route: "direct",
+          delivery: "final",
+          lifecycle: "success"
+        },
+        atoms: [{ group: "durable-final", id: "text" }]
+      }]
+    };
+    let rejectedDerivedInventory = false;
+    try {
+      workflowInventoryFromFamilies([duplicateFamily, duplicateFamily]);
+    } catch (error) {
+      rejectedDerivedInventory = /duplicate channel workflow inventory workflow/.test(error.message);
+    }
+    assertEqual(rejectedDerivedInventory, true, "derived workflow inventories validate duplicate family ids");
+
+    let rejectedDerivedCaseCatalog = false;
+    try {
+      workflowCaseCatalogFromFamilies([duplicateFamily, {
+        ...duplicateFamily,
+        id: "other-family"
+      }]);
+    } catch (error) {
+      rejectedDerivedCaseCatalog = /duplicate channel workflow case/.test(error.message);
+    }
+    assertEqual(rejectedDerivedCaseCatalog, true, "derived workflow case catalogs validate duplicate case ids");
 
     let rejectedWorkflowCaseReference = false;
     try {

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -12141,18 +12141,6 @@
           ],
           "healthScope": "post-ready",
           "collectionIntent": "post-ready-health"
-        },
-        {
-          "id": "cleanup",
-          "title": "Cleanup",
-          "intent": "Destroy the disposable OpenClaw environment unless retained for debugging.",
-          "commands": [
-            "ocm env destroy {env} --yes"
-          ],
-          "evidence": [
-            "destroy result"
-          ],
-          "healthScope": "none"
         }
       ],
       "proves": [

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -7912,7 +7912,7 @@
           "id": "text",
           "group": "durable-final",
           "catalogId": "durable-final:text",
-          "title": "durable-final:text",
+          "title": "Durable Final Text",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim",
@@ -7924,7 +7924,7 @@
           "id": "media",
           "group": "durable-final",
           "catalogId": "durable-final:media",
-          "title": "durable-final:media",
+          "title": "Durable Final Media",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim",
@@ -7936,7 +7936,7 @@
           "id": "payload",
           "group": "durable-final",
           "catalogId": "durable-final:payload",
-          "title": "durable-final:payload",
+          "title": "Durable Final Payload",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim"
@@ -7947,7 +7947,7 @@
           "id": "reply-to",
           "group": "durable-final",
           "catalogId": "durable-final:reply-to",
-          "title": "durable-final:reply-to",
+          "title": "Durable Final Reply Target",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim"
@@ -7958,7 +7958,7 @@
           "id": "thread",
           "group": "durable-final",
           "catalogId": "durable-final:thread",
-          "title": "durable-final:thread",
+          "title": "Durable Final Thread Target",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim"
@@ -7969,7 +7969,7 @@
           "id": "silent",
           "group": "durable-final",
           "catalogId": "durable-final:silent",
-          "title": "durable-final:silent",
+          "title": "Durable Final Silent Delivery",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -7980,7 +7980,7 @@
           "id": "message-sending-hooks",
           "group": "durable-final",
           "catalogId": "durable-final:message-sending-hooks",
-          "title": "durable-final:message-sending-hooks",
+          "title": "Durable Final Message Sending Hooks",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -7991,7 +7991,7 @@
           "id": "manual",
           "group": "ack",
           "catalogId": "ack:manual",
-          "title": "ack:manual",
+          "title": "Manual Ack",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -8002,7 +8002,7 @@
           "id": "draft-preview",
           "group": "live-preview",
           "catalogId": "live-preview:draft-preview",
-          "title": "live-preview:draft-preview",
+          "title": "Live Draft Preview",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -8013,7 +8013,7 @@
           "id": "preview-finalization",
           "group": "live-preview",
           "catalogId": "live-preview:preview-finalization",
-          "title": "live-preview:preview-finalization",
+          "title": "Live Preview Finalization",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -8024,7 +8024,7 @@
           "id": "progress-updates",
           "group": "live-preview",
           "catalogId": "live-preview:progress-updates",
-          "title": "live-preview:progress-updates",
+          "title": "Live Progress Updates",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -8035,7 +8035,7 @@
           "id": "final-edit",
           "group": "live-finalizer",
           "catalogId": "live-finalizer:final-edit",
-          "title": "live-finalizer:final-edit",
+          "title": "Live Final Edit",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -8046,7 +8046,7 @@
           "id": "normal-fallback",
           "group": "live-finalizer",
           "catalogId": "live-finalizer:normal-fallback",
-          "title": "live-finalizer:normal-fallback",
+          "title": "Live Normal Fallback",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -8057,7 +8057,7 @@
           "id": "discard-pending",
           "group": "live-finalizer",
           "catalogId": "live-finalizer:discard-pending",
-          "title": "live-finalizer:discard-pending",
+          "title": "Live Discard Pending",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9124,7 +9124,7 @@
           "id": "text",
           "group": "durable-final",
           "catalogId": "durable-final:text",
-          "title": "durable-final:text",
+          "title": "Durable Final Text",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim",
@@ -9136,7 +9136,7 @@
           "id": "media",
           "group": "durable-final",
           "catalogId": "durable-final:media",
-          "title": "durable-final:media",
+          "title": "Durable Final Media",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim",
@@ -9148,7 +9148,7 @@
           "id": "payload",
           "group": "durable-final",
           "catalogId": "durable-final:payload",
-          "title": "durable-final:payload",
+          "title": "Durable Final Payload",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim"
@@ -9159,7 +9159,7 @@
           "id": "reply-to",
           "group": "durable-final",
           "catalogId": "durable-final:reply-to",
-          "title": "durable-final:reply-to",
+          "title": "Durable Final Reply Target",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim"
@@ -9170,7 +9170,7 @@
           "id": "thread",
           "group": "durable-final",
           "catalogId": "durable-final:thread",
-          "title": "durable-final:thread",
+          "title": "Durable Final Thread Target",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim"
@@ -9181,7 +9181,7 @@
           "id": "silent",
           "group": "durable-final",
           "catalogId": "durable-final:silent",
-          "title": "durable-final:silent",
+          "title": "Durable Final Silent Delivery",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9192,7 +9192,7 @@
           "id": "message-sending-hooks",
           "group": "durable-final",
           "catalogId": "durable-final:message-sending-hooks",
-          "title": "durable-final:message-sending-hooks",
+          "title": "Durable Final Message Sending Hooks",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9203,7 +9203,7 @@
           "id": "batch",
           "group": "durable-final",
           "catalogId": "durable-final:batch",
-          "title": "durable-final:batch",
+          "title": "Durable Final Batch",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9214,7 +9214,7 @@
           "id": "after-receive-record",
           "group": "ack",
           "catalogId": "ack:after-receive-record",
-          "title": "ack:after-receive-record",
+          "title": "Ack After Receive Record",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9225,7 +9225,7 @@
           "id": "after-agent-dispatch",
           "group": "ack",
           "catalogId": "ack:after-agent-dispatch",
-          "title": "ack:after-agent-dispatch",
+          "title": "Ack After Agent Dispatch",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim"
@@ -9236,7 +9236,7 @@
           "id": "draft-preview",
           "group": "live-preview",
           "catalogId": "live-preview:draft-preview",
-          "title": "live-preview:draft-preview",
+          "title": "Live Draft Preview",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9247,7 +9247,7 @@
           "id": "preview-finalization",
           "group": "live-preview",
           "catalogId": "live-preview:preview-finalization",
-          "title": "live-preview:preview-finalization",
+          "title": "Live Preview Finalization",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9258,7 +9258,7 @@
           "id": "progress-updates",
           "group": "live-preview",
           "catalogId": "live-preview:progress-updates",
-          "title": "live-preview:progress-updates",
+          "title": "Live Progress Updates",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9269,7 +9269,7 @@
           "id": "final-edit",
           "group": "live-finalizer",
           "catalogId": "live-finalizer:final-edit",
-          "title": "live-finalizer:final-edit",
+          "title": "Live Final Edit",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9280,7 +9280,7 @@
           "id": "normal-fallback",
           "group": "live-finalizer",
           "catalogId": "live-finalizer:normal-fallback",
-          "title": "live-finalizer:normal-fallback",
+          "title": "Live Normal Fallback",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9291,7 +9291,7 @@
           "id": "preview-receipt",
           "group": "live-finalizer",
           "catalogId": "live-finalizer:preview-receipt",
-          "title": "live-finalizer:preview-receipt",
+          "title": "Live Preview Receipt",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9302,7 +9302,7 @@
           "id": "retain-on-ambiguous-failure",
           "group": "live-finalizer",
           "catalogId": "live-finalizer:retain-on-ambiguous-failure",
-          "title": "live-finalizer:retain-on-ambiguous-failure",
+          "title": "Live Retain On Ambiguous Failure",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim"
@@ -9313,7 +9313,7 @@
           "id": "action-send",
           "group": "native-platform",
           "catalogId": "native-platform:action-send",
-          "title": "native-platform:action-send",
+          "title": "Message Tool Send Action",
           "requiredLevel": "blocking",
           "proofModes": [
             "deterministic-shim",
@@ -9325,7 +9325,7 @@
           "id": "action-poll",
           "group": "native-platform",
           "catalogId": "native-platform:action-poll",
-          "title": "native-platform:action-poll",
+          "title": "Message Tool Poll Action",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim",
@@ -9337,7 +9337,7 @@
           "id": "action-react",
           "group": "native-platform",
           "catalogId": "native-platform:action-react",
-          "title": "native-platform:action-react",
+          "title": "Message Tool React Action",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim",
@@ -9349,7 +9349,7 @@
           "id": "action-delete",
           "group": "native-platform",
           "catalogId": "native-platform:action-delete",
-          "title": "native-platform:action-delete",
+          "title": "Message Tool Delete Action",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim",
@@ -9361,7 +9361,7 @@
           "id": "action-edit",
           "group": "native-platform",
           "catalogId": "native-platform:action-edit",
-          "title": "native-platform:action-edit",
+          "title": "Message Tool Edit Action",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim",
@@ -9373,7 +9373,7 @@
           "id": "action-topic-create",
           "group": "native-platform",
           "catalogId": "native-platform:action-topic-create",
-          "title": "native-platform:action-topic-create",
+          "title": "Message Tool Topic Create Action",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim",
@@ -9385,7 +9385,7 @@
           "id": "action-topic-edit",
           "group": "native-platform",
           "catalogId": "native-platform:action-topic-edit",
-          "title": "native-platform:action-topic-edit",
+          "title": "Message Tool Topic Edit Action",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim",
@@ -9397,7 +9397,7 @@
           "id": "delivery-pin",
           "group": "native-platform",
           "catalogId": "native-platform:delivery-pin",
-          "title": "native-platform:delivery-pin",
+          "title": "Message Delivery Pin",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim",
@@ -9409,7 +9409,7 @@
           "id": "presentation",
           "group": "native-platform",
           "catalogId": "native-platform:presentation",
-          "title": "native-platform:presentation",
+          "title": "Message Presentation",
           "requiredLevel": "warning",
           "proofModes": [
             "deterministic-shim",
@@ -11550,7 +11550,7 @@
       "thresholds": {
         "gatewayReadyMs": 45000,
         "healthMs": 5000,
-        "syncFsStallDetected": false
+        "syncFsStallDetected": 0
       },
       "phases": [
         {
@@ -11992,8 +11992,8 @@
         "gateway"
       ],
       "thresholds": {
-        "gatewaySurvives": true,
-        "diagnosticPresent": true,
+        "gatewaySurvives": 1,
+        "diagnosticPresent": 1,
         "statusAfterFailureMs": 10000
       },
       "phases": [
@@ -13457,7 +13457,7 @@
       "thresholds": {
         "modelsListMs": 20000,
         "statusAfterModelsMs": 10000,
-        "gatewayResponsive": true
+        "gatewayResponsive": 1
       },
       "phases": [
         {

--- a/tests/snapshots/report-fail-json.snap
+++ b/tests/snapshots/report-fail-json.snap
@@ -218,7 +218,7 @@
           "startupP95Ms": 200,
           "postReadyP95Ms": 20,
           "finalFailures": 0,
-          "totalFailures": 0,
+          "totalFailures": null,
           "slowestSample": {
             "phaseId": "provision",
             "durationMs": 200
@@ -334,7 +334,7 @@
           "startupP95Ms": 200,
           "postReadyP95Ms": 20,
           "finalFailures": 0,
-          "totalFailures": 0,
+          "totalFailures": null,
           "slowestSample": {
             "phaseId": "provision",
             "durationMs": 200

--- a/tests/snapshots/report-pass-json.snap
+++ b/tests/snapshots/report-pass-json.snap
@@ -149,7 +149,7 @@
           "startupP95Ms": 200,
           "postReadyP95Ms": 20,
           "finalFailures": 0,
-          "totalFailures": 0,
+          "totalFailures": null,
           "slowestSample": {
             "phaseId": "provision",
             "durationMs": 200
@@ -257,7 +257,7 @@
           "startupP95Ms": 200,
           "postReadyP95Ms": 20,
           "finalFailures": 0,
-          "totalFailures": 0,
+          "totalFailures": null,
           "slowestSample": {
             "phaseId": "provision",
             "durationMs": 200


### PR DESCRIPTION
## What Problem This Solves

Kova could silently accept or misclassify invalid registry and evaluation data:

- duplicate capability keys could overwrite one another across catalogs
- proof policies could reference capabilities that did not exist
- derived workflow catalogs skipped validation
- non-finite or malformed thresholds could leak into verdict evaluation
- malformed harness evidence could produce a misleading pass or hide a confirmed target failure

## Why This Change Was Made

Kova is release-validation infrastructure, so registry construction and verdict evaluation need to fail closed with attributable errors. This change validates the registry boundary, distinguishes harness failures from OpenClaw target failures, and preserves established failure precedence.

## User Impact

- invalid catalogs and thresholds are rejected before execution
- malformed measurement evidence is reported as `kova-harness`
- harness-only corruption blocks a would-be pass
- confirmed OpenClaw violations and existing failures remain failures
- capability titles and threshold provenance are reported correctly

## Evidence

- `NO_COLOR=1 npm run check` - 231/231 self-checks passed, including concurrent isolation
- `NO_COLOR=1 npm run test:snapshots` - 21/21 snapshots passed
- `git diff --check origin/main...HEAD`
- Codex autoreview with `gpt-5.6-sol` / high reasoning - no accepted or actionable findings
- `CHANGELOG.md` includes the Unreleased fix entry: "Hardened registry and evaluation integrity for capability catalogs, workflow derivation, thresholds, and malformed harness evidence."
