### PR TITLE
fix(runner): harden command execution boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Hardened command execution with bounded streaming redaction, POSIX process-group cleanup, strict optional-log matching, and direct scenario command validation.
 - Fixed OpenClaw inventory discovery to recognize canonical JSON5 plugin manifests consistently across platforms while deterministically bounding scans.
 - Isolated concurrent self-check OCM identities, child environments, runtime names, and temp cleanup ownership.
 - Hardened performance baseline persistence, unstable-group detection, and repeated-work audit isolation.

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { isNoLogsOutput } from "../command-results.mjs";
+import { isOptionalNoLogsResult } from "../command-results.mjs";
 import { runCommand } from "../commands.mjs";
 import { ocmLogs } from "../ocm/commands.mjs";
 
@@ -15,7 +15,7 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, command
     env: commandEnv
   });
   const text = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-  const noLogsAvailable = result.status !== 0 && isNoLogsOutput(text);
+  const noLogsAvailable = isOptionalNoLogsResult(result);
   const timestamps = collectTimestamps(text);
   const stdoutSnippet = boundedLogSnippet(result.stdout, 4000);
   const stderrSnippet = boundedLogSnippet(result.stderr, 4000);

--- a/src/command-results.mjs
+++ b/src/command-results.mjs
@@ -6,9 +6,18 @@ const structuredFailureStatuses = new Set([
   RECORD_STATUS.INCOMPLETE,
   RECORD_STATUS.BLOCKED
 ]);
