### PR TITLE
fix(runtime): harden provider process cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Kova are documented in this file.
 ### Fixed
 
 - Hardened command execution with bounded streaming redaction, POSIX process-group cleanup, strict optional-log matching, and direct scenario command validation.
+- Hardened mock-provider and diagnostic process handling to avoid signaling unrelated processes, clean failed launches safely, retain retryable PID state, and preserve colliding diagnostic artifacts.
 - Fixed OpenClaw inventory discovery to recognize canonical JSON5 plugin manifests consistently across platforms while deterministically bounding scans.
 - Isolated concurrent self-check OCM identities, child environments, runtime names, and temp cleanup ownership.
 - Hardened performance baseline persistence, unstable-group detection, and repeated-work audit isolation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Kova are documented in this file.
 ### Fixed
 
 - Hardened command execution with bounded streaming redaction, POSIX process-group cleanup, strict optional-log matching, and direct scenario command validation.
-- Hardened mock-provider and diagnostic process handling to migrate active legacy providers safely, avoid signaling unrelated processes, retain retryable PID state, and preserve colliding diagnostic artifacts.
+- Hardened mock-provider and diagnostic process handling to migrate active legacy providers safely, reject stale startup metadata, avoid signaling unrelated processes, retain retryable PID state, and preserve colliding diagnostic artifacts.
 - Fixed OpenClaw inventory discovery to recognize canonical JSON5 plugin manifests consistently across platforms while deterministically bounding scans.
 - Isolated concurrent self-check OCM identities, child environments, runtime names, and temp cleanup ownership.
 - Hardened performance baseline persistence, unstable-group detection, and repeated-work audit isolation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Kova are documented in this file.
 ### Fixed
 
 - Hardened command execution with bounded streaming redaction, POSIX process-group cleanup, strict optional-log matching, and direct scenario command validation.
-- Hardened mock-provider and diagnostic process handling to avoid signaling unrelated processes, clean failed launches safely, retain retryable PID state, and preserve colliding diagnostic artifacts.
+- Hardened mock-provider and diagnostic process handling to migrate active legacy providers safely, avoid signaling unrelated processes, retain retryable PID state, and preserve colliding diagnostic artifacts.
 - Fixed OpenClaw inventory discovery to recognize canonical JSON5 plugin manifests consistently across platforms while deterministically bounding scans.
 - Isolated concurrent self-check OCM identities, child environments, runtime names, and temp cleanup ownership.
 - Hardened performance baseline persistence, unstable-group detection, and repeated-work audit isolation.

--- a/src/auth.mjs
+++ b/src/auth.mjs
@@ -6,6 +6,7 @@ import { basename, isAbsolute, join } from "node:path";
 import { credentialsDir, liveEnvPath, providersPath, repoRoot } from "./paths.mjs";
 import { quoteShell } from "./commands.mjs";
 import { ocmAt, ocmEnvExec } from "./ocm/commands.mjs";