+const noLogsStderrPattern = /^ocm: no logs exist for env "[^"\r\n]+" across stdout or stderr\n?$/;
 
 export function isNoLogsOutput(output) {
-  return /no logs exist for env\b/i.test(String(output ?? ""));
+  return noLogsStderrPattern.test(String(output ?? ""));
+}
+
+export function isOptionalNoLogsResult(result) {
+  return result?.status === 1 &&
+    result?.timedOut !== true &&
+    !result?.signal &&
+    result?.stdout === "" &&
+    isNoLogsOutput(result?.stderr);
 }
 
 export function normalizeOptionalCommandResult(result) {
@@ -16,8 +25,7 @@ export function normalizeOptionalCommandResult(result) {
     return result;
   }
 
-  const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-  if (/^ocm\s+logs\s/.test(result.command ?? "") && isNoLogsOutput(output)) {
+  if (/^ocm\s+logs(?:\s|$)/.test(result.command ?? "") && isOptionalNoLogsResult(result)) {
     result.optional = true;
     result.originalStatus = result.status;
     result.status = 0;

--- a/src/commands.mjs
+++ b/src/commands.mjs
@@ -1,10 +1,23 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { spawn, spawnSync } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 import { startResourceSampler } from "./collectors/resources.mjs";
 import { repoRoot } from "./paths.mjs";
 
 const defaultCommandTimeoutMs = 120000;
 const commandEnvStorage = new AsyncLocalStorage();
+const timeoutTerminationGraceMs = 3000;
+const shutdownTerminationGraceMs = 1000;
+const redactionMarker = "[REDACTED]";
+const shutdownSignals = ["SIGHUP", "SIGINT", "SIGQUIT", "SIGTERM"];
+const activeDetachedChildren = new Set();
+const shutdownSignalHandlers = new Map(
+  shutdownSignals.map((signal) => [signal, () => {
+    void forwardShutdownSignal(signal);
+  }])
+);
+let shutdownHandlersInstalled = false;
+let shutdownInProgress = false;
 
 export function runWithCommandEnv(env, callback) {
   return commandEnvStorage.run(
@@ -32,6 +45,7 @@ export function checkCommand(command, args) {
 
 export function runCommand(command, options = {}) {
   const timeoutMs = normalizeTimeoutMs(options.timeoutMs);
+  const maxOutputChars = normalizeMaxOutputChars(options.maxOutputChars);
   const startedAtEpochMs = Date.now();
   const startedAt = new Date(startedAtEpochMs).toISOString();
   return new Promise((resolve) => {
@@ -48,8 +62,10 @@ export function runCommand(command, options = {}) {
     const child = spawn(shell, ["-c", command], {
       cwd: repoRoot,
       env: childEnv,
-      stdio: ["ignore", "pipe", "pipe"]
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32"
     });
+    const stopTrackingChild = trackDetachedChild(child);
 
     const sampler = options.resourceSample
       ? startResourceSampler(child.pid, {
@@ -58,50 +74,73 @@ export function runCommand(command, options = {}) {
         redactValues: options.redactValues ?? []
       })
       : null;
-    let stdout = "";
-    let stderr = "";
+    const stdout = createBoundedOutputAccumulator({
+      limit: maxOutputChars,
+      redactValues: options.redactValues
+    });
+    const stderr = createBoundedOutputAccumulator({
+      limit: maxOutputChars,
+      redactValues: options.redactValues
+    });
     let timedOut = false;
     let settled = false;
+    let termination = null;
+    let terminationErrorReported = false;
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGTERM");
-      setTimeout(() => child.kill("SIGKILL"), 3000).unref();
+      termination = terminateTimedOutProcess(child).then(
+        () => null,
+        (error) => error
+      );
+      void termination.then((error) => {
+        if (!error) {
+          return;
+        }
+        reportTerminationError(error);
+        complete(124, child.signalCode, true);
+      });
     }, timeoutMs);
 
     child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
+      stdout.write(chunk);
     });
     child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
+      stderr.write(chunk);
     });
-    child.on("error", (error) => {
+    child.on("error", async (error) => {
       clearTimeout(timer);
+      if (termination) {
+        reportTerminationError(await termination);
+      }
+      stderr.write(Buffer.from(error.message));
+      complete(timedOut ? 124 : 127, null);
+    });
+    child.on("close", async (status, signal) => {
+      clearTimeout(timer);
+      if (termination) {
+        reportTerminationError(await termination);
+      }
+      complete(timedOut ? 124 : (status ?? 1), signal);
+    });
+
+    function reportTerminationError(error) {
+      if (!error || terminationErrorReported) {
+        return;
+      }
+      terminationErrorReported = true;
+      stderr.write(Buffer.from(`\ncommand timeout cleanup failed: ${error.message}`));
+    }
+
+    function complete(status, signal, keepTracking = false) {
+      if (!keepTracking) {
+        stopTrackingChild();
+      }
       const finishedAtEpochMs = Date.now();
-      const stdoutResult = truncateText(redact(stdout, options.redactValues), options.maxOutputChars ?? 20000);
-      const stderrResult = truncateText(redact(error.message, options.redactValues), options.maxOutputChars ?? 20000);
+      const stdoutResult = stdout.finish();
+      const stderrResult = stderr.finish();
       settle({
         command: redact(command, options.redactValues),
-        status: 127,
-        signal: null,
-        timedOut,
-        startedAt,
-        startedAtEpochMs,
-        finishedAt: new Date(finishedAtEpochMs).toISOString(),
-        finishedAtEpochMs,
-        durationMs: finishedAtEpochMs - startedAtEpochMs,
-        stdout: stdoutResult.text,
-        stderr: stderrResult.text,
-        outputBudget: outputBudgetSummary(stdoutResult, stderrResult)
-      });
-    });
-    child.on("close", (status, signal) => {
-      clearTimeout(timer);
-      const finishedAtEpochMs = Date.now();
-      const stdoutResult = truncateText(redact(stdout, options.redactValues), options.maxOutputChars ?? 20000);
-      const stderrResult = truncateText(redact(stderr, options.redactValues), options.maxOutputChars ?? 20000);
-      settle({
-        command: redact(command, options.redactValues),
-        status: timedOut ? 124 : (status ?? 1),
+        status,
         signal,
         timedOut,
         startedAt,
@@ -113,7 +152,7 @@ export function runCommand(command, options = {}) {
         stderr: stderrResult.text,
         outputBudget: outputBudgetSummary(stdoutResult, stderrResult)
       });
-    });
+    }
 
     async function settle(result) {
       if (settled) {
@@ -128,8 +167,198 @@ export function runCommand(command, options = {}) {
   });
 }
 
+function trackDetachedChild(child) {
+  if (process.platform === "win32") {
+    return () => {};
+  }
+  activeDetachedChildren.add(child);
+  installShutdownHandlers();
+  let tracked = true;
+  return () => {
+    if (!tracked) {
+      return;
+    }
+    tracked = false;
+    activeDetachedChildren.delete(child);
+    if (activeDetachedChildren.size === 0 && !shutdownInProgress) {
+      uninstallShutdownHandlers();
+    }
+  };
+}
+
+function installShutdownHandlers() {
+  if (shutdownHandlersInstalled) {
+    return;
+  }
+  shutdownHandlersInstalled = true;
+  for (const [signal, handler] of shutdownSignalHandlers) {
+    process.on(signal, handler);
+  }
+  process.on("exit", forceKillActiveChildren);
+}
+
+function uninstallShutdownHandlers() {
+  if (!shutdownHandlersInstalled) {
+    return;
+  }
+  shutdownHandlersInstalled = false;
+  for (const [signal, handler] of shutdownSignalHandlers) {
+    process.off(signal, handler);
+  }
+  process.off("exit", forceKillActiveChildren);
+}
+
+async function forwardShutdownSignal(signal) {
+  if (shutdownInProgress) {
+    return;
+  }
+  shutdownInProgress = true;
+  const children = [...activeDetachedChildren];
+  for (const child of children) {
+    try {
+      signalProcessTree(child, signal);
+    } catch {
+      // The exit handler below still makes a best-effort SIGKILL pass.
+    }
+  }
+  await Promise.all(children.map(async (child) => {
+    try {
+      await waitForProcessTreeExit(child, shutdownTerminationGraceMs);
+    } catch {
+      // Fall through to the forced pass.
+    }
+  }));
+  for (const child of children) {
+    try {
+      if (processTreeIsRunning(child)) {
+        signalProcessTree(child, "SIGKILL");
+      }
+    } catch {
+      // Process exit is already committed; this is best-effort cleanup.
+    }
+  }
+  process.exit(signalExitCode(signal));
+}
+
+function forceKillActiveChildren() {
+  for (const child of activeDetachedChildren) {
+    try {
+      signalProcessTree(child, "SIGKILL");
+    } catch {
+      // Exit hooks cannot recover; only avoid leaving children when possible.
+    }
+  }
+}
+
+function signalExitCode(signal) {
+  return {
+    SIGHUP: 129,
+    SIGINT: 130,
+    SIGQUIT: 131,
+    SIGTERM: 143
+  }[signal] ?? 1;
+}
+
 export function quoteShell(value) {
   return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+export function createBoundedOutputAccumulator(options = {}) {
+  const limit = normalizeMaxOutputChars(options.limit);
+  const secrets = [...new Set((options.redactValues ?? []).filter((value) =>
+    typeof value === "string" && value.length > 0
+  ))].sort((left, right) => right.length - left.length);
+  const decoder = new StringDecoder("utf8");
+  let pending = "";
+  let retained = "";
+  let originalChars = 0;
+  let finished = false;
+
+  return {
+    write(chunk) {
+      if (finished) {
+        return;
+      }
+      const text = typeof chunk === "string" ? chunk : decoder.write(chunk);
+      processText(text, false);
+    },
+    finish() {
+      if (!finished) {
+        processText(decoder.end(), true);
+        finished = true;
+      }
+      const omittedChars = originalChars - retained.length;
+      return {
+        text: omittedChars > 0
+          ? `${retained}\n[truncated ${omittedChars} chars]`
+          : retained,
+        originalChars,
+        retainedChars: retained.length,
+        omittedChars,
+        truncated: omittedChars > 0,
+        limitChars: limit
+      };
+    }
+  };
+
+  function processText(text, final) {
+    pending += text;
+    if (secrets.length === 0) {
+      append(pending);
+      pending = "";
+      return;
+    }
+    const deferredAt = final ? pending.length : incompleteSecretStart(pending, secrets);
+    let cursor = 0;
+    while (cursor < deferredAt) {
+      const match = nextSecretMatch(pending, secrets, cursor);
+      if (!match || match.index >= deferredAt) {
+        append(pending.slice(cursor, deferredAt));
+        cursor = deferredAt;
+        break;
+      }
+      append(pending.slice(cursor, match.index));
+      if (match.secret) {
+        append(redactionMarker);
+        cursor = match.index + match.secret.length;
+      }
+    }
+    pending = pending.slice(cursor);
+  }
+
+  function append(text) {
+    originalChars += text.length;
+    const remaining = limit - retained.length;
+    if (remaining > 0) {
+      retained += text.slice(0, remaining);
+    }
+  }
+}
+
+function incompleteSecretStart(text, secrets) {
+  const maxLength = secrets.reduce((max, value) => Math.max(max, value.length), 0);
+  const firstCandidate = Math.max(0, text.length - maxLength + 1);
+  for (let index = firstCandidate; index < text.length; index += 1) {
+    const suffix = text.slice(index);
+    if (secrets.some((value) => suffix.length < value.length && value.startsWith(suffix))) {
+      return index;
+    }
+  }
+  return text.length;
+}
+
+function nextSecretMatch(text, secrets, fromIndex) {
+  let match = null;
+  for (const secret of secrets) {
+    const index = text.indexOf(secret, fromIndex);
+    if (index < 0) {
+      continue;
+    }
+    if (!match || index < match.index || (index === match.index && secret.length > match.secret.length)) {
+      match = { index, secret };
+    }
+  }
+  return match;
 }
 
 function normalizeTimeoutMs(value) {
@@ -140,26 +369,75 @@ function normalizeTimeoutMs(value) {
   return timeoutMs;
 }
 
-function truncateText(value, limit = 20000) {
-  if (value.length <= limit) {
-    return {
-      text: value,
-      originalChars: value.length,
-      retainedChars: value.length,
-      omittedChars: 0,
-      truncated: false,
-      limitChars: limit
-    };
+function normalizeMaxOutputChars(value) {
+  const limit = value === undefined ? 20000 : Number(value);
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error(`runCommand maxOutputChars must be a positive integer, got ${JSON.stringify(value)}`);
   }
-  const marker = `\n[truncated ${value.length - limit} chars]`;
-  return {
-    text: `${value.slice(0, limit)}${marker}`,
-    originalChars: value.length,
-    retainedChars: limit,
-    omittedChars: value.length - limit,
-    truncated: true,
-    limitChars: limit
-  };
+  return limit;
+}
+
+async function terminateTimedOutProcess(child) {
+  signalProcessTree(child, "SIGTERM");
+  if (await waitForProcessTreeExit(child, timeoutTerminationGraceMs)) {
+    return;
+  }
+  signalProcessTree(child, "SIGKILL");
+  await waitForProcessTreeExit(child, timeoutTerminationGraceMs);
+}
+
+function signalProcessTree(child, signal) {
+  if (process.platform !== "win32" && Number.isInteger(child.pid)) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch (error) {
+      if (error.code !== "ESRCH") {
+        throw error;
+      }
+      return;
+    }
+  }
+  try {
+    child.kill(signal);
+  } catch (error) {
+    if (error.code !== "ESRCH") {
+      throw error;
+    }
+  }
+}
+
+async function waitForProcessTreeExit(child, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (processTreeIsRunning(child)) {
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await sleep(25);
+  }
+  return true;
+}
+
+function processTreeIsRunning(child) {
+  if (process.platform === "win32" || !Number.isInteger(child.pid)) {
+    return child.exitCode === null && child.signalCode === null;
+  }
+  try {
+    process.kill(-child.pid, 0);
+    return true;
+  } catch (error) {
+    if (error.code === "ESRCH") {
+      return false;
+    }
+    if (error.code === "EPERM") {
+      return true;
+    }
+    throw error;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function outputBudgetSummary(stdout, stderr) {

--- a/src/commands.mjs
+++ b/src/commands.mjs
@@ -109,18 +109,22 @@ export function runCommand(command, options = {}) {
     });
     child.on("error", async (error) => {
       clearTimeout(timer);
+      let terminationError = null;
       if (termination) {
-        reportTerminationError(await termination);
+        terminationError = await termination;
+        reportTerminationError(terminationError);
       }
       stderr.write(Buffer.from(error.message));
-      complete(timedOut ? 124 : 127, null);
+      complete(timedOut ? 124 : 127, null, Boolean(terminationError));
     });
     child.on("close", async (status, signal) => {
       clearTimeout(timer);
+      let terminationError = null;
       if (termination) {
-        reportTerminationError(await termination);
+        terminationError = await termination;
+        reportTerminationError(terminationError);
       }
-      complete(timedOut ? 124 : (status ?? 1), signal);
+      complete(timedOut ? 124 : (status ?? 1), signal, Boolean(terminationError));
     });
 
     function reportTerminationError(error) {
@@ -383,7 +387,9 @@ async function terminateTimedOutProcess(child) {
     return;
   }
   signalProcessTree(child, "SIGKILL");
-  await waitForProcessTreeExit(child, timeoutTerminationGraceMs);
+  if (!await waitForProcessTreeExit(child, timeoutTerminationGraceMs)) {
+    throw new Error(`process group ${child.pid ?? "unknown"} survived SIGKILL`);
+  }
 }
 
 function signalProcessTree(child, signal) {

--- a/src/commands.mjs
+++ b/src/commands.mjs
@@ -232,26 +232,27 @@ async function forwardShutdownSignal(signal) {
       // Fall through to the forced pass.
     }
   }));
-  for (const child of children) {
+  const forcedChildren = forceKillActiveChildren();
+  await Promise.all(forcedChildren.map(async (child) => {
     try {
-      if (processTreeIsRunning(child)) {
-        signalProcessTree(child, "SIGKILL");
-      }
+      await waitForProcessTreeExit(child, shutdownTerminationGraceMs);
     } catch {
-      // Process exit is already committed; this is best-effort cleanup.
+      // The exit hook makes one final synchronous kill pass.
     }
-  }
+  }));
   process.exit(signalExitCode(signal));
 }
 
 function forceKillActiveChildren() {
-  for (const child of activeDetachedChildren) {
+  const children = [...activeDetachedChildren];
+  for (const child of children) {
     try {
       signalProcessTree(child, "SIGKILL");
     } catch {
       // Exit hooks cannot recover; only avoid leaving children when possible.
     }
   }
+  return children;
 }
 
 function signalExitCode(signal) {

--- a/src/run/command-executor.mjs
+++ b/src/run/command-executor.mjs
@@ -17,7 +17,7 @@ import { assertSafeScenarioCommand } from "../safety.mjs";
 import { safeSegment } from "./phase-commands.mjs";
 
 export async function runScenarioCommand(command, context, envName, artifactDir, phase, commandIndex, authPolicy = null) {
-  assertSafeScenarioCommand(command, context, envName);
+  assertSafeScenarioCommand(command, context, envName, artifactDir);
   const phaseId = phase.id;
   const measurementScope = measurementScopeForPhase(phase);
   if (measurementScope === "product") {

--- a/src/safety.mjs
+++ b/src/safety.mjs
@@ -1,25 +1,96 @@
+import { isAbsolute, resolve } from "node:path";
+import { repoRoot } from "./paths.mjs";
 import { maxOcmEnvNameLength } from "./run/env-name.mjs";
 
-export function assertSafeScenarioCommand(command, context, envName) {
+const allowedScenarioExecutables = new Set(["ocm", "node", "rm"]);
+const delegatedCommandNodeScripts = new Set([
+  "support/assert-command-output.mjs",
+  "support/expect-command-fails.mjs"
+].map((path) => resolve(repoRoot, path)));
+const allowedNodeScenarioScripts = new Set([
+  "scripts/large-session-fixture.mjs",
+  "support/agent-network-offline.mjs",
+  "support/assert-command-output.mjs",
+  "support/browser-automation-smoke.mjs",
+  "support/channel-conformance/run.mjs",
+  "support/ensure-gateway-running.mjs",
+  "support/expect-command-fails.mjs",
+  "support/install-channel-adapter-package.mjs",
+  "support/mcp-bridge-smoke.mjs",
+  "support/mcp-tool-call-smoke.mjs",
+  "support/media-understanding-timeout.mjs",
+  "support/restore-first-ocm-upgrade-snapshot.mjs",
+  "support/run-adversarial-inputs.mjs",
+  "support/run-channel-adapter-conformance.mjs",
+  "support/run-channel-capability-preflight.mjs",
+  "support/run-channel-probe-turn.mjs",
+  "support/run-concurrent-agent-turns.mjs",
+  "support/run-cron-runtime-smoke.mjs",
+  "support/run-doctor-repair.mjs",
+  "support/run-exec-tool-safety.mjs",
+  "support/run-gateway-session-send-turn.mjs",
+  "support/run-official-plugin-install.mjs",
+  "support/run-openai-compatible-turn.mjs",
+  "support/run-openclaw-release-age-upgrade.mjs",
+  "support/run-soak-loop.mjs",
+  "support/run-tui-message-turn.mjs",
+  "support/tui-smoke.mjs"
+].map((path) => resolve(repoRoot, path)));
+const ocmMutationRules = [
+  { matches: (words) => hasPrefix(words, ["ocm", "start"]), targetIndex: 2, label: "ocm start" },
+  { matches: (words) => hasPrefix(words, ["ocm", "upgrade"]), targetIndex: 2, label: "ocm upgrade" },
+  { matches: (words) => hasPrefix(words, ["ocm", "rollback"]), targetIndex: 2, label: "ocm rollback" },
+  { matches: (words) => hasPrefix(words, ["ocm", "logs"]), targetIndex: 2, label: "ocm logs" },
+  {
+    matches: (words) =>
+      hasPrefix(words, ["ocm", "service"]) && ["status", "start", "stop", "restart"].includes(words[2]),
+    targetIndex: 3,
+    label: "ocm service"
+  },
+  {
+    matches: (words) =>
+      hasPrefix(words, ["ocm", "env"]) && ["destroy", "exec", "run", "use"].includes(words[2]),
+    targetIndex: 3,
+    label: "ocm env"
+  },
+  {
+    matches: (words) => hasPrefix(words, ["ocm", "env", "clone"]),
+    targetIndex: 3,
+    label: "ocm env clone source",
+    allowSourceClone: true
+  },
+  {
+    matches: (words) => hasPrefix(words, ["ocm", "env", "clone"]),
+    targetIndex: 4,
+    label: "ocm env clone destination"
+  }
+];
+
+export function assertSafeScenarioCommand(command, context, envName, artifactDir = null) {
   const trimmed = String(command ?? "").trim();
-  for (const rule of mutationRules()) {
-    const value = extractCommandTarget(trimmed, rule);
-    if (value === null) {
+  const words = assertSingleTopLevelShellCommand(trimmed);
+  assertDirectScenarioCommand(words, context, envName, artifactDir);
+  assertOcmMutationTargets(words, context);
+
+  if (trimmed.includes(envName) && !isKovaEnvName(envName)) {
+    throw new Error(`unsafe Kova env name ${JSON.stringify(envName)}; generated envs must start with kova-`);
+  }
+}
+
+function assertOcmMutationTargets(words, context) {
+  for (const rule of ocmMutationRules) {
+    if (!rule.matches(words)) {
       continue;
     }
+    const value = words[rule.targetIndex];
     if (rule.allowSourceClone && value === context.sourceEnv) {
       continue;
     }
     assertKovaEnvName(value, `${rule.label} target`);
   }
 
-  const atEnv = extractAtEnvTarget(trimmed);
-  if (atEnv !== null) {
-    assertKovaEnvName(atEnv, "ocm @ target");
-  }
-
-  if (trimmed.includes(envName) && !isKovaEnvName(envName)) {
-    throw new Error(`unsafe Kova env name ${JSON.stringify(envName)}; generated envs must start with kova-`);
+  if (words[0] === "ocm" && words[1]?.startsWith("@")) {
+    assertKovaEnvName(words[1].slice(1), "ocm @ target");
   }
 }
 
@@ -37,34 +108,205 @@ export function isKovaEnvName(value) {
   return text.length <= maxOcmEnvNameLength() && /^kova-[a-z0-9][a-z0-9-]*$/i.test(text);
 }
 
-function mutationRules() {
-  const shellWordPattern = "((?:'[^']*(?:'\\\\''[^']*)*')|(?:\"[^\"]*\")|\\S+)";
-  return [
-    { pattern: new RegExp(`^ocm\\s+start\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm start" },
-    { pattern: new RegExp(`^ocm\\s+upgrade\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm upgrade" },
-    { pattern: new RegExp(`^ocm\\s+rollback\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm rollback" },
-    { pattern: new RegExp(`^ocm\\s+logs\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm logs" },
-    { pattern: new RegExp(`^ocm\\s+service\\s+(?:status|start|stop|restart)\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm service" },
-    { pattern: new RegExp(`^ocm\\s+env\\s+(?:destroy|exec|run|use)\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm env" },
-    { pattern: new RegExp(`^ocm\\s+env\\s+clone\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm env clone source", allowSourceClone: true },
-    { pattern: new RegExp(`^ocm\\s+env\\s+clone\\s+${shellWordPattern}\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm env clone destination", group: 2 }
-  ];
+function hasPrefix(words, prefix) {
+  return prefix.every((word, index) => words[index] === word);
 }
 
-function extractAtEnvTarget(command) {
-  const match = command.match(/^ocm\s+@((?:'[^']*(?:'\\''[^']*)*')|(?:"[^"]*")|\S+)(?:\s|$)/);
-  return match ? unquoteShellToken(match[1]) : null;
-}
-
-function extractCommandTarget(command, rule) {
-  const match = command.match(rule.pattern);
-  return match ? unquoteShellToken(match[rule.group ?? 1]) : null;
-}
-
-function unquoteShellToken(value) {
-  const text = String(value ?? "").trim();
-  if ((text.startsWith("'") && text.endsWith("'")) || (text.startsWith('"') && text.endsWith('"'))) {
-    return text.slice(1, -1).replaceAll("'\\''", "'");
+export function assertSingleTopLevelShellCommand(command) {
+  const text = String(command ?? "");
+  const executable = text.match(/^([A-Za-z0-9_./+-]+)(?:\s|$)/)?.[1] ?? "";
+  if (!allowedScenarioExecutables.has(executable)) {
+    throw shellEvaluationError("non-direct scenario executable");
   }
-  return text;
+  let quote = null;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (quote === "'") {
+      if (char === "'") {
+        quote = null;
+      }
+      continue;
+    }
+    if (quote === '"') {
+      if (char === "\\") {
+        throw shellEvaluationError("backslash in double-quoted argument");
+      } else if (char === "`" || char === "$") {
+        throw shellEvaluationError("shell expansion");
+      } else if (char === '"') {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "\\") {
+      if (index + 1 >= text.length) {
+        throw shellEvaluationError("dangling escape");
+      }
+      if (text[index + 1] === "\n" || text[index + 1] === "\r") {
+        throw shellEvaluationError("line continuation");
+      }
+      index += 1;
+      continue;
+    }
+    if (char === "`" || char === "$") {
+      throw shellEvaluationError("shell expansion");
+    }
+    if (char === "*" || char === "?" || char === "[" || char === "]") {
+      throw shellEvaluationError("pathname expansion");
+    }
+    if (char === "{" && hasBraceExpansion(text, index)) {
+      throw shellEvaluationError("brace expansion");
+    }
+    if (char === "(" || char === ")") {
+      throw shellEvaluationError(`top-level ${char}`);
+    }
+    if (char === "\n" || char === "\r" || char === ";" || char === "|" || char === "&" || char === "<" || char === ">") {
+      throw compoundCommandError(char);
+    }
+  }
+  if (quote !== null) {
+    throw shellEvaluationError("unterminated quote");
+  }
+  return parseShellWords(text);
+}
+
+function hasBraceExpansion(command, startIndex) {
+  const endIndex = command.indexOf("}", startIndex + 1);
+  if (endIndex < 0) {
+    return false;
+  }
+  const body = command.slice(startIndex + 1, endIndex);
+  return body.includes(",") || body.includes("..");
+}
+
+function assertDirectScenarioCommand(words, context, envName, artifactDir) {
+  if (words[0] === "ocm" && words[1]?.startsWith("-")) {
+    if (words.length === 2 && words[1] === "--version") {
+      return;
+    }
+    throw shellEvaluationError("OCM global options before a subcommand");
+  }
+  if (words[0] === "node") {
+    if (words.length === 2 && words[1] === "--version") {
+      return;
+    }
+    const script = resolve(repoRoot, String(words[1] ?? ""));
+    if (!allowedNodeScenarioScripts.has(script)) {
+      throw shellEvaluationError("unapproved Node scenario entry point");
+    }
+    assertNodeHelperEnvTargets(words, envName);
+    assertDelegatedNodeCommand(words, script, context);
+    return;
+  }
+  if (words[0] === "rm") {
+    const expectedPath = artifactDir && isAbsolute(artifactDir) ? resolve(artifactDir, "import") : null;
+    const operand = words[2];
+    if (
+      words.length !== 3 ||
+      words[1] !== "-rf" ||
+      !expectedPath ||
+      !isAbsolute(operand ?? "") ||
+      resolve(operand) !== expectedPath
+    ) {
+      throw shellEvaluationError("unapproved artifact cleanup");
+    }
+  }
+}
+
+function assertDelegatedNodeCommand(words, script, context) {
+  if (!delegatedCommandNodeScripts.has(script)) {
+    return;
+  }
+  const separatorIndex = words.indexOf("--", 2);
+  const delegated = separatorIndex >= 0 ? words.slice(separatorIndex + 1) : [];
+  if (delegated[0] !== "ocm") {
+    throw shellEvaluationError("unapproved delegated scenario command");
+  }
+  if (delegated[1]?.startsWith("-")) {
+    throw shellEvaluationError("OCM global options before a delegated subcommand");
+  }
+  assertOcmMutationTargets(delegated, context);
+}
+
+function assertNodeHelperEnvTargets(words, envName) {
+  for (let index = 2; index < words.length; index += 1) {
+    if (words[index].startsWith("--env=")) {
+      throw shellEvaluationError("unsupported inline Node helper --env");
+    }
+    if (words[index] !== "--env") {
+      continue;
+    }
+    const target = words[index + 1];
+    assertKovaEnvName(target, "Node helper --env");
+    if (target !== envName) {
+      throw new Error(
+        `refusing Node helper --env outside active Kova env ${JSON.stringify(envName)}: ${JSON.stringify(target)}`
+      );
+    }
+    index += 1;
+  }
+}
+
+function parseShellWords(command) {
+  const words = [];
+  let word = "";
+  let started = false;
+  let quote = null;
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else if (quote === '"' && char === "\\") {
+        const next = command[index + 1] ?? "";
+        if (next === "$" || next === "`" || next === '"' || next === "\\" || next === "\n") {
+          index += 1;
+          word += next;
+        } else {
+          word += char;
+        }
+      } else {
+        word += char;
+      }
+      started = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      started = true;
+      continue;
+    }
+    if (char === "\\") {
+      index += 1;
+      word += command[index] ?? "";
+      started = true;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (started) {
+        words.push(word);
+        word = "";
+        started = false;
+      }
+      continue;
+    }
+    word += char;
+    started = true;
+  }
+  if (started) {
+    words.push(word);
+  }
+  return words;
+}
+
+function compoundCommandError(operator) {
+  const label = operator === "\n" || operator === "\r" ? "newline" : operator;
+  return new Error(`refusing compound scenario command with top-level ${JSON.stringify(label)}; use one command per step`);
+}
+
+function shellEvaluationError(kind) {
+  return new Error(`refusing scenario command with ${kind}; use a direct command with inert arguments`);
 }

--- a/src/safety.mjs
+++ b/src/safety.mjs
@@ -38,16 +38,16 @@ export function isKovaEnvName(value) {
 }
 
 function mutationRules() {
-  const token = "((?:'[^']*(?:'\\\\''[^']*)*')|(?:\"[^\"]*\")|\\S+)";
+  const shellWordPattern = "((?:'[^']*(?:'\\\\''[^']*)*')|(?:\"[^\"]*\")|\\S+)";
   return [
-    { pattern: new RegExp(`^ocm\\s+start\\s+${token}(?:\\s|$)`), label: "ocm start" },
-    { pattern: new RegExp(`^ocm\\s+upgrade\\s+${token}(?:\\s|$)`), label: "ocm upgrade" },
-    { pattern: new RegExp(`^ocm\\s+rollback\\s+${token}(?:\\s|$)`), label: "ocm rollback" },
-    { pattern: new RegExp(`^ocm\\s+logs\\s+${token}(?:\\s|$)`), label: "ocm logs" },
-    { pattern: new RegExp(`^ocm\\s+service\\s+(?:status|start|stop|restart)\\s+${token}(?:\\s|$)`), label: "ocm service" },
-    { pattern: new RegExp(`^ocm\\s+env\\s+(?:destroy|exec|run|use)\\s+${token}(?:\\s|$)`), label: "ocm env" },
-    { pattern: new RegExp(`^ocm\\s+env\\s+clone\\s+${token}(?:\\s|$)`), label: "ocm env clone source", allowSourceClone: true },
-    { pattern: new RegExp(`^ocm\\s+env\\s+clone\\s+${token}\\s+${token}(?:\\s|$)`), label: "ocm env clone destination", group: 2 }
+    { pattern: new RegExp(`^ocm\\s+start\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm start" },
+    { pattern: new RegExp(`^ocm\\s+upgrade\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm upgrade" },
+    { pattern: new RegExp(`^ocm\\s+rollback\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm rollback" },
+    { pattern: new RegExp(`^ocm\\s+logs\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm logs" },
+    { pattern: new RegExp(`^ocm\\s+service\\s+(?:status|start|stop|restart)\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm service" },
+    { pattern: new RegExp(`^ocm\\s+env\\s+(?:destroy|exec|run|use)\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm env" },
+    { pattern: new RegExp(`^ocm\\s+env\\s+clone\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm env clone source", allowSourceClone: true },
+    { pattern: new RegExp(`^ocm\\s+env\\s+clone\\s+${shellWordPattern}\\s+${shellWordPattern}(?:\\s|$)`), label: "ocm env clone destination", group: 2 }
   ];
 }
 

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3627,14 +3627,14 @@ async function stateLifecycleCommandIndexesCheck(tmp) {
       [
         {
           commands: [
-            "node -e 'process.stdout.write(\"first\")'",
-            "node -e 'process.stdout.write(\"second\")'"
+            "node --version",
+            "node --version"
           ],
           evidence: [],
           collectionIntent: "skip-env"
         },
         {
-          commands: ["node -e 'process.stdout.write(\"third\")'"],
+          commands: ["node --version"],
           evidence: [],
           collectionIntent: "skip-env"
         }
@@ -16667,14 +16667,15 @@ function expectedMockProviderFailureTimeoutLogCheck() {
 
 function optionalNoLogsCommandCheck() {
   try {
-    const result = normalizeOptionalCommandResult({
+    const result = {
       command: "ocm logs 'kova-empty-logs' --tail 250 --raw",
       status: 1,
       stdout: "",
       stderr: "ocm: no logs exist for env \"kova-empty-logs\" across stdout or stderr\n"
-    });
+    };
     assertEqual(isNoLogsOutput(result.stderr), true, "exact missing logs stderr is detected");
     assertEqual(isOptionalNoLogsResult(result), true, "empty stdout and exact stderr are optional");
+    normalizeOptionalCommandResult(result);
     assertEqual(result.status, 0, "missing logs are normalized to optional success");
     assertEqual(result.originalStatus, 1, "original log command status retained");
     assertEqual(result.optional, true, "optional marker set");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3,7 +3,7 @@ import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, uti
 import { createServer } from "node:http";
 import { join } from "node:path";
 import { resolveScriptStep } from "mock-ai-provider/dist/providers/openai/common/scripted-response.js";
-import { quoteShell, runCommand } from "./commands.mjs";
+import { createBoundedOutputAccumulator, quoteShell, runCommand } from "./commands.mjs";
 import { runCleanupCommand } from "./cleanup.mjs";
 import { applyEvidenceLedgerGating, attachEvidenceLedger } from "./evidence-ledger.mjs";
 import { attachCleanupEvidence } from "./evidence/record.mjs";
@@ -63,7 +63,7 @@ import { validateScenarioShape } from "./registries/scenarios.mjs";
 import { validateStateShape } from "./registries/states.mjs";
 import { validateRegistryReferences } from "./registries/validate.mjs";
 import { isMissingOcmResource } from "./ocm/missing-resource.mjs";
-import { assertSafeScenarioCommand } from "./safety.mjs";
+import { assertSafeScenarioCommand, assertSingleTopLevelShellCommand } from "./safety.mjs";
 import { resolveTarget } from "./targets.mjs";
 import {
   measurementScopeForPhase,
@@ -117,6 +117,7 @@ import {
   commandFailureRecordStatus,
   interpretCommandResult,
   isNoLogsOutput,
+  isOptionalNoLogsResult,
   normalizeOptionalCommandResult
 } from "./command-results.mjs";
 import { createRunId } from "./run/run-id.mjs";
@@ -339,7 +340,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       "external-cli codex is not usable"
     ));
     checks.push(await externalCliRunAuthVerificationCheck(tmp));
-    checks.push(await commandTimeoutContractCheck());
+    checks.push(await commandTimeoutContractCheck(tmp));
     checks.push(await commandOutputBudgetCheck());
     checks.push(logSnippetBudgetCheck());
     checks.push(expectedMockProviderFailureTimeoutLogCheck());
@@ -4754,7 +4755,21 @@ async function gateDryRunCheck(tmp) {
 function safetyGuardCheck() {
   try {
     assertSafeScenarioCommand("ocm start kova-safe-test --runtime stable --json", {}, "kova-safe-test");
+    assertSafeScenarioCommand("ocm --version", {}, "kova-safe-test");
     assertSafeScenarioCommand("ocm env clone 'Team Env' kova-safe-test --json", { sourceEnv: "Team Env" }, "kova-safe-test");
+    assertSafeScenarioCommand("node support/run-soak-loop.mjs --env kova-safe-test", {}, "kova-safe-test");
+    assertSafeScenarioCommand(
+      "node support/expect-command-fails.mjs -- ocm @kova-safe-test -- agent --local --message hi",
+      {},
+      "kova-safe-test"
+    );
+    assertSafeScenarioCommand(
+      "rm -rf '/tmp/kova-self-check-artifacts/import'",
+      {},
+      "kova-safe-test",
+      "/tmp/kova-self-check-artifacts"
+    );
+    assertSingleTopLevelShellCommand("ocm env exec kova-safe-test -- sh -lc 'printf \"a;b|c&&d\" >&2'");
     const blockedCases = [
       "ocm env destroy Violet --yes",
       "ocm upgrade Violet --channel beta --json",
@@ -4779,6 +4794,80 @@ function safetyGuardCheck() {
       wrongSourceBlocked = /refusing to mutate non-Kova/.test(error.message);
     }
     assertEqual(wrongSourceBlocked, true, "unexpected source env clone blocked");
+    const compoundCases = [
+      "ocm logs kova-safe-test; ocm env destroy Violet --yes",
+      "true && ocm env destroy Violet --yes",
+      "true | ocm env destroy Violet --yes",
+      "sleep 10 & ocm env destroy Violet --yes",
+      "true\nocm env destroy Violet --yes"
+    ];
+    let compoundBlocked = 0;
+    for (const command of compoundCases) {
+      try {
+        assertSafeScenarioCommand(command, {}, "kova-safe-test");
+      } catch (error) {
+        if (/refusing (?:compound )?scenario command/.test(error.message)) {
+          compoundBlocked += 1;
+        }
+      }
+    }
+    assertEqual(compoundBlocked, compoundCases.length, "top-level compound commands blocked");
+    const shellEvaluationCases = [
+      "echo \"$(ocm env destroy Violet --yes)\"",
+      "echo `ocm env destroy Violet --yes`",
+      "cat <(ocm env destroy Violet --yes)",
+      "sh -c 'ocm env destroy Violet --yes'",
+      "env ocm env destroy Violet --yes",
+      "KOVA_MODE=test ocm env destroy Violet --yes",
+      "\"$OCM\" env destroy Violet --yes",
+      "/usr/local/bin/ocm env destroy Violet --yes",
+      "! ocm env destroy Violet --yes",
+      "(ocm env destroy Violet --yes)",
+      "> /tmp/kova-redirection ocm env destroy Violet --yes",
+      "timeout 30 ocm env destroy Violet --yes",
+      "node -e 'require(\"node:child_process\").execFileSync(\"ocm\", [\"env\", \"destroy\", \"Violet\", \"--yes\"])'",
+      "node /tmp/support/run-soak-loop.mjs --env kova-safe-test",
+      "node support/run-openclaw-release-age-upgrade.mjs --env Violet --age day --json",
+      "node support/run-openclaw-release-age-upgrade.mjs --env=Violet --age day --json",
+      "node support/run-doctor-repair.mjs --env kova-safe-test --env Violet",
+      "node support/expect-command-fails.mjs -- ocm env destroy Violet --yes",
+      "node support/assert-command-output.mjs --pattern done -- ocm logs Violet --tail 20 --raw",
+      "ocm env des\\\ntroy Violet --yes",
+      "ocm --json env destroy Violet --yes",
+      "ocm e?? d?????? Violet --yes",
+      "rm -rf \"/tmp/kova-self-check-artifacts/im\\port\""
+    ];
+    let shellEvaluationBlocked = 0;
+    for (const command of shellEvaluationCases) {
+      try {
+        assertSafeScenarioCommand(command, {}, "kova-safe-test");
+      } catch (error) {
+        if (/^refusing /.test(error.message)) {
+          shellEvaluationBlocked += 1;
+        }
+      }
+    }
+    assertEqual(shellEvaluationBlocked, shellEvaluationCases.length, "shell evaluation bypasses blocked");
+    const artifactCleanupCases = [
+      ["rm -rf relative/import", "relative"],
+      ["rm -rf ~/kova-self-check-artifacts/import", "/tmp/kova-self-check-artifacts"]
+    ];
+    for (const [command, artifactDir] of artifactCleanupCases) {
+      let blocked = false;
+      try {
+        assertSafeScenarioCommand(command, {}, "kova-safe-test", artifactDir);
+      } catch (error) {
+        blocked = /unapproved artifact cleanup/.test(error.message);
+      }
+      assertEqual(blocked, true, `unsafe artifact cleanup path blocked: ${command}`);
+    }
+    let obfuscatedMutationBlocked = false;
+    try {
+      assertSafeScenarioCommand("ocm e''nv des''troy Violet --yes", {}, "kova-safe-test");
+    } catch (error) {
+      obfuscatedMutationBlocked = /refusing to mutate non-Kova/.test(error.message);
+    }
+    assertEqual(obfuscatedMutationBlocked, true, "quoted OCM mutation words are canonicalized");
     return {
       id: "durable-env-mutation-guard",
       status: "PASS",
@@ -9722,11 +9811,12 @@ if (args[0] === ${JSON.stringify(`@${scope.envName}`)} && args[1] === "--" && ar
 async function networkFrontageProductPreflightBlocksPendingCheck(tmp, scope) {
   const fakeBin = join(tmp, "network-frontage-pending-bin");
   const artifactDir = join(tmp, "network-frontage-pending-artifacts");
-  const sentinel = join(tmp, "network-frontage-pending-ran");
+  const sentinel = join(artifactDir, "import");
   const fakeOcm = join(fakeBin, "ocm");
   try {
     await mkdir(fakeBin, { recursive: true });
     await mkdir(artifactDir, { recursive: true });
+    await mkdir(sentinel, { recursive: true });
     await writeFile(fakeOcm, `#!/bin/sh
 if [ "$1:$2" = "service:status" ]; then
   printf '{"gatewayPort":43123,"gatewayState":"starting","running":false}\\n'
@@ -9737,7 +9827,7 @@ exit 2
 `, "utf8");
     await chmod(fakeOcm, 0o755);
     const result = await runScenarioCommand(
-      `node -e "require('node:fs').writeFileSync(process.argv[1], 'ran')" ${quoteShell(sentinel)}`,
+      `rm -rf ${quoteShell(sentinel)}`,
       {
         timeoutMs: 5000,
         networkFrontage: {
@@ -9759,9 +9849,10 @@ exit 2
     let commandRan = false;
     try {
       await stat(sentinel);
-      commandRan = true;
     } catch (error) {
-      if (error.code !== "ENOENT") {
+      if (error.code === "ENOENT") {
+        commandRan = true;
+      } else {
         throw error;
       }
     }
@@ -16259,7 +16350,7 @@ async function externalCliRunAuthVerificationCheck(tmp) {
   };
 }
 
-async function commandTimeoutContractCheck() {
+async function commandTimeoutContractCheck(tmp) {
   const command = "node -e 'setTimeout(() => console.log(\"default-timeout-ok\"), 20)'";
   try {
     const result = await runCommand(command, { maxOutputChars: 100000 });
@@ -16273,6 +16364,37 @@ async function commandTimeoutContractCheck() {
       invalidRejected = /timeoutMs must be a positive integer/.test(error.message);
     }
     assertEqual(invalidRejected, true, "invalid timeout rejected");
+    if (process.platform !== "win32") {
+      const pidPath = join(tmp, "timed-out-command.pid");
+      const stubbornTree = [
+        "trap '' TERM",
+        "sleep 30 & child=$!",
+        `printf '%s %s' "$$" "$child" > ${quoteShell(pidPath)}`,
+        "wait"
+      ].join("; ");
+      const timedOut = await runCommand(stubbornTree, {
+        timeoutMs: 500,
+        maxOutputChars: 1000
+      });
+      assertEqual(timedOut.status, 124, "timed out command status");
+      assertEqual(timedOut.timedOut, true, "timed out command marker");
+      const pids = (await readFile(pidPath, "utf8")).trim().split(/\s+/).map(Number);
+      assertEqual(pids.length, 2, "timed out process tree pids captured");
+      for (const pid of pids) {
+        let alive = true;
+        try {
+          process.kill(pid, 0);
+        } catch (error) {
+          if (error.code === "ESRCH") {
+            alive = false;
+          } else {
+            throw error;
+          }
+        }
+        assertEqual(alive, false, `timed out process ${pid} is closed`);
+      }
+      await assertShutdownSignalCleansProcessTree(tmp);
+    }
     return {
       id: "command-timeout-contract",
       status: "PASS",
@@ -16290,9 +16412,90 @@ async function commandTimeoutContractCheck() {
   }
 }
 
+async function assertShutdownSignalCleansProcessTree(tmp) {
+  const shutdownSignal = "SIGQUIT";
+  const expectedExitCode = 131;
+  const pidPath = join(tmp, "shutdown-forwarding-command.pid");
+  const commandsModuleUrl = new URL("./commands.mjs", import.meta.url).href;
+  const command = [
+    "trap '' TERM INT HUP QUIT",
+    "(trap '' TERM INT HUP QUIT; sleep 30) & child=$!",
+    `printf '%s %s' "$$" "$child" > ${quoteShell(pidPath)}`,
+    "wait"
+  ].join("; ");
+  const runnerCode = [
+    `import { runCommand } from ${JSON.stringify(commandsModuleUrl)};`,
+    `process.on(${JSON.stringify(shutdownSignal)}, () => {});`,
+    `await runCommand(${JSON.stringify(command)}, { timeoutMs: 60000 });`
+  ].join("\n");
+  const runner = spawn(process.execPath, ["--input-type=module", "-e", runnerCode], {
+    stdio: "ignore"
+  });
+  const closed = new Promise((resolve, reject) => {
+    runner.once("error", reject);
+    runner.once("close", (status, signal) => resolve({ status, signal }));
+  });
+  let pids = null;
+  try {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      try {
+        const raw = (await readFile(pidPath, "utf8")).trim();
+        if (/^\d+ \d+$/.test(raw)) {
+          pids = raw.split(" ").map(Number);
+          break;
+        }
+      } catch (error) {
+        if (error.code !== "ENOENT") {
+          throw error;
+        }
+      }
+      await sleep(25);
+    }
+    assertEqual(pids?.length, 2, "shutdown forwarding process tree pids captured");
+    runner.kill(shutdownSignal);
+    const result = await Promise.race([
+      closed,
+      sleep(5000).then(() => {
+        throw new Error("shutdown forwarding runner did not exit");
+      })
+    ]);
+    assertEqual(result.status, expectedExitCode, "shutdown forwarding returns the conventional signal exit code");
+    for (const pid of pids) {
+      let alive = true;
+      try {
+        process.kill(pid, 0);
+      } catch (error) {
+        if (error.code === "ESRCH") {
+          alive = false;
+        } else {
+          throw error;
+        }
+      }
+      assertEqual(alive, false, `shutdown-forwarded process ${pid} is closed`);
+    }
+  } finally {
+    if (runner.exitCode === null && runner.signalCode === null) {
+      runner.kill("SIGTERM");
+      await Promise.race([closed.catch(() => null), sleep(1500)]);
+      if (runner.exitCode === null && runner.signalCode === null) {
+        runner.kill("SIGKILL");
+      }
+    }
+    if (pids?.[0]) {
+      try {
+        process.kill(-pids[0], "SIGKILL");
+      } catch (error) {
+        if (error.code !== "ESRCH") {
+          throw error;
+        }
+      }
+    }
+  }
+}
+
 async function commandOutputBudgetCheck() {
   try {
-    const result = await runCommand("node -e 'process.stdout.write(\"x\".repeat(80)); process.stderr.write(\"y\".repeat(30));'", {
+    const result = await runCommand("node -e 'process.stdout.write(\"x\".repeat(1000000)); process.stderr.write(\"y\".repeat(100000));'", {
       timeoutMs: 10000,
       maxOutputChars: 20
     });
@@ -16300,8 +16503,20 @@ async function commandOutputBudgetCheck() {
     assertEqual(result.outputBudget?.schemaVersion, "kova.commandOutputBudget.v1", "command output budget schema");
     assertEqual(result.outputBudget?.stdout?.truncated, true, "stdout budget truncates");
     assertEqual(result.outputBudget?.stderr?.truncated, true, "stderr budget truncates");
-    assertEqual(result.outputBudget?.stdout?.omittedChars, 60, "stdout omitted chars");
-    assertEqual(result.outputBudget?.stderr?.omittedChars, 10, "stderr omitted chars");
+    assertEqual(result.outputBudget?.stdout?.omittedChars, 999980, "stdout omitted chars");
+    assertEqual(result.outputBudget?.stderr?.omittedChars, 99980, "stderr omitted chars");
+    const redactionValue = "kova-sensitive-marker";
+    const accumulator = createBoundedOutputAccumulator({
+      limit: 20,
+      redactValues: [redactionValue]
+    });
+    accumulator.write("prefix-kova-sensitive-");
+    accumulator.write("marker-suffix-that-is-truncated");
+    const redacted = accumulator.finish();
+    assertEqual(redacted.text.includes(redactionValue), false, "streaming accumulator redacts split secrets");
+    assertEqual(redacted.text.startsWith("prefix-[REDACTED]"), true, "streaming accumulator retains redaction marker");
+    assertEqual(redacted.truncated, true, "streaming redacted output remains bounded");
+    assertEqual(redacted.retainedChars, 20, "streaming redacted output cap");
     return {
       id: "command-output-budget",
       status: "PASS",
@@ -16456,12 +16671,51 @@ function optionalNoLogsCommandCheck() {
       command: "ocm logs 'kova-empty-logs' --tail 250 --raw",
       status: 1,
       stdout: "",
-      stderr: "ocm: no logs exist for env \"kova-empty-logs\" across stdout or stderr"
+      stderr: "ocm: no logs exist for env \"kova-empty-logs\" across stdout or stderr\n"
     });
-    assertEqual(isNoLogsOutput(`${result.stdout ?? ""}\n${result.stderr ?? ""}`), true, "missing logs output is detected");
+    assertEqual(isNoLogsOutput(result.stderr), true, "exact missing logs stderr is detected");
+    assertEqual(isOptionalNoLogsResult(result), true, "empty stdout and exact stderr are optional");
     assertEqual(result.status, 0, "missing logs are normalized to optional success");
     assertEqual(result.originalStatus, 1, "original log command status retained");
     assertEqual(result.optional, true, "optional marker set");
+    for (const candidate of [
+      {
+        command: "ocm logs 'kova-empty-logs' --tail 250 --raw",
+        status: 1,
+        stdout: "unexpected output",
+        stderr: "ocm: no logs exist for env \"kova-empty-logs\" across stdout or stderr\n"
+      },
+      {
+        command: "ocm logs 'kova-empty-logs' --tail 250 --raw",
+        status: 1,
+        stdout: "",
+        stderr: "warning\nocm: no logs exist for env \"kova-empty-logs\" across stdout or stderr\n"
+      },
+      {
+        command: "ocm logs 'kova-empty-logs' --tail 250 --raw",
+        status: 1,
+        stdout: "",
+        stderr: "ocm: no logs exist for env \"kova-empty-logs\" across stdout or stderr\nextra"
+      },
+      {
+        command: "ocm logs 'kova-empty-logs' --tail 250 --raw",
+        status: 124,
+        timedOut: true,
+        stdout: "",
+        stderr: "ocm: no logs exist for env \"kova-empty-logs\" across stdout or stderr\n"
+      },
+      {
+        command: "ocm logs 'kova-empty-logs' --tail 250 --raw",
+        status: 1,
+        signal: "SIGTERM",
+        stdout: "",
+        stderr: "ocm: no logs exist for env \"kova-empty-logs\" across stdout or stderr\n"
+      }
+    ]) {
+      normalizeOptionalCommandResult(candidate);
+      assertEqual(candidate.status, 1, "non-exact missing logs output remains failed");
+      assertEqual(candidate.optional, undefined, "non-exact missing logs output is not optional");
+    }
     return {
       id: "optional-no-logs-command",
       status: "PASS",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -16713,8 +16713,9 @@ function optionalNoLogsCommandCheck() {
         stderr: "ocm: no logs exist for env \"kova-empty-logs\" across stdout or stderr\n"
       }
     ]) {
+      const originalStatus = candidate.status;
       normalizeOptionalCommandResult(candidate);
-      assertEqual(candidate.status, 1, "non-exact missing logs output remains failed");
+      assertEqual(candidate.status, originalStatus, "non-exact missing logs output retains its failure status");
       assertEqual(candidate.optional, undefined, "non-exact missing logs output is not optional");
     }
     return {


### PR DESCRIPTION
## What Problem This Solves

Kova command execution could retain unbounded output, leave descendant processes alive after timeouts or runner shutdown, treat mixed log failures as optional success, and validate scenario commands without fully accounting for shell parsing and delegated command wrappers.

## Why This Change Was Made

- Bound stdout and stderr while streaming, including redaction across chunk boundaries.
- Run POSIX commands in owned process groups and clean them up on timeout and runner shutdown.
- Preserve failed process groups in the shutdown registry when forced termination cannot be confirmed.
- Normalize optional OCM log absence only for the exact expected stderr, empty stdout, ordinary exit status, and no timeout or signal.
- Parse scenario commands into canonical shell words, reject compound or expanding forms, restrict Node helpers and cleanup paths, and recursively validate delegated OCM commands.
- Keep the existing async-local command environment isolation from current `main`.

## User Impact

Kova runs now have bounded, secret-safe command output and more reliable cleanup. Unsafe or ambiguous scenario command forms fail before execution, while exact optional no-log responses remain non-fatal.

## Evidence

- `NO_COLOR=1 npm run check`
  - concurrent self-check isolation: pass
  - Kova self-check: 231/231 passed in 75.0s
- Sol/high autoreview over the complete behavioral range: clean, confidence 0.83
- Targeted timeout, SIGQUIT shutdown, output redaction, optional-log, delegated-command, and cleanup-path proofs passed during development.
- `git diff --check`