+import { mockProviderSupervisorArgs } from "./process-safety.mjs";
 import {
   externalCliVerificationSummary,
   resolveExternalCliName,
@@ -1097,26 +1098,41 @@ function startMockProviderCommand(dir, mockProvider = {}) {
 }
 
 export function mockAiProviderServeCommand({ scriptPath, requestLog, serverLog, pidFile }) {
+  const values = {
+    supervisorPath: join(repoRoot, "support/mock-ai-provider-supervisor.mjs"),
+    scriptPath,
+    requestLog,
+    serverLog,
+    pidFile
+  };
   const bin = quoteShell(join(repoRoot, "node_modules/.bin/mock-ai-provider"));
-  const args = `serve --providers openai --script ${quoteShell(scriptPath)} --port 0 --request-log ${quoteShell(requestLog)}`;
-  const output = `>${quoteShell(serverLog)} 2>&1 & echo $! >${quoteShell(pidFile)}`;
-  return `test -x ${bin} || { echo "Kova requires the local npm package mock-ai-provider; run npm install in the Kova repo" >&2; exit 127; }; ${bin} ${args} ${output}`;
+  const publishedPid = quoteShell(pidFile);
+  const readPublishedPid = [
+    "node",
+    "-e",
+    quoteShell("const fs=require('fs'); const record=JSON.parse(fs.readFileSync(process.argv[1],'utf8')); process.stdout.write(String(record.pid));"),
+    publishedPid
+  ].join(" ");
+  const supervisor = ["node", ...mockProviderSupervisorArgs(values)].map(quoteShell).join(" ");
+  return `test -x ${bin} || { echo "Kova requires the local npm package mock-ai-provider; run npm install in the Kova repo" >&2; exit 127; }; ${supervisor} >/dev/null 2>&1 & supervisor_pid=$!; for i in $(seq 1 100); do if test -s ${publishedPid}; then published_pid=$(${readPublishedPid} 2>/dev/null || true); test "$published_pid" = "$supervisor_pid" && break; fi; kill -0 "$supervisor_pid" 2>/dev/null || break; sleep 0.05; done; published_pid=$(${readPublishedPid} 2>/dev/null || true); test "$published_pid" = "$supervisor_pid" || { kill "$supervisor_pid" 2>/dev/null || true; wait "$supervisor_pid"; status=$?; test "$status" -ne 0 && exit "$status"; echo "Kova mock provider supervisor did not publish its PID" >&2; exit 1; }`;
 }
 
 export function mockProviderCleanupCommand(dir) {
   const values = {
     pidFile: join(dir, "pid"),
-    executablePath: join(repoRoot, "node_modules/.bin/mock-ai-provider"),
+    supervisorPath: join(repoRoot, "support/mock-ai-provider-supervisor.mjs"),
     scriptPath: join(dir, "script.json"),
-    requestLog: join(dir, "requests.jsonl")
+    requestLog: join(dir, "requests.jsonl"),
+    serverLog: join(dir, "server.log")
   };
   return [
     "node",
     quoteShell(join(repoRoot, "support/stop-mock-ai-provider.mjs")),
     "--pid-file", quoteShell(values.pidFile),
-    "--executable", quoteShell(values.executablePath),
+    "--supervisor", quoteShell(values.supervisorPath),
     "--script", quoteShell(values.scriptPath),
-    "--request-log", quoteShell(values.requestLog)
+    "--request-log", quoteShell(values.requestLog),
+    "--server-log", quoteShell(values.serverLog)
   ].join(" ");
 }
 

--- a/src/auth.mjs
+++ b/src/auth.mjs
@@ -1121,6 +1121,7 @@ export function mockProviderCleanupCommand(dir) {
   const values = {
     pidFile: join(dir, "pid"),
     supervisorPath: join(repoRoot, "support/mock-ai-provider-supervisor.mjs"),
+    legacyExecutablePath: join(repoRoot, "node_modules/.bin/mock-ai-provider"),
     scriptPath: join(dir, "script.json"),
     requestLog: join(dir, "requests.jsonl"),
     serverLog: join(dir, "server.log")
@@ -1130,6 +1131,7 @@ export function mockProviderCleanupCommand(dir) {
     quoteShell(join(repoRoot, "support/stop-mock-ai-provider.mjs")),
     "--pid-file", quoteShell(values.pidFile),
     "--supervisor", quoteShell(values.supervisorPath),
+    "--legacy-executable", quoteShell(values.legacyExecutablePath),
     "--script", quoteShell(values.scriptPath),
     "--request-log", quoteShell(values.requestLog),
     "--server-log", quoteShell(values.serverLog)

--- a/src/auth.mjs
+++ b/src/auth.mjs
@@ -293,7 +293,7 @@ export function buildAuthCleanupPhase(authPolicy, artifactDir) {
     title: "Auth Cleanup",
     intent: "Stop Kova's deterministic mock provider.",
     collectionIntent: "skip-env",
-    commands: [`if test -f ${quoteShell(join(dir, "pid"))}; then kill "$(cat ${quoteShell(join(dir, "pid"))})" 2>/dev/null || true; fi`],
+    commands: [mockProviderCleanupCommand(dir)],
     evidence: ["mock provider stopped"]
   };
 }
@@ -1083,11 +1083,14 @@ function startMockProviderCommand(dir, mockProvider = {}) {
     quoteShell(serverLog),
     quoteShell(portFile)
   ].join(" ");
+  const cleanup = mockProviderCleanupCommand(dir);
   return [
     `mkdir -p ${quoteShell(dir)}`,
+    `${cleanup} || exit $?`,
     `node ${quoteShell(join(repoRoot, "support/write-mock-ai-provider-script.mjs"))} ${scriptArgText}`,
     mockAiProviderServeCommand({ scriptPath, requestLog, serverLog, pidFile }),
     `for i in $(seq 1 100); do ${writePort} >/dev/null 2>&1 && test -s ${quoteShell(portFile)} && node -e 'fetch("http://127.0.0.1:"+process.argv[1]+"/health").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))' "$(cat ${quoteShell(portFile)})" && exit 0; sleep 0.1; done`,
+    cleanup,
     `cat ${quoteShell(serverLog)} >&2`,
     "exit 1"
   ].join("; ");
@@ -1098,6 +1101,23 @@ export function mockAiProviderServeCommand({ scriptPath, requestLog, serverLog, 
   const args = `serve --providers openai --script ${quoteShell(scriptPath)} --port 0 --request-log ${quoteShell(requestLog)}`;
   const output = `>${quoteShell(serverLog)} 2>&1 & echo $! >${quoteShell(pidFile)}`;
   return `test -x ${bin} || { echo "Kova requires the local npm package mock-ai-provider; run npm install in the Kova repo" >&2; exit 127; }; ${bin} ${args} ${output}`;
+}
+
+export function mockProviderCleanupCommand(dir) {
+  const values = {
+    pidFile: join(dir, "pid"),
+    executablePath: join(repoRoot, "node_modules/.bin/mock-ai-provider"),
+    scriptPath: join(dir, "script.json"),
+    requestLog: join(dir, "requests.jsonl")
+  };
+  return [
+    "node",
+    quoteShell(join(repoRoot, "support/stop-mock-ai-provider.mjs")),
+    "--pid-file", quoteShell(values.pidFile),
+    "--executable", quoteShell(values.executablePath),
+    "--script", quoteShell(values.scriptPath),
+    "--request-log", quoteShell(values.requestLog)
+  ].join(" ");
 }
 
 function mockProviderPolicy(scenario, state) {

--- a/src/auth.mjs
+++ b/src/auth.mjs
@@ -1077,13 +1077,7 @@ function startMockProviderCommand(dir, mockProvider = {}) {
     }
   }
   const scriptArgText = scriptArgs.map(quoteShell).join(" ");
-  const writePort = [
-    "node",
-    "-e",
-    quoteShell("const fs=require('fs'); const [logPath, portPath] = process.argv.slice(1); const line=fs.readFileSync(logPath,'utf8').split(/\\r?\\n/).find(Boolean); if (!line) process.exit(1); const startup=JSON.parse(line); if (!startup.port) process.exit(1); fs.writeFileSync(portPath, String(startup.port));"),
-    quoteShell(serverLog),
-    quoteShell(portFile)
-  ].join(" ");
+  const writePort = mockProviderPortCommand({ serverLog, pidFile, portFile });
   const cleanup = mockProviderCleanupCommand(dir);
   return [
     `mkdir -p ${quoteShell(dir)}`,
@@ -1110,11 +1104,23 @@ export function mockAiProviderServeCommand({ scriptPath, requestLog, serverLog, 
   const readPublishedPid = [
     "node",
     "-e",
-    quoteShell("const fs=require('fs'); const record=JSON.parse(fs.readFileSync(process.argv[1],'utf8')); process.stdout.write(String(record.pid));"),
-    publishedPid
+    quoteShell("const fs=require('fs'); const [pidPath,logPath]=process.argv.slice(1); const owner=JSON.parse(fs.readFileSync(pidPath,'utf8')); const line=fs.readFileSync(logPath,'utf8').split(/\\r?\\n/).find(Boolean); if(!line)process.exit(1); const startup=JSON.parse(line); const sameOwner=startup.owner?.schemaVersion===owner.schemaVersion&&startup.owner?.pid===owner.pid&&startup.owner?.token===owner.token; if(!sameOwner)process.exit(1); process.stdout.write(String(owner.pid));"),
+    publishedPid,
+    quoteShell(serverLog)
   ].join(" ");
   const supervisor = ["node", ...mockProviderSupervisorArgs(values)].map(quoteShell).join(" ");
   return `test -x ${bin} || { echo "Kova requires the local npm package mock-ai-provider; run npm install in the Kova repo" >&2; exit 127; }; ${supervisor} >/dev/null 2>&1 & supervisor_pid=$!; for i in $(seq 1 100); do if test -s ${publishedPid}; then published_pid=$(${readPublishedPid} 2>/dev/null || true); test "$published_pid" = "$supervisor_pid" && break; fi; kill -0 "$supervisor_pid" 2>/dev/null || break; sleep 0.05; done; published_pid=$(${readPublishedPid} 2>/dev/null || true); test "$published_pid" = "$supervisor_pid" || { kill "$supervisor_pid" 2>/dev/null || true; wait "$supervisor_pid"; status=$?; test "$status" -ne 0 && exit "$status"; echo "Kova mock provider supervisor did not publish its PID" >&2; exit 1; }`;
+}
+
+export function mockProviderPortCommand({ serverLog, pidFile, portFile }) {
+  return [
+    "node",
+    "-e",
+    quoteShell("const fs=require('fs'); const [logPath,pidPath,portPath]=process.argv.slice(1); const line=fs.readFileSync(logPath,'utf8').split(/\\r?\\n/).find(Boolean); if(!line)process.exit(1); const startup=JSON.parse(line); const owner=JSON.parse(fs.readFileSync(pidPath,'utf8')); const sameOwner=startup.owner?.schemaVersion===owner.schemaVersion&&startup.owner?.pid===owner.pid&&startup.owner?.token===owner.token; if(!sameOwner||!Number.isInteger(startup.port)||startup.port<=0)process.exit(1); fs.writeFileSync(portPath,String(startup.port));"),
+    quoteShell(serverLog),
+    quoteShell(pidFile),
+    quoteShell(portFile)
+  ].join(" ");
 }
 
 export function mockProviderCleanupCommand(dir) {

--- a/src/collectors/diagnostics.mjs
+++ b/src/collectors/diagnostics.mjs
@@ -1,8 +1,10 @@
+import { createHash } from "node:crypto";
 import { cp, mkdir, readdir, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, extname, join, resolve } from "node:path";
 import { runCommand } from "../commands.mjs";
 import { ocmEnvExecShell } from "../ocm/commands.mjs";
+import { positiveProcessId } from "../process-safety.mjs";
 
 export const OPENCLAW_DIAGNOSTICS_SCHEMA = "kova.openclawDiagnostics.v1";
 export const DIAGNOSTIC_ARTIFACTS_SCHEMA = "kova.diagnosticArtifacts.v1";
@@ -58,7 +60,7 @@ export async function collectDiagnosticMetrics(envName, timeoutMs, artifactDir, 
       if (!existsSync(file)) {
         continue;
       }
-      const target = join(diagnosticsDir, basename(file));
+      const target = join(diagnosticsDir, diagnosticArtifactName(file));
       await cp(file, target, { force: true });
       artifactBytes += await fileSize(target);
       artifacts.push(target);
@@ -81,9 +83,10 @@ export async function collectDiagnosticMetrics(envName, timeoutMs, artifactDir, 
 }
 
 export async function triggerHeapSnapshot(envName, pid, timeoutMs, artifactDir, commandEnv) {
+  const targetPid = positiveProcessId(pid, "heap snapshot pid");
   const command = ocmEnvExecShell(
     envName,
-    `kill -USR2 ${Number(pid)} 2>/dev/null || true; sleep 1; find "$OPENCLAW_HOME" -maxdepth 6 -type f -name "*.heapsnapshot" -print 2>/dev/null | head -25`
+    `kill -USR2 ${targetPid} 2>/dev/null || true; sleep 1; find "$OPENCLAW_HOME" -maxdepth 6 -type f -name "*.heapsnapshot" -print 2>/dev/null | head -25`
   );
   const result = await runCommand(command, {
     timeoutMs,
@@ -104,7 +107,7 @@ export async function triggerHeapSnapshot(envName, pid, timeoutMs, artifactDir, 
         continue;
       }
       await waitForStableFile(file, Math.min(timeoutMs, 5000));
-      const target = join(heapDir, basename(file));
+      const target = join(heapDir, diagnosticArtifactName(file));
       await cp(file, target, { force: true });
       artifactBytes += await fileSize(target);
       artifacts.push(target);
@@ -126,7 +129,8 @@ export async function triggerHeapSnapshot(envName, pid, timeoutMs, artifactDir, 
 }
 
 export async function triggerDiagnosticReport(envName, pid, timeoutMs, artifactDir, options = {}) {
-  const signalCommand = options.signalAlreadySent === true ? ":" : `kill -USR2 ${Number(pid)} 2>/dev/null || true`;
+  const targetPid = positiveProcessId(pid, "diagnostic report pid");
+  const signalCommand = options.signalAlreadySent === true ? ":" : `kill -USR2 ${targetPid} 2>/dev/null || true`;
   const command = ocmEnvExecShell(
     envName,
     `${signalCommand}; sleep 1; find "$OPENCLAW_HOME" -maxdepth 6 -type f \\( -name "report.*.json" -o -name "*diagnostic*.json" \\) -print 2>/dev/null | head -25`
@@ -151,7 +155,7 @@ export async function triggerDiagnosticReport(envName, pid, timeoutMs, artifactD
       if (!existsSync(file)) {
         continue;
       }
-      const target = join(reportDir, basename(file));
+      const target = join(reportDir, diagnosticArtifactName(file));
       await cp(file, target, { force: true });
       artifactBytes += await fileSize(target);
       artifacts.push(target);
@@ -170,6 +174,14 @@ export async function triggerDiagnosticReport(envName, pid, timeoutMs, artifactD
     artifacts,
     error: result.status === 0 ? null : firstOutputLine(result.stderr) || firstOutputLine(result.stdout) || "diagnostic report trigger unavailable"
   };
+}
+
+export function diagnosticArtifactName(path) {
+  const name = basename(path);
+  const extension = extname(name);
+  const stem = extension ? name.slice(0, -extension.length) : name;
+  const sourceHash = createHash("sha256").update(resolve(path)).digest("hex").slice(0, 12);
+  return `${stem}-${sourceHash}${extension}`;
 }
 
 async function collectLocalDiagnosticReports(artifactDir) {

--- a/src/process-safety.mjs
+++ b/src/process-safety.mjs
@@ -1,0 +1,97 @@
+import { execFile } from "node:child_process";
+import { readFile, rm } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export function positiveProcessId(value, label = "pid") {
+  const text = typeof value === "string" ? value.trim() : value;
+  const pid = typeof text === "number" ? text : Number(text);
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    throw new Error(`${label} must be a positive integer, got ${JSON.stringify(value)}`);
+  }
+  return pid;
+}
+
+export function isOwnedMockProviderCommand(command, expected) {
+  const text = String(command ?? "").trim();
+  const executable = escapeRegExp(expected.executablePath);
+  const script = escapeRegExp(expected.scriptPath);
+  const requestLog = escapeRegExp(expected.requestLog);
+  const invocation = new RegExp(
+    `^(?:\\S*node\\s+)?${executable}\\s+serve\\s+--providers\\s+openai\\s+--script\\s+${script}\\s+--port\\s+0\\s+--request-log\\s+${requestLog}(?=\\s|$)`
+  );
+  return invocation.test(text);
+}
+
+export async function stopOwnedMockProvider(options) {
+  const {
+    pidFile,
+    executablePath,
+    scriptPath,
+    requestLog,
+    inspectProcess = readProcessCommand,
+    signalProcess = process.kill
+  } = options;
+
+  let rawPid;
+  try {
+    rawPid = await readFile(pidFile, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return { status: "already-absent", pid: null };
+    }
+    throw error;
+  }
+
+  let result;
+  let pid;
+  try {
+    pid = positiveProcessId(rawPid, "mock provider pid");
+  } catch {
+    result = { status: "invalid-pid", pid: null };
+  }
+
+  if (!result) {
+    const command = await inspectProcess(pid);
+    if (command === null) {
+      result = { status: "not-running", pid };
+    } else if (!isOwnedMockProviderCommand(command, { executablePath, scriptPath, requestLog })) {
+      result = { status: "identity-mismatch", pid };
+    } else {
+      try {
+        signalProcess(pid, "SIGTERM");
+        result = { status: "signaled", pid };
+      } catch (error) {
+        if (error.code === "ESRCH") {
+          result = { status: "not-running", pid };
+        } else {
+          throw error;
+        }
+      }
+    }
+  }
+
+  await rm(pidFile, { force: true });
+  return result;
+}
+
+async function readProcessCommand(pid) {
+  try {
+    const result = await execFileAsync("ps", ["-ww", "-p", String(pid), "-o", "command="], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024
+    });
+    const command = result.stdout.trim();
+    return command || null;
+  } catch (error) {
+    if (typeof error.code === "number" && error.code === 1) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/process-safety.mjs
+++ b/src/process-safety.mjs
@@ -19,7 +19,7 @@ export function isOwnedMockProviderCommand(command, expected) {
   const script = escapeRegExp(expected.scriptPath);
   const requestLog = escapeRegExp(expected.requestLog);
   const invocation = new RegExp(
-    `^(?:\\S*node\\s+)?${executable}\\s+serve\\s+--providers\\s+openai\\s+--script\\s+${script}\\s+--port\\s+0\\s+--request-log\\s+${requestLog}(?=\\s|$)`
+    `^(?:\\S*node\\s+)?${executable}\\s+serve\\s+--providers\\s+openai\\s+--script\\s+${script}\\s+--port\\s+0\\s+--request-log\\s+${requestLog}\\s*$`
   );
   return invocation.test(text);
 }

--- a/src/process-safety.mjs
+++ b/src/process-safety.mjs
@@ -31,8 +31,12 @@ export async function stopOwnedMockProvider(options) {
     scriptPath,
     requestLog,
     inspectProcess = readProcessCommand,
-    signalProcess = process.kill
+    signalProcess = process.kill,
+    stopTimeoutMs = 5000,
+    pollIntervalMs = 50,
+    wait = sleep
   } = options;
+  const expectedCommand = { executablePath, scriptPath, requestLog };
 
   let rawPid;
   try {
@@ -56,12 +60,11 @@ export async function stopOwnedMockProvider(options) {
     const command = await inspectProcess(pid);
     if (command === null) {
       result = { status: "not-running", pid };
-    } else if (!isOwnedMockProviderCommand(command, { executablePath, scriptPath, requestLog })) {
+    } else if (!isOwnedMockProviderCommand(command, expectedCommand)) {
       result = { status: "identity-mismatch", pid };
     } else {
       try {
         signalProcess(pid, "SIGTERM");
-        result = { status: "signaled", pid };
       } catch (error) {
         if (error.code === "ESRCH") {
           result = { status: "not-running", pid };
@@ -69,11 +72,48 @@ export async function stopOwnedMockProvider(options) {
           throw error;
         }
       }
+      if (!result) {
+        const stopped = await waitForProcessExit({
+          pid,
+          expectedCommand,
+          inspectProcess,
+          stopTimeoutMs,
+          pollIntervalMs,
+          wait
+        });
+        if (!stopped) {
+          throw new Error(`mock provider ${pid} did not stop within ${stopTimeoutMs}ms`);
+        }
+        result = { status: "stopped", pid };
+      }
     }
   }
 
   await rm(pidFile, { force: true });
   return result;
+}
+
+async function waitForProcessExit(options) {
+  const {
+    pid,
+    expectedCommand,
+    inspectProcess,
+    stopTimeoutMs,
+    pollIntervalMs,
+    wait
+  } = options;
+  const deadline = Date.now() + Math.max(0, stopTimeoutMs);
+
+  while (true) {
+    const command = await inspectProcess(pid);
+    if (command === null || !isOwnedMockProviderCommand(command, expectedCommand)) {
+      return true;
+    }
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await wait(Math.min(Math.max(1, pollIntervalMs), deadline - Date.now()));
+  }
 }
 
 async function readProcessCommand(pid) {
@@ -90,6 +130,10 @@ async function readProcessCommand(pid) {
     }
     throw error;
   }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function escapeRegExp(value) {

--- a/src/process-safety.mjs
+++ b/src/process-safety.mjs
@@ -1,8 +1,11 @@
 import { execFile } from "node:child_process";
-import { readFile, rm } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { link, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+const mockProviderOwnerSchema = "kova.mock-provider-owner.v1";
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function positiveProcessId(value, label = "pid") {
   const text = typeof value === "string" ? value.trim() : value;
@@ -13,34 +16,61 @@ export function positiveProcessId(value, label = "pid") {
   return pid;
 }
 
-export function isOwnedMockProviderCommand(command, expected) {
+export function isOwnedMockProviderSupervisorCommand(command, expected) {
   const text = String(command ?? "").trim();
-  const executable = escapeRegExp(expected.executablePath);
-  const script = escapeRegExp(expected.scriptPath);
-  const requestLog = escapeRegExp(expected.requestLog);
+  const args = mockProviderSupervisorArgs(expected).map(escapeRegExp).join("\\s+");
   const invocation = new RegExp(
-    `^(?:\\S*node\\s+)?${executable}\\s+serve\\s+--providers\\s+openai\\s+--script\\s+${script}\\s+--port\\s+0\\s+--request-log\\s+${requestLog}\\s*$`
+    `^(?:node|\\S*[\\\\/]node)\\s+${args}\\s*$`
   );
   return invocation.test(text);
+}
+
+export function mockProviderSupervisorArgs(expected) {
+  return [
+    expected.supervisorPath,
+    "--script", expected.scriptPath,
+    "--request-log", expected.requestLog,
+    "--server-log", expected.serverLog,
+    "--pid-file", expected.pidFile
+  ];
+}
+
+export function mockProviderOwnerRecord(pid, token) {
+  return {
+    schemaVersion: mockProviderOwnerSchema,
+    pid: positiveProcessId(pid, "mock provider pid"),
+    token: validOwnerToken(token)
+  };
+}
+
+export function mockProviderStopFile(pidFile, owner) {
+  const pid = positiveProcessId(owner.pid, "mock provider pid");
+  return `${pidFile}.stop.${pid}.${validOwnerToken(owner.token)}`;
 }
 
 export async function stopOwnedMockProvider(options) {
   const {
     pidFile,
-    executablePath,
+    supervisorPath,
     scriptPath,
     requestLog,
+    serverLog,
     inspectProcess = readProcessCommand,
-    signalProcess = process.kill,
+    requestStop = writeStopRequest,
     stopTimeoutMs = 5000,
     pollIntervalMs = 50,
     wait = sleep
   } = options;
-  const expectedCommand = { executablePath, scriptPath, requestLog };
-
-  let rawPid;
+  const expectedCommand = {
+    supervisorPath,
+    scriptPath,
+    requestLog,
+    serverLog,
+    pidFile
+  };
+  let rawOwner;
   try {
-    rawPid = await readFile(pidFile, "utf8");
+    rawOwner = await readFile(pidFile, "utf8");
   } catch (error) {
     if (error.code === "ENOENT") {
       return { status: "already-absent", pid: null };
@@ -49,9 +79,11 @@ export async function stopOwnedMockProvider(options) {
   }
 
   let result;
+  let owner;
   let pid;
   try {
-    pid = positiveProcessId(rawPid, "mock provider pid");
+    owner = parseMockProviderOwner(rawOwner);
+    pid = owner.pid;
   } catch {
     result = { status: "invalid-pid", pid: null };
   }
@@ -60,37 +92,91 @@ export async function stopOwnedMockProvider(options) {
     const command = await inspectProcess(pid);
     if (command === null) {
       result = { status: "not-running", pid };
-    } else if (!isOwnedMockProviderCommand(command, expectedCommand)) {
+    } else if (!isOwnedMockProviderSupervisorCommand(command, expectedCommand)) {
       result = { status: "identity-mismatch", pid };
     } else {
-      try {
-        signalProcess(pid, "SIGTERM");
-      } catch (error) {
-        if (error.code === "ESRCH") {
-          result = { status: "not-running", pid };
-        } else {
-          throw error;
-        }
+      const stopFile = mockProviderStopFile(pidFile, owner);
+      await requestStop(stopFile);
+      const stopped = await waitForProcessExit({
+        pid,
+        expectedCommand,
+        inspectProcess,
+        stopTimeoutMs,
+        pollIntervalMs,
+        wait
+      });
+      if (!stopped) {
+        throw new Error(`mock provider supervisor ${pid} did not stop within ${stopTimeoutMs}ms`);
       }
-      if (!result) {
-        const stopped = await waitForProcessExit({
-          pid,
-          expectedCommand,
-          inspectProcess,
-          stopTimeoutMs,
-          pollIntervalMs,
-          wait
-        });
-        if (!stopped) {
-          throw new Error(`mock provider ${pid} did not stop within ${stopTimeoutMs}ms`);
-        }
-        result = { status: "stopped", pid };
-      }
+      result = { status: "stopped", pid };
     }
   }
 
-  await rm(pidFile, { force: true });
+  await removeOwnedControlFiles({
+    pidFile,
+    rawOwner,
+    stopFile: owner ? mockProviderStopFile(pidFile, owner) : null
+  });
   return result;
+}
+
+function parseMockProviderOwner(rawOwner) {
+  const parsed = JSON.parse(rawOwner);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("mock provider owner must be an object");
+  }
+  if (parsed.schemaVersion !== mockProviderOwnerSchema) {
+    throw new Error(`unsupported mock provider owner schema: ${String(parsed.schemaVersion)}`);
+  }
+  return mockProviderOwnerRecord(parsed.pid, parsed.token);
+}
+
+async function removeOwnedControlFiles({ pidFile, rawOwner, stopFile }) {
+  if (stopFile) {
+    await rm(stopFile, { force: true });
+  }
+  await removeMockProviderOwnerFile(pidFile, rawOwner);
+}
+
+export async function removeMockProviderOwnerFile(pidFile, expectedOwner) {
+  let currentOwner;
+  try {
+    currentOwner = await readFile(pidFile, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT" || error.code === "EISDIR") {
+      return;
+    }
+    throw error;
+  }
+  if (currentOwner !== expectedOwner) {
+    return;
+  }
+
+  // Claim the path atomically, then verify the claimed generation. If a
+  // replacement won the race, restore its record without overwriting a newer one.
+  const claimedFile = `${pidFile}.cleanup.${randomUUID()}`;
+  try {
+    await rename(pidFile, claimedFile);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  try {
+    const claimedOwner = await readFile(claimedFile, "utf8");
+    if (claimedOwner !== expectedOwner) {
+      try {
+        await link(claimedFile, pidFile);
+      } catch (error) {
+        if (error.code !== "EEXIST") {
+          throw error;
+        }
+      }
+    }
+  } finally {
+    await rm(claimedFile, { force: true });
+  }
 }
 
 async function waitForProcessExit(options) {
@@ -106,7 +192,7 @@ async function waitForProcessExit(options) {
 
   while (true) {
     const command = await inspectProcess(pid);
-    if (command === null || !isOwnedMockProviderCommand(command, expectedCommand)) {
+    if (command === null || !isOwnedMockProviderSupervisorCommand(command, expectedCommand)) {
       return true;
     }
     if (Date.now() >= deadline) {
@@ -132,10 +218,21 @@ async function readProcessCommand(pid) {
   }
 }
 
+async function writeStopRequest(stopFile) {
+  await writeFile(stopFile, `${Date.now()}\n`, "utf8");
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function validOwnerToken(value) {
+  if (typeof value !== "string" || !uuidPattern.test(value)) {
+    throw new Error(`mock provider owner token must be a UUID, got ${JSON.stringify(value)}`);
+  }
+  return value;
 }

--- a/src/process-safety.mjs
+++ b/src/process-safety.mjs
@@ -25,6 +25,17 @@ export function isOwnedMockProviderSupervisorCommand(command, expected) {
   return invocation.test(text);
 }
 
+export function isOwnedLegacyMockProviderCommand(command, expected) {
+  const text = String(command ?? "").trim();
+  const executable = escapeRegExp(expected.legacyExecutablePath);
+  const script = escapeRegExp(expected.scriptPath);
+  const requestLog = escapeRegExp(expected.requestLog);
+  const invocation = new RegExp(
+    `^(?:(?:node|\\S*[\\\\/]node)\\s+)?${executable}\\s+serve\\s+--providers\\s+openai\\s+--script\\s+${script}\\s+--port\\s+0\\s+--request-log\\s+${requestLog}\\s*$`
+  );
+  return invocation.test(text);
+}
+
 export function mockProviderSupervisorArgs(expected) {
   return [
     expected.supervisorPath,
@@ -52,17 +63,20 @@ export async function stopOwnedMockProvider(options) {
   const {
     pidFile,
     supervisorPath,
+    legacyExecutablePath,
     scriptPath,
     requestLog,
     serverLog,
     inspectProcess = readProcessCommand,
     requestStop = writeStopRequest,
+    signalProcess = process.kill,
     stopTimeoutMs = 5000,
     pollIntervalMs = 50,
     wait = sleep
   } = options;
   const expectedCommand = {
     supervisorPath,
+    legacyExecutablePath,
     scriptPath,
     requestLog,
     serverLog,
@@ -81,17 +95,50 @@ export async function stopOwnedMockProvider(options) {
   let result;
   let owner;
   let pid;
+  let legacy = false;
   try {
     owner = parseMockProviderOwner(rawOwner);
     pid = owner.pid;
   } catch {
-    result = { status: "invalid-pid", pid: null };
+    try {
+      pid = positiveProcessId(rawOwner, "legacy mock provider pid");
+      legacy = true;
+    } catch {
+      result = { status: "invalid-pid", pid: null };
+    }
   }
 
   if (!result) {
     const command = await inspectProcess(pid);
     if (command === null) {
-      result = { status: "not-running", pid };
+      result = { status: legacy ? "legacy-not-running" : "not-running", pid };
+    } else if (legacy) {
+      if (!isOwnedLegacyMockProviderCommand(command, expectedCommand)) {
+        throw new Error(`legacy mock provider pid ${pid} does not match the expected command; retaining ${pidFile}`);
+      }
+      try {
+        signalProcess(pid, "SIGTERM");
+      } catch (error) {
+        if (error.code === "ESRCH") {
+          result = { status: "legacy-not-running", pid };
+        } else {
+          throw error;
+        }
+      }
+      if (!result) {
+        const stopped = await waitForProcessExit({
+          pid,
+          isExpectedCommand: (currentCommand) => isOwnedLegacyMockProviderCommand(currentCommand, expectedCommand),
+          inspectProcess,
+          stopTimeoutMs,
+          pollIntervalMs,
+          wait
+        });
+        if (!stopped) {
+          throw new Error(`legacy mock provider ${pid} did not stop within ${stopTimeoutMs}ms`);
+        }
+        result = { status: "legacy-stopped", pid };
+      }
     } else if (!isOwnedMockProviderSupervisorCommand(command, expectedCommand)) {
       result = { status: "identity-mismatch", pid };
     } else {
@@ -99,7 +146,7 @@ export async function stopOwnedMockProvider(options) {
       await requestStop(stopFile);
       const stopped = await waitForProcessExit({
         pid,
-        expectedCommand,
+        isExpectedCommand: (currentCommand) => isOwnedMockProviderSupervisorCommand(currentCommand, expectedCommand),
         inspectProcess,
         stopTimeoutMs,
         pollIntervalMs,
@@ -182,7 +229,7 @@ export async function removeMockProviderOwnerFile(pidFile, expectedOwner) {
 async function waitForProcessExit(options) {
   const {
     pid,
-    expectedCommand,
+    isExpectedCommand,
     inspectProcess,
     stopTimeoutMs,
     pollIntervalMs,
@@ -192,7 +239,7 @@ async function waitForProcessExit(options) {
 
   while (true) {
     const command = await inspectProcess(pid);
-    if (command === null || !isOwnedMockProviderSupervisorCommand(command, expectedCommand)) {
+    if (command === null || !isExpectedCommand(command)) {
       return true;
     }
     if (Date.now() >= deadline) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { chmod, link, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
+import { access, chmod, link, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -144,7 +144,9 @@ import {
   ocmServiceStatusJson,
   ocmTargetSelector
 } from "./ocm/commands.mjs";
-import { mockAiProviderServeCommand } from "./auth.mjs";
+import { buildAuthCleanupPhase, buildAuthPreparePhase, mockAiProviderServeCommand } from "./auth.mjs";
+import { diagnosticArtifactName, triggerDiagnosticReport, triggerHeapSnapshot } from "./collectors/diagnostics.mjs";
+import { isOwnedMockProviderCommand, stopOwnedMockProvider } from "./process-safety.mjs";
 import { envNameFor, maxOcmEnvNameLength } from "./run/env-name.mjs";
 import {
   checkAggregateThreshold,
@@ -883,6 +885,8 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       assertArray(data.envs, "cleanup envs");
     }));
     checks.push(await cleanupArtifactsCheck(tmp));
+    checks.push(await mockProviderProcessSafetyCheck(tmp));
+    checks.push(await diagnosticArtifactIdentityCheck(tmp));
     checks.push(await diagnosticsTimelineCheck());
     checks.push(await diagnosticsOpenSpanCheck());
     checks.push(diagnosticsTimelineEvaluationCheck());
@@ -8370,6 +8374,217 @@ async function mockProviderBehaviorCheck(tmp) {
       status: "FAIL",
       command,
       durationMs: result.durationMs,
+      message: error.message
+    };
+  }
+}
+
+async function mockProviderProcessSafetyCheck(tmp) {
+  const dir = join(tmp, "mock-provider-process-safety");
+  await mkdir(dir, { recursive: true });
+  const executablePath = join(process.cwd(), "node_modules/.bin/mock-ai-provider");
+  const scriptPath = join(dir, "script.json");
+  const requestLog = join(dir, "requests.jsonl");
+  const pidFile = join(dir, "pid");
+  const expectedCommand = [
+    "node",
+    executablePath,
+    "serve --providers openai",
+    `--script ${scriptPath}`,
+    "--port 0",
+    `--request-log ${requestLog}`
+  ].join(" ");
+
+  try {
+    assertEqual(
+      isOwnedMockProviderCommand(expectedCommand, { executablePath, scriptPath, requestLog }),
+      true,
+      "exact mock provider process identity"
+    );
+    assertEqual(
+      isOwnedMockProviderCommand(expectedCommand, {
+        executablePath,
+        scriptPath: join(dir, "other", "script.json"),
+        requestLog
+      }),
+      false,
+      "same-basename mock provider script is not accepted"
+    );
+    assertEqual(
+      isOwnedMockProviderCommand(
+        `node unrelated.mjs ${expectedCommand}`,
+        { executablePath, scriptPath, requestLog }
+      ),
+      false,
+      "expected provider arguments do not authenticate an unrelated process"
+    );
+
+    for (const invalidPid of ["0\n", "-1\n"]) {
+      await writeFile(pidFile, invalidPid, "utf8");
+      let inspected = false;
+      let signaled = false;
+      const result = await stopOwnedMockProvider({
+        pidFile,
+        executablePath,
+        scriptPath,
+        requestLog,
+        inspectProcess: async () => {
+          inspected = true;
+          return expectedCommand;
+        },
+        signalProcess: () => {
+          signaled = true;
+        }
+      });
+      assertEqual(result.status, "invalid-pid", `${invalidPid.trim()} pid status`);
+      assertEqual(inspected, false, `${invalidPid.trim()} pid is not inspected`);
+      assertEqual(signaled, false, `${invalidPid.trim()} pid is not signaled`);
+      await assertPathMissing(pidFile, `${invalidPid.trim()} pid file removed`);
+    }
+
+    const unrelated = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore"
+    });
+    try {
+      await writeFile(pidFile, `${unrelated.pid}\n`, "utf8");
+      const recycled = await stopOwnedMockProvider({
+        pidFile,
+        executablePath,
+        scriptPath,
+        requestLog
+      });
+      assertEqual(recycled.status, "identity-mismatch", "recycled pid identity status");
+      process.kill(unrelated.pid, 0);
+      await assertPathMissing(pidFile, "recycled pid file removed");
+    } finally {
+      unrelated.kill("SIGTERM");
+    }
+
+    const absent = await stopOwnedMockProvider({
+      pidFile,
+      executablePath,
+      scriptPath,
+      requestLog
+    });
+    assertEqual(absent.status, "already-absent", "mock cleanup is idempotent");
+
+    for (const failure of ["inspect", "signal"]) {
+      await writeFile(pidFile, "12345\n", "utf8");
+      let rejected = false;
+      try {
+        await stopOwnedMockProvider({
+          pidFile,
+          executablePath,
+          scriptPath,
+          requestLog,
+          inspectProcess: async () => {
+            if (failure === "inspect") {
+              throw new Error("process inspection failed");
+            }
+            return expectedCommand;
+          },
+          signalProcess: () => {
+            const error = new Error("signal denied");
+            error.code = "EPERM";
+            throw error;
+          }
+        });
+      } catch (error) {
+        rejected = error.message === (failure === "inspect" ? "process inspection failed" : "signal denied");
+      }
+      assertEqual(rejected, true, `${failure} failure is propagated`);
+      await access(pidFile);
+      await rm(pidFile, { force: true });
+    }
+
+    const cleanupPhase = buildAuthCleanupPhase({ mode: "mock" }, dir);
+    const cleanupCommand = cleanupPhase.commands[0];
+    assertEqual(cleanupCommand.includes("stop-mock-ai-provider.mjs"), true, "auth cleanup uses guarded helper");
+    assertEqual(cleanupCommand.includes(executablePath), true, "auth cleanup pins executable path");
+    assertEqual(cleanupCommand.includes(join(dir, "mock-openai", "script.json")), true, "auth cleanup pins script path");
+    assertEqual(cleanupCommand.includes(join(dir, "mock-openai", "requests.jsonl")), true, "auth cleanup pins request log");
+
+    const prepareDir = join(tmp, "mock-provider-startup-failure");
+    const preparePhase = buildAuthPreparePhase(
+      { mode: "mock", mockProvider: { mode: "normal" } },
+      prepareDir
+    );
+    const prepareCommand = preparePhase.commands[0]
+      .replace("seq 1 100", "seq 1 2")
+      .replace('+"/health"', '+"/not-ready"');
+    assertEqual(
+      prepareCommand.split("stop-mock-ai-provider.mjs").length - 1,
+      2,
+      "startup command cleans stale and unhealthy providers"
+    );
+    assertEqual(
+      prepareCommand.includes("stop-mock-ai-provider.mjs") && prepareCommand.includes(" || exit $?; "),
+      true,
+      "stale provider cleanup failure aborts startup"
+    );
+    const failedStartup = await runCommand(prepareCommand, { timeoutMs: 10000 });
+    assertEqual(failedStartup.status === 0, false, "unhealthy mock provider startup fails");
+    await assertPathMissing(join(prepareDir, "mock-openai", "pid"), "unhealthy startup pid file removed");
+    await sleep(200);
+    const processList = await runCommand("ps -ww -axo command=", { timeoutMs: 10000 });
+    assertEqual(
+      processList.stdout.includes(join(prepareDir, "mock-openai", "script.json")),
+      false,
+      "unhealthy mock provider process stopped"
+    );
+
+    return {
+      id: "mock-provider-process-safety",
+      status: "PASS",
+      command: "exercise guarded mock provider cleanup",
+      durationMs: failedStartup.durationMs
+    };
+  } catch (error) {
+    return {
+      id: "mock-provider-process-safety",
+      status: "FAIL",
+      command: "exercise guarded mock provider cleanup",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function diagnosticArtifactIdentityCheck(tmp) {
+  try {
+    const first = join(tmp, "diagnostics-a", "report.json");
+    const second = join(tmp, "diagnostics-b", "report.json");
+    const firstName = diagnosticArtifactName(first);
+    const secondName = diagnosticArtifactName(second);
+    assertEqual(firstName, diagnosticArtifactName(first), "diagnostic artifact name is stable");
+    assertEqual(firstName === secondName, false, "same-basename diagnostics remain distinct");
+    assertEqual(firstName.startsWith("report-"), true, "diagnostic artifact keeps source basename");
+    assertEqual(firstName.endsWith(".json"), true, "diagnostic artifact keeps source extension");
+
+    for (const invalidPid of [0, -1]) {
+      for (const trigger of [triggerHeapSnapshot, triggerDiagnosticReport]) {
+        let rejected = false;
+        try {
+          await trigger("kova-invalid-pid", invalidPid, 1000, null);
+        } catch (error) {
+          rejected = error.message.includes("must be a positive integer");
+        }
+        assertEqual(rejected, true, `${trigger.name} rejects pid ${invalidPid}`);
+      }
+    }
+
+    return {
+      id: "diagnostic-process-and-artifact-safety",
+      status: "PASS",
+      command: "validate diagnostic PID and artifact identity",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "diagnostic-process-and-artifact-safety",
+      status: "FAIL",
+      command: "validate diagnostic PID and artifact identity",
+      durationMs: 0,
       message: error.message
     };
   }
@@ -17717,6 +17932,18 @@ async function inlineCheck(id, validate) {
       message: error.message
     };
   }
+}
+
+async function assertPathMissing(path, label) {
+  try {
+    await access(path);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  throw new Error(`${label}: ${path} still exists`);
 }
 
 function validateReport(report) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -8468,6 +8468,43 @@ async function mockProviderProcessSafetyCheck(tmp) {
     });
     assertEqual(absent.status, "already-absent", "mock cleanup is idempotent");
 
+    await writeFile(pidFile, "12345\n", "utf8");
+    let delayedInspections = 0;
+    const delayedStop = await stopOwnedMockProvider({
+      pidFile,
+      executablePath,
+      scriptPath,
+      requestLog,
+      inspectProcess: async () => {
+        delayedInspections += 1;
+        return delayedInspections < 3 ? expectedCommand : null;
+      },
+      signalProcess: () => {},
+      wait: async () => {}
+    });
+    assertEqual(delayedStop.status, "stopped", "mock cleanup confirms delayed process exit");
+    assertEqual(delayedInspections, 3, "mock cleanup polls until process exit");
+    await assertPathMissing(pidFile, "confirmed stop removes pid file");
+
+    await writeFile(pidFile, "12345\n", "utf8");
+    let stopTimedOut = false;
+    try {
+      await stopOwnedMockProvider({
+        pidFile,
+        executablePath,
+        scriptPath,
+        requestLog,
+        inspectProcess: async () => expectedCommand,
+        signalProcess: () => {},
+        stopTimeoutMs: 0
+      });
+    } catch (error) {
+      stopTimedOut = error.message === "mock provider 12345 did not stop within 0ms";
+    }
+    assertEqual(stopTimedOut, true, "mock cleanup reports stop timeout");
+    await access(pidFile);
+    await rm(pidFile, { force: true });
+
     for (const failure of ["inspect", "signal"]) {
       await writeFile(pidFile, "12345\n", "utf8");
       let rejected = false;

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -148,7 +148,8 @@ import {
   buildAuthCleanupPhase,
   buildAuthPreparePhase,
   mockAiProviderServeCommand,
-  mockProviderCleanupCommand
+  mockProviderCleanupCommand,
+  mockProviderPortCommand
 } from "./auth.mjs";
 import { diagnosticArtifactName, triggerDiagnosticReport, triggerHeapSnapshot } from "./collectors/diagnostics.mjs";
 import {
@@ -8342,13 +8343,11 @@ async function mockProviderBehaviorCheck(tmp) {
   const serverLogPath = join(dir, "server.log");
   const portPath = join(dir, "port");
   const pidPath = join(dir, "pid");
-  const writePort = [
-    "node",
-    "-e",
-    quoteShell("const fs=require('fs'); const [logPath, portPath] = process.argv.slice(1); const line=fs.readFileSync(logPath,'utf8').split(/\\r?\\n/).find(Boolean); if (!line) process.exit(1); const startup=JSON.parse(line); if (!startup.port) process.exit(1); fs.writeFileSync(portPath, String(startup.port));"),
-    quoteShell(serverLogPath),
-    quoteShell(portPath)
-  ].join(" ");
+  const writePort = mockProviderPortCommand({
+    serverLog: serverLogPath,
+    pidFile: pidPath,
+    portFile: portPath
+  });
   const command = [
     `node support/write-mock-ai-provider-script.mjs --output ${quoteShell(scriptPath)} --mode error-then-recover --error-status 503`,
     mockAiProviderServeCommand({ scriptPath, requestLog: requestLogPath, serverLog: serverLogPath, pidFile: pidPath }),
@@ -8622,6 +8621,20 @@ async function mockProviderProcessSafetyCheck(tmp) {
       "cleanup retains replacement owner generation"
     );
     await rm(pidFile, { force: true });
+
+    const portFile = join(dir, "port");
+    const writePort = mockProviderPortCommand({ serverLog, pidFile, portFile });
+    await writeFile(pidFile, `${JSON.stringify(inspectedOwner)}\n`, "utf8");
+    await writeFile(serverLog, `${JSON.stringify({ owner: replacementOwner, port: 31337 })}\n`, "utf8");
+    const stalePort = await runCommand(writePort, { timeoutMs: 10000 });
+    assertEqual(stalePort.status === 0, false, "stale server metadata is rejected");
+    await assertPathMissing(portFile, "stale server metadata does not publish a port");
+    await writeFile(serverLog, `${JSON.stringify({ owner: inspectedOwner, port: 31338 })}\n`, "utf8");
+    const currentPort = await runCommand(writePort, { timeoutMs: 10000 });
+    assertEqual(currentPort.status, 0, "matching server metadata publishes a port");
+    assertEqual(await readFile(portFile, "utf8"), "31338", "matching server metadata port");
+    await rm(pidFile, { force: true });
+    await rm(portFile, { force: true });
 
     await writeFile(pidFile, ownerText(12345), "utf8");
     let stopTimedOut = false;

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -144,9 +144,20 @@ import {
   ocmServiceStatusJson,
   ocmTargetSelector
 } from "./ocm/commands.mjs";
-import { buildAuthCleanupPhase, buildAuthPreparePhase, mockAiProviderServeCommand } from "./auth.mjs";
+import {
+  buildAuthCleanupPhase,
+  buildAuthPreparePhase,
+  mockAiProviderServeCommand,
+  mockProviderCleanupCommand
+} from "./auth.mjs";
 import { diagnosticArtifactName, triggerDiagnosticReport, triggerHeapSnapshot } from "./collectors/diagnostics.mjs";
-import { isOwnedMockProviderCommand, stopOwnedMockProvider } from "./process-safety.mjs";
+import {
+  isOwnedMockProviderSupervisorCommand,
+  mockProviderOwnerRecord,
+  mockProviderStopFile,
+  mockProviderSupervisorArgs,
+  stopOwnedMockProvider
+} from "./process-safety.mjs";
 import { envNameFor, maxOcmEnvNameLength } from "./run/env-name.mjs";
 import {
   checkAggregateThreshold,
@@ -8340,7 +8351,7 @@ async function mockProviderBehaviorCheck(tmp) {
   const command = [
     `node support/write-mock-ai-provider-script.mjs --output ${quoteShell(scriptPath)} --mode error-then-recover --error-status 503`,
     mockAiProviderServeCommand({ scriptPath, requestLog: requestLogPath, serverLog: serverLogPath, pidFile: pidPath }),
-    `trap 'test -s ${quoteShell(pidPath)} && kill "$(cat ${quoteShell(pidPath)})" 2>/dev/null || true' EXIT`,
+    `trap ${quoteShell(`${mockProviderCleanupCommand(dir)} >/dev/null 2>&1 || true`)} EXIT`,
     `for i in $(seq 1 100); do ${writePort} >/dev/null 2>&1 && test -s ${quoteShell(portPath)} && node -e 'fetch("http://127.0.0.1:"+process.argv[1]+"/health").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))' "$(cat ${quoteShell(portPath)})" && break; sleep 0.1; done`,
     `test -s ${quoteShell(portPath)} || { cat ${quoteShell(serverLogPath)} >&2; exit 1; }`,
     `port=$(cat ${quoteShell(portPath)})`,
@@ -8382,84 +8393,121 @@ async function mockProviderBehaviorCheck(tmp) {
 async function mockProviderProcessSafetyCheck(tmp) {
   const dir = join(tmp, "mock-provider-process-safety");
   await mkdir(dir, { recursive: true });
-  const executablePath = join(repoRoot, "node_modules/.bin/mock-ai-provider");
+  const supervisorPath = join(repoRoot, "support/mock-ai-provider-supervisor.mjs");
   const scriptPath = join(dir, "script.json");
   const requestLog = join(dir, "requests.jsonl");
+  const serverLog = join(dir, "server.log");
   const pidFile = join(dir, "pid");
-  const expectedCommand = [
-    "node",
-    executablePath,
-    "serve --providers openai",
-    `--script ${scriptPath}`,
-    "--port 0",
-    `--request-log ${requestLog}`
-  ].join(" ");
+  const stopOptions = {
+    pidFile,
+    supervisorPath,
+    scriptPath,
+    requestLog,
+    serverLog
+  };
+  const expectedCommand = ["node", ...mockProviderSupervisorArgs(stopOptions)].join(" ");
+  const ownerGeneration = "00000000-0000-4000-8000-000000000001";
+  const replacementGeneration = "00000000-0000-4000-8000-000000000002";
+  const ownerText = (pid, generation = ownerGeneration) => `${JSON.stringify(mockProviderOwnerRecord(pid, generation))}\n`;
 
   try {
     assertEqual(
-      isOwnedMockProviderCommand(expectedCommand, { executablePath, scriptPath, requestLog }),
+      isOwnedMockProviderSupervisorCommand(expectedCommand, stopOptions),
       true,
-      "exact mock provider process identity"
+      "exact mock provider supervisor identity"
     );
     assertEqual(
-      isOwnedMockProviderCommand(expectedCommand, {
-        executablePath,
-        scriptPath: join(dir, "other", "script.json"),
-        requestLog
+      isOwnedMockProviderSupervisorCommand(expectedCommand, {
+        ...stopOptions,
+        scriptPath: join(dir, "other", "script.json")
       }),
       false,
-      "same-basename mock provider script is not accepted"
+      "same-basename supervisor script is not accepted"
     );
     assertEqual(
-      isOwnedMockProviderCommand(
+      isOwnedMockProviderSupervisorCommand(
         `node unrelated.mjs ${expectedCommand}`,
-        { executablePath, scriptPath, requestLog }
+        stopOptions
       ),
       false,
-      "expected provider arguments do not authenticate an unrelated process"
+      "expected supervisor arguments do not authenticate an unrelated process"
     );
     assertEqual(
-      isOwnedMockProviderCommand(
-        `${expectedCommand} --script ${join(dir, "other", "script.json")}`,
-        { executablePath, scriptPath, requestLog }
+      isOwnedMockProviderSupervisorCommand(
+        `untrusted-node ${mockProviderSupervisorArgs(stopOptions).join(" ")}`,
+        stopOptions
       ),
       false,
-      "trailing provider arguments do not authenticate a different invocation"
+      "node-like executable name does not authenticate a supervisor"
+    );
+    assertEqual(
+      isOwnedMockProviderSupervisorCommand(
+        `${expectedCommand} --script ${join(dir, "other", "script.json")}`,
+        stopOptions
+      ),
+      false,
+      "trailing supervisor arguments do not authenticate a different invocation"
     );
 
-    for (const invalidPid of ["0\n", "-1\n"]) {
-      await writeFile(pidFile, invalidPid, "utf8");
+    const failedPidFile = join(dir, "pid-directory");
+    const failedScriptPath = join(dir, "failed-start-script.json");
+    const failedRequestLog = join(dir, "failed-start-requests.jsonl");
+    const failedServerLog = join(dir, "failed-start-server.log");
+    await mkdir(failedPidFile);
+    const writeFailedScript = await runCommand(
+      `node support/write-mock-ai-provider-script.mjs --output ${quoteShell(failedScriptPath)} --mode normal`,
+      { timeoutMs: 10000 }
+    );
+    assertEqual(writeFailedScript.status, 0, "partial-startup fixture script created");
+    const failedSupervisor = await runCommand(
+      mockAiProviderServeCommand({
+        scriptPath: failedScriptPath,
+        requestLog: failedRequestLog,
+        serverLog: failedServerLog,
+        pidFile: failedPidFile
+      }),
+      { timeoutMs: 10000 }
+    );
+    assertEqual(failedSupervisor.status === 0, false, "supervisor reports pid publication failure");
+    await sleep(200);
+    const failedProcessList = await runCommand("ps -ww -axo command=", { timeoutMs: 10000 });
+    assertEqual(
+      failedProcessList.stdout.includes(failedScriptPath),
+      false,
+      "pid publication failure stops the owned provider"
+    );
+
+    for (const invalidPid of [0, -1]) {
+      await writeFile(pidFile, `${JSON.stringify({
+        schemaVersion: "kova.mock-provider-owner.v1",
+        pid: invalidPid,
+        token: ownerGeneration
+      })}\n`, "utf8");
       let inspected = false;
-      let signaled = false;
+      let stopRequested = false;
       const result = await stopOwnedMockProvider({
-        pidFile,
-        executablePath,
-        scriptPath,
-        requestLog,
+        ...stopOptions,
         inspectProcess: async () => {
           inspected = true;
           return expectedCommand;
         },
-        signalProcess: () => {
-          signaled = true;
+        requestStop: async () => {
+          stopRequested = true;
         }
       });
-      assertEqual(result.status, "invalid-pid", `${invalidPid.trim()} pid status`);
-      assertEqual(inspected, false, `${invalidPid.trim()} pid is not inspected`);
-      assertEqual(signaled, false, `${invalidPid.trim()} pid is not signaled`);
-      await assertPathMissing(pidFile, `${invalidPid.trim()} pid file removed`);
+      assertEqual(result.status, "invalid-pid", `${invalidPid} pid status`);
+      assertEqual(inspected, false, `${invalidPid} pid is not inspected`);
+      assertEqual(stopRequested, false, `${invalidPid} pid does not request shutdown`);
+      await assertPathMissing(pidFile, `${invalidPid} pid file removed`);
     }
 
     const unrelated = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
       stdio: "ignore"
     });
     try {
-      await writeFile(pidFile, `${unrelated.pid}\n`, "utf8");
+      await writeFile(pidFile, ownerText(unrelated.pid), "utf8");
       const recycled = await stopOwnedMockProvider({
-        pidFile,
-        executablePath,
-        scriptPath,
-        requestLog
+        ...stopOptions
       });
       assertEqual(recycled.status, "identity-mismatch", "recycled pid identity status");
       process.kill(unrelated.pid, 0);
@@ -8469,73 +8517,89 @@ async function mockProviderProcessSafetyCheck(tmp) {
     }
 
     const absent = await stopOwnedMockProvider({
-      pidFile,
-      executablePath,
-      scriptPath,
-      requestLog
+      ...stopOptions
     });
     assertEqual(absent.status, "already-absent", "mock cleanup is idempotent");
 
-    await writeFile(pidFile, "12345\n", "utf8");
+    await writeFile(pidFile, ownerText(12345), "utf8");
     let delayedInspections = 0;
     const delayedStop = await stopOwnedMockProvider({
-      pidFile,
-      executablePath,
-      scriptPath,
-      requestLog,
+      ...stopOptions,
       inspectProcess: async () => {
         delayedInspections += 1;
         return delayedInspections < 3 ? expectedCommand : null;
       },
-      signalProcess: () => {},
+      requestStop: async () => {},
       wait: async () => {}
     });
     assertEqual(delayedStop.status, "stopped", "mock cleanup confirms delayed process exit");
     assertEqual(delayedInspections, 3, "mock cleanup polls until process exit");
     await assertPathMissing(pidFile, "confirmed stop removes pid file");
 
-    await writeFile(pidFile, "12345\n", "utf8");
+    const inspectedOwner = mockProviderOwnerRecord(12345, ownerGeneration);
+    const replacementOwner = mockProviderOwnerRecord(12346, replacementGeneration);
+    const replacementOwnerText = `${JSON.stringify(replacementOwner)}\n`;
+    await writeFile(pidFile, `${JSON.stringify(inspectedOwner)}\n`, "utf8");
+    let abaInspections = 0;
+    let requestedStopFile = null;
+    const replaced = await stopOwnedMockProvider({
+      ...stopOptions,
+      inspectProcess: async () => {
+        abaInspections += 1;
+        return abaInspections === 1 ? expectedCommand : null;
+      },
+      requestStop: async (stopFile) => {
+        requestedStopFile = stopFile;
+        await writeFile(pidFile, replacementOwnerText, "utf8");
+      }
+    });
+    assertEqual(replaced.status, "stopped", "replaced supervisor cleanup confirms inspected exit");
+    assertEqual(
+      requestedStopFile,
+      mockProviderStopFile(pidFile, inspectedOwner),
+      "stop request is bound to inspected owner generation"
+    );
+    assertEqual(
+      await readFile(pidFile, "utf8"),
+      replacementOwnerText,
+      "cleanup retains replacement owner generation"
+    );
+    await rm(pidFile, { force: true });
+
+    await writeFile(pidFile, ownerText(12345), "utf8");
     let stopTimedOut = false;
     try {
       await stopOwnedMockProvider({
-        pidFile,
-        executablePath,
-        scriptPath,
-        requestLog,
+        ...stopOptions,
         inspectProcess: async () => expectedCommand,
-        signalProcess: () => {},
+        requestStop: async () => {},
         stopTimeoutMs: 0
       });
     } catch (error) {
-      stopTimedOut = error.message === "mock provider 12345 did not stop within 0ms";
+      stopTimedOut = error.message === "mock provider supervisor 12345 did not stop within 0ms";
     }
     assertEqual(stopTimedOut, true, "mock cleanup reports stop timeout");
     await access(pidFile);
     await rm(pidFile, { force: true });
 
-    for (const failure of ["inspect", "signal"]) {
-      await writeFile(pidFile, "12345\n", "utf8");
+    for (const failure of ["inspect", "request"]) {
+      await writeFile(pidFile, ownerText(12345), "utf8");
       let rejected = false;
       try {
         await stopOwnedMockProvider({
-          pidFile,
-          executablePath,
-          scriptPath,
-          requestLog,
+          ...stopOptions,
           inspectProcess: async () => {
             if (failure === "inspect") {
               throw new Error("process inspection failed");
             }
             return expectedCommand;
           },
-          signalProcess: () => {
-            const error = new Error("signal denied");
-            error.code = "EPERM";
-            throw error;
+          requestStop: async () => {
+            throw new Error("stop request failed");
           }
         });
       } catch (error) {
-        rejected = error.message === (failure === "inspect" ? "process inspection failed" : "signal denied");
+        rejected = error.message === (failure === "inspect" ? "process inspection failed" : "stop request failed");
       }
       assertEqual(rejected, true, `${failure} failure is propagated`);
       await access(pidFile);
@@ -8545,9 +8609,10 @@ async function mockProviderProcessSafetyCheck(tmp) {
     const cleanupPhase = buildAuthCleanupPhase({ mode: "mock" }, dir);
     const cleanupCommand = cleanupPhase.commands[0];
     assertEqual(cleanupCommand.includes("stop-mock-ai-provider.mjs"), true, "auth cleanup uses guarded helper");
-    assertEqual(cleanupCommand.includes(executablePath), true, "auth cleanup pins executable path");
+    assertEqual(cleanupCommand.includes(supervisorPath), true, "auth cleanup pins supervisor path");
     assertEqual(cleanupCommand.includes(join(dir, "mock-openai", "script.json")), true, "auth cleanup pins script path");
     assertEqual(cleanupCommand.includes(join(dir, "mock-openai", "requests.jsonl")), true, "auth cleanup pins request log");
+    assertEqual(cleanupCommand.includes(join(dir, "mock-openai", "server.log")), true, "auth cleanup pins server log");
 
     const prepareDir = join(tmp, "mock-provider-startup-failure");
     const preparePhase = buildAuthPreparePhase(
@@ -8566,6 +8631,11 @@ async function mockProviderProcessSafetyCheck(tmp) {
       prepareCommand.includes("stop-mock-ai-provider.mjs") && prepareCommand.includes(" || exit $?; "),
       true,
       "stale provider cleanup failure aborts startup"
+    );
+    assertEqual(
+      prepareCommand.includes('kill "$supervisor_pid"'),
+      true,
+      "provider startup bounds supervisor pid publication"
     );
     const failedStartup = await runCommand(prepareCommand, { timeoutMs: 10000 });
     assertEqual(failedStartup.status === 0, false, "unhealthy mock provider startup fails");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -8418,6 +8418,14 @@ async function mockProviderProcessSafetyCheck(tmp) {
       false,
       "expected provider arguments do not authenticate an unrelated process"
     );
+    assertEqual(
+      isOwnedMockProviderCommand(
+        `${expectedCommand} --script ${join(dir, "other", "script.json")}`,
+        { executablePath, scriptPath, requestLog }
+      ),
+      false,
+      "trailing provider arguments do not authenticate a different invocation"
+    );
 
     for (const invalidPid of ["0\n", "-1\n"]) {
       await writeFile(pidFile, invalidPid, "utf8");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -152,6 +152,7 @@ import {
 } from "./auth.mjs";
 import { diagnosticArtifactName, triggerDiagnosticReport, triggerHeapSnapshot } from "./collectors/diagnostics.mjs";
 import {
+  isOwnedLegacyMockProviderCommand,
   isOwnedMockProviderSupervisorCommand,
   mockProviderOwnerRecord,
   mockProviderStopFile,
@@ -8394,6 +8395,7 @@ async function mockProviderProcessSafetyCheck(tmp) {
   const dir = join(tmp, "mock-provider-process-safety");
   await mkdir(dir, { recursive: true });
   const supervisorPath = join(repoRoot, "support/mock-ai-provider-supervisor.mjs");
+  const legacyExecutablePath = join(repoRoot, "node_modules/.bin/mock-ai-provider");
   const scriptPath = join(dir, "script.json");
   const requestLog = join(dir, "requests.jsonl");
   const serverLog = join(dir, "server.log");
@@ -8401,11 +8403,21 @@ async function mockProviderProcessSafetyCheck(tmp) {
   const stopOptions = {
     pidFile,
     supervisorPath,
+    legacyExecutablePath,
     scriptPath,
     requestLog,
     serverLog
   };
   const expectedCommand = ["node", ...mockProviderSupervisorArgs(stopOptions)].join(" ");
+  const expectedLegacyCommand = [
+    "node",
+    legacyExecutablePath,
+    "serve",
+    "--providers", "openai",
+    "--script", scriptPath,
+    "--port", "0",
+    "--request-log", requestLog
+  ].join(" ");
   const ownerGeneration = "00000000-0000-4000-8000-000000000001";
   const replacementGeneration = "00000000-0000-4000-8000-000000000002";
   const ownerText = (pid, generation = ownerGeneration) => `${JSON.stringify(mockProviderOwnerRecord(pid, generation))}\n`;
@@ -8448,6 +8460,51 @@ async function mockProviderProcessSafetyCheck(tmp) {
       false,
       "trailing supervisor arguments do not authenticate a different invocation"
     );
+    assertEqual(
+      isOwnedLegacyMockProviderCommand(expectedLegacyCommand, stopOptions),
+      true,
+      "exact legacy mock provider identity"
+    );
+    assertEqual(
+      isOwnedLegacyMockProviderCommand(
+        `${expectedLegacyCommand} --script ${join(dir, "other", "script.json")}`,
+        stopOptions
+      ),
+      false,
+      "trailing legacy arguments do not authenticate a different invocation"
+    );
+
+    await writeFile(pidFile, "12345\n", "utf8");
+    let legacyInspections = 0;
+    let legacySignal = null;
+    const legacyStop = await stopOwnedMockProvider({
+      ...stopOptions,
+      inspectProcess: async () => {
+        legacyInspections += 1;
+        return legacyInspections === 1 ? expectedLegacyCommand : null;
+      },
+      signalProcess: (pid, signal) => {
+        legacySignal = { pid, signal };
+      },
+      wait: async () => {}
+    });
+    assertEqual(legacyStop.status, "legacy-stopped", "legacy provider is stopped after exact identity match");
+    assertEqual(JSON.stringify(legacySignal), JSON.stringify({ pid: 12345, signal: "SIGTERM" }), "legacy provider signal");
+    await assertPathMissing(pidFile, "stopped legacy provider pid file removed");
+
+    await writeFile(pidFile, "12345\n", "utf8");
+    let legacyMismatchRejected = false;
+    try {
+      await stopOwnedMockProvider({
+        ...stopOptions,
+        inspectProcess: async () => "node unrelated.mjs"
+      });
+    } catch (error) {
+      legacyMismatchRejected = error.message.includes("does not match the expected command");
+    }
+    assertEqual(legacyMismatchRejected, true, "legacy provider identity mismatch aborts cleanup");
+    await access(pidFile);
+    await rm(pidFile, { force: true });
 
     const failedPidFile = join(dir, "pid-directory");
     const failedScriptPath = join(dir, "failed-start-script.json");
@@ -8610,6 +8667,7 @@ async function mockProviderProcessSafetyCheck(tmp) {
     const cleanupCommand = cleanupPhase.commands[0];
     assertEqual(cleanupCommand.includes("stop-mock-ai-provider.mjs"), true, "auth cleanup uses guarded helper");
     assertEqual(cleanupCommand.includes(supervisorPath), true, "auth cleanup pins supervisor path");
+    assertEqual(cleanupCommand.includes(legacyExecutablePath), true, "auth cleanup pins legacy executable path");
     assertEqual(cleanupCommand.includes(join(dir, "mock-openai", "script.json")), true, "auth cleanup pins script path");
     assertEqual(cleanupCommand.includes(join(dir, "mock-openai", "requests.jsonl")), true, "auth cleanup pins request log");
     assertEqual(cleanupCommand.includes(join(dir, "mock-openai", "server.log")), true, "auth cleanup pins server log");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -8382,7 +8382,7 @@ async function mockProviderBehaviorCheck(tmp) {
 async function mockProviderProcessSafetyCheck(tmp) {
   const dir = join(tmp, "mock-provider-process-safety");
   await mkdir(dir, { recursive: true });
-  const executablePath = join(process.cwd(), "node_modules/.bin/mock-ai-provider");
+  const executablePath = join(repoRoot, "node_modules/.bin/mock-ai-provider");
   const scriptPath = join(dir, "script.json");
   const requestLog = join(dir, "requests.jsonl");
   const pidFile = join(dir, "pid");

--- a/support/mock-ai-provider-supervisor.mjs
+++ b/support/mock-ai-provider-supervisor.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import { randomUUID } from "node:crypto";
+import { access, appendFile, rm, writeFile } from "node:fs/promises";
+import { createMockAiProviderServer } from "mock-ai-provider/dist/server/create-server.js";
+import { listen } from "mock-ai-provider/dist/server/listen.js";
+import {
+  mockProviderOwnerRecord,
+  mockProviderStopFile,
+  removeMockProviderOwnerFile
+} from "../src/process-safety.mjs";
+
+const options = parseArgs(process.argv.slice(2));
+const owner = mockProviderOwnerRecord(process.pid, randomUUID());
+
+try {
+  await supervise(options, owner);
+} catch (error) {
+  await appendFile(options.serverLog, `${error.stack ?? error.message}\n`, "utf8").catch(() => {});
+  await cleanupControlFiles(options.pidFile, owner);
+  process.exitCode = 1;
+}
+
+async function supervise({ scriptPath, requestLog, serverLog, pidFile }, owner) {
+  const stopFile = mockProviderStopFile(pidFile, owner);
+  await rm(stopFile, { force: true });
+
+  let server = null;
+  let interval = null;
+  let stopping = null;
+  const stopServer = async () => {
+    if (!server) {
+      return;
+    }
+    if (!stopping) {
+      stopping = closeServer(server);
+    }
+    await stopping;
+  };
+  const handleSignal = () => void stopServer();
+
+  try {
+    server = await createMockAiProviderServer({
+      providers: ["openai"],
+      scriptPath,
+      requestLogPath: requestLog,
+      openAiAuth: { strict: false }
+    });
+    const serverClosed = new Promise((resolve) => {
+      server.once("close", resolve);
+    });
+    const { port } = await listen(server, { port: 0, host: "127.0.0.1" });
+    process.once("SIGINT", handleSignal);
+    process.once("SIGTERM", handleSignal);
+    await writeFile(pidFile, `${JSON.stringify(owner)}\n`, {
+      encoding: "utf8",
+      flag: "wx"
+    });
+    await writeFile(serverLog, `${JSON.stringify({
+      ok: true,
+      providers: ["openai"],
+      host: "127.0.0.1",
+      port,
+      baseUrl: `http://127.0.0.1:${port}`,
+      script: {
+        source: "file",
+        path: scriptPath
+      },
+      models: {
+        source: "default"
+      },
+      requestLog,
+      auth: {
+        strict: false,
+        apiKeyConfigured: false
+      }
+    })}\n`, "utf8");
+
+    // Cleanup requests never signal a persisted PID; this process owns the
+    // server handle and closes its active connections before exiting.
+    interval = setInterval(() => {
+      void access(stopFile)
+        .then(stopServer)
+        .catch((error) => {
+          if (error.code !== "ENOENT") {
+            void stopServer();
+          }
+        });
+    }, 50);
+    interval.unref();
+    await serverClosed;
+  } catch (error) {
+    await stopServer();
+    throw error;
+  } finally {
+    clearInterval(interval);
+    process.off("SIGINT", handleSignal);
+    process.off("SIGTERM", handleSignal);
+    await cleanupControlFiles(pidFile, owner);
+  }
+}
+
+async function closeServer(server) {
+  const closed = new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error && error.code !== "ERR_SERVER_NOT_RUNNING") {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+  const forceTimer = setTimeout(() => {
+    server.closeAllConnections();
+  }, 3000);
+  forceTimer.unref();
+  try {
+    await closed;
+  } finally {
+    clearTimeout(forceTimer);
+  }
+}
+
+async function cleanupControlFiles(pidFile, owner) {
+  await removeControlFile(mockProviderStopFile(pidFile, owner));
+  await removeMockProviderOwnerFile(pidFile, `${JSON.stringify(owner)}\n`);
+}
+
+async function removeControlFile(path) {
+  try {
+    await rm(path, { force: true });
+  } catch (error) {
+    if (error.code !== "EISDIR") {
+      throw error;
+    }
+  }
+}
+
+function parseArgs(args) {
+  const values = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument: ${flag ?? ""}`);
+    }
+    values[flag.slice(2)] = value;
+  }
+  for (const key of ["script", "request-log", "server-log", "pid-file"]) {
+    if (!values[key]) {
+      throw new Error(`--${key} is required`);
+    }
+  }
+  return {
+    scriptPath: values.script,
+    requestLog: values["request-log"],
+    serverLog: values["server-log"],
+    pidFile: values["pid-file"]
+  };
+}

--- a/support/mock-ai-provider-supervisor.mjs
+++ b/support/mock-ai-provider-supervisor.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
-import { access, appendFile, rm, writeFile } from "node:fs/promises";
+import { access, rename, rm, writeFile } from "node:fs/promises";
 import { createMockAiProviderServer } from "mock-ai-provider/dist/server/create-server.js";
 import { listen } from "mock-ai-provider/dist/server/listen.js";
 import {
@@ -15,14 +15,15 @@ const owner = mockProviderOwnerRecord(process.pid, randomUUID());
 try {
   await supervise(options, owner);
 } catch (error) {
-  await appendFile(options.serverLog, `${error.stack ?? error.message}\n`, "utf8").catch(() => {});
-  await cleanupControlFiles(options.pidFile, owner);
+  process.stderr.write(`${error.stack ?? error.message}\n`);
   process.exitCode = 1;
 }
 
 async function supervise({ scriptPath, requestLog, serverLog, pidFile }, owner) {
   const stopFile = mockProviderStopFile(pidFile, owner);
+  const startupLog = `${serverLog}.startup.${owner.pid}.${owner.token}`;
   await rm(stopFile, { force: true });
+  await rm(startupLog, { force: true });
 
   let server = null;
   let interval = null;
@@ -51,12 +52,9 @@ async function supervise({ scriptPath, requestLog, serverLog, pidFile }, owner) 
     const { port } = await listen(server, { port: 0, host: "127.0.0.1" });
     process.once("SIGINT", handleSignal);
     process.once("SIGTERM", handleSignal);
-    await writeFile(pidFile, `${JSON.stringify(owner)}\n`, {
-      encoding: "utf8",
-      flag: "wx"
-    });
-    await writeFile(serverLog, `${JSON.stringify({
+    await writeFile(startupLog, `${JSON.stringify({
       ok: true,
+      owner,
       providers: ["openai"],
       host: "127.0.0.1",
       port,
@@ -74,6 +72,11 @@ async function supervise({ scriptPath, requestLog, serverLog, pidFile }, owner) 
         apiKeyConfigured: false
       }
     })}\n`, "utf8");
+    await writeFile(pidFile, `${JSON.stringify(owner)}\n`, {
+      encoding: "utf8",
+      flag: "wx"
+    });
+    await rename(startupLog, serverLog);
 
     // Cleanup requests never signal a persisted PID; this process owns the
     // server handle and closes its active connections before exiting.
@@ -95,6 +98,7 @@ async function supervise({ scriptPath, requestLog, serverLog, pidFile }, owner) 
     clearInterval(interval);
     process.off("SIGINT", handleSignal);
     process.off("SIGTERM", handleSignal);
+    await removeControlFile(startupLog);
     await cleanupControlFiles(pidFile, owner);
   }
 }

--- a/support/stop-mock-ai-provider.mjs
+++ b/support/stop-mock-ai-provider.mjs
@@ -14,15 +14,16 @@ function parseArgs(args) {
     }
     values[flag.slice(2)] = value;
   }
-  for (const key of ["pid-file", "executable", "script", "request-log"]) {
+  for (const key of ["pid-file", "supervisor", "script", "request-log", "server-log"]) {
     if (!values[key]) {
       throw new Error(`--${key} is required`);
     }
   }
   return {
     pidFile: values["pid-file"],
-    executablePath: values.executable,
+    supervisorPath: values.supervisor,
     scriptPath: values.script,
-    requestLog: values["request-log"]
+    requestLog: values["request-log"],
+    serverLog: values["server-log"]
   };
 }

--- a/support/stop-mock-ai-provider.mjs
+++ b/support/stop-mock-ai-provider.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { stopOwnedMockProvider } from "../src/process-safety.mjs";
+
+const options = parseArgs(process.argv.slice(2));
+await stopOwnedMockProvider(options);
+
+function parseArgs(args) {
+  const values = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument: ${flag ?? ""}`);
+    }
+    values[flag.slice(2)] = value;
+  }
+  for (const key of ["pid-file", "executable", "script", "request-log"]) {
+    if (!values[key]) {
+      throw new Error(`--${key} is required`);
+    }
+  }
+  return {
+    pidFile: values["pid-file"],
+    executablePath: values.executable,
+    scriptPath: values.script,
+    requestLog: values["request-log"]
+  };
+}

--- a/support/stop-mock-ai-provider.mjs
+++ b/support/stop-mock-ai-provider.mjs
@@ -14,7 +14,7 @@ function parseArgs(args) {
     }
     values[flag.slice(2)] = value;
   }
-  for (const key of ["pid-file", "supervisor", "script", "request-log", "server-log"]) {
+  for (const key of ["pid-file", "supervisor", "legacy-executable", "script", "request-log", "server-log"]) {
     if (!values[key]) {
       throw new Error(`--${key} is required`);
     }
@@ -22,6 +22,7 @@ function parseArgs(args) {
   return {
     pidFile: values["pid-file"],
     supervisorPath: values.supervisor,
+    legacyExecutablePath: values["legacy-executable"],
     scriptPath: values.script,
     requestLog: values["request-log"],
     serverLog: values["server-log"]


### PR DESCRIPTION
## What Problem This Solves

Kova could trust stale or recycled PID files, signal unrelated processes, orphan a mock provider during cleanup or upgrade, accept stale startup port metadata, and overwrite diagnostic artifacts that shared a basename.

## Why This Change Was Made

- Validate diagnostic and mock-provider PIDs before interpolation or process operations.
- Run the mock provider inside a Kova-owned supervisor with generation-bound owner and stop records.
- Authenticate exact supervisor and legacy CLI command lines before cleanup.
- Migrate active numeric PID records from the previous launcher, while retaining ambiguous or failed cleanup state for retry.
- Bind PID publication, server metadata, and port extraction to the same owner generation.
- Close active provider connections before supervisor exit and bound failed startup cleanup.
- Hash diagnostic artifact source paths so same-basename files remain distinct.
- Add self-check coverage for recycled PIDs, legacy handoff, delayed exit, timeout, ABA replacement, stale metadata, failed publication, and artifact collisions.

## User Impact

Kova cleanup no longer risks terminating an unrelated process or abandoning an older mock provider during an upgrade. Startup cannot reuse stale port metadata, failed shutdown remains visible and retryable, and diagnostic collection preserves every distinct artifact.

## Evidence

- Focused process-safety probes: exact legacy ownership, generation-safe cleanup, stale metadata rejection, and live supervisor publication/cleanup passed.
- `NO_COLOR=1 npm run check`: concurrent isolation passed; Kova self-check 242/242 passed in 58.7s.
- Final Codex Sol/high autoreview over the complete branch against current `origin/main`: clean, confidence 0.86.
- `git diff --check origin/main...HEAD` passed.
- Eight scoped commits retained; no squash.