### PR TITLE
fix(diagnostics): scope open spans to gateway pid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 24
       - name: Install OCM
         run: |
-          curl -fsSL https://raw.githubusercontent.com/shakkernerd/ocm/main/install.sh | bash -s -- --force
+          ./scripts/install-ocm-ci.sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 24
       - name: Install OCM
         run: |
-          curl -fsSL https://raw.githubusercontent.com/shakkernerd/ocm/main/install.sh | bash -s -- --force
+          ./scripts/install-ocm-ci.sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
         run: npm ci

--- a/scripts/install-ocm-ci.sh
+++ b/scripts/install-ocm-ci.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="v0.2.25"
+case "$(uname -s):$(uname -m)" in
+  Linux:x86_64)
+    asset="ocm-x86_64-unknown-linux-gnu.tar.gz"
+    expected_sha256="57530199d21eb5bfa29695749928b40fd2869484c7edff69b7c65bfc84f2f1aa"
+    ;;
+  Darwin:arm64)
+    asset="ocm-aarch64-apple-darwin.tar.gz"
+    expected_sha256="0bfe89d967592b09d3fc4e4be7bac70d3995135e012564316a74173b157506bf"
+    ;;
+  *)
+    echo "unsupported OCM CI platform: $(uname -s) $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+archive_path="$tmp_dir/$asset"
+curl -fsSL "https://github.com/shakkernerd/ocm/releases/download/$version/$asset" -o "$archive_path"
+actual_sha256="$(shasum -a 256 "$archive_path" | awk '{print $1}')"
+if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+  echo "OCM checksum mismatch for $asset" >&2
+  exit 1
+fi
+
+tar -xzf "$archive_path" -C "$tmp_dir"
+install -d "$HOME/.local/bin"
+install -m 0755 "$tmp_dir/ocm" "$HOME/.local/bin/ocm"

--- a/src/collectors/timeline.mjs
+++ b/src/collectors/timeline.mjs
@@ -54,6 +54,9 @@ export async function collectTimelineMetrics(artifactDir) {
     spanTotals: timeline.spanTotals,
     repeatedSpans: timeline.repeatedSpans,
     openSpans: timeline.openSpans,
+    openSpansAll: timeline.openSpansAll,
+    gatewayPids: timeline.gatewayPids,
+    terminalGatewayPid: timeline.terminalGatewayPid,
     keySpans: timeline.keySpans,
     runtimeDeps: timeline.runtimeDeps,
     eventLoop: timeline.eventLoop,
@@ -113,7 +116,9 @@ export function summarizeTimeline(events, parseErrors = []) {
   const providerRequests = events.filter((event) => event.type === "provider.request");
   const childProcesses = events.filter((event) => event.type === "childProcess.exit");
   const spanTotals = summarizeSpans(spanEvents);
-  const openSpans = summarizeOpenSpans({ starts: spanStarts, terminals: spanEvents, events });
+  const openSpansAll = summarizeOpenSpans(events);
+  const openSpans = openSpansAll.slice(0, 25);
+  const gatewayPids = gatewayProcessPids(events);
   const runtimeDeps = summarizeRuntimeDeps(spanEvents);
   const slowestSpans = spanEvents
     .filter((event) => typeof event.durationMs === "number")
@@ -135,9 +140,12 @@ export function summarizeTimeline(events, parseErrors = []) {
       .filter((span) => span.count > 1)
       .toSorted((left, right) => (right.totalDurationMs - left.totalDurationMs) || (right.count - left.count))
       .slice(0, 10),
-    openSpanCount: openSpans.length,
+    openSpanCount: openSpansAll.length,
     openSpans,
-    keySpans: summarizeKeySpans({ spanEvents, openSpans }),
+    openSpansAll,
+    gatewayPids,
+    terminalGatewayPid: gatewayPids.at(-1) ?? null,
+    keySpans: summarizeKeySpans({ spanEvents, openSpans: openSpansAll }),
     runtimeDeps,
     eventLoop: summarizeEventLoop(eventLoopSamples),
     providers: summarizeTimedCollection(providerRequests),
@@ -160,6 +168,9 @@ function emptyTimeline(extra = {}) {
     repeatedSpans: [],
     openSpanCount: 0,
     openSpans: [],
+    openSpansAll: [],
+    gatewayPids: [],
+    terminalGatewayPid: null,
     keySpans: emptyKeySpans(),
     runtimeDeps: {
       count: 0,
@@ -286,22 +297,43 @@ function summarizeRuntimeDeps(events) {
   };
 }
 
-function summarizeOpenSpans({ starts, terminals, events }) {
-  const terminalKeys = new Set(terminals.map(spanIdentity).filter(Boolean));
-  const terminalNames = countNames(terminals);
+function summarizeOpenSpans(events) {
+  const starts = [];
+  const matched = new Set();
+  const buckets = new Map();
   const latestTimestamp = latestEventTimestamp(events);
-  const open = [];
 
-  for (const start of starts) {
-    const key = spanIdentity(start);
-    if (key && terminalKeys.has(key)) {
+  // Consume the append-only stream in order. Per-identity stacks keep matching
+  // amortized linear while newest-first wildcard matching handles reused span IDs.
+  for (const event of events) {
+    if (event.type === "span.start") {
+      const index = starts.push(event) - 1;
+      const bucket = spanMatchBucket(buckets, event);
+      bucket.all.push(index);
+      const pidKey = spanPidKey(event.pid);
+      const pidStack = bucket.byPid.get(pidKey) ?? [];
+      pidStack.push(index);
+      bucket.byPid.set(pidKey, pidStack);
       continue;
     }
-    if (!key && (terminalNames.get(start.name) ?? 0) > 0) {
-      terminalNames.set(start.name, terminalNames.get(start.name) - 1);
+    if (event.type !== "span.end" && event.type !== "span.error") {
       continue;
     }
-    open.push({
+    const bucket = buckets.get(spanMatchKey(event));
+    if (!bucket) {
+      continue;
+    }
+    const terminalPidKey = spanPidKey(event.pid);
+    const index = terminalPidKey === UNKNOWN_PID_KEY
+      ? popUnmatched(bucket.all, matched)
+      : popUnmatched(bucket.byPid.get(terminalPidKey), matched) ??
+        popUnmatched(bucket.byPid.get(UNKNOWN_PID_KEY), matched);
+    if (index !== null) {
+      matched.add(index);
+    }
+  }
+
+  return starts.flatMap((start, index) => matched.has(index) ? [] : [{
       type: start.type,
       name: start.name,
       spanId: start.spanId ?? null,
@@ -311,11 +343,34 @@ function summarizeOpenSpans({ starts, terminals, events }) {
       phase: start.phase ?? null,
       provider: start.provider ?? start.attributes?.provider ?? null,
       operation: start.operation ?? start.attributes?.operation ?? null,
-      pluginId: start.pluginId ?? start.attributes?.pluginId ?? null
-    });
-  }
+      pluginId: start.pluginId ?? start.attributes?.pluginId ?? null,
+      pid: start.pid ?? null
+    }]).toSorted((left, right) => (right.ageMs ?? -1) - (left.ageMs ?? -1));
+}
 
-  return open.toSorted((left, right) => (right.ageMs ?? -1) - (left.ageMs ?? -1)).slice(0, 25);
+const UNKNOWN_PID_KEY = "<unknown>";
+
+function spanMatchBucket(buckets, event) {
+  const key = spanMatchKey(event);
+  const bucket = buckets.get(key) ?? { all: [], byPid: new Map() };
+  buckets.set(key, bucket);
+  return bucket;
+}
+
+function spanMatchKey(event) {
+  const spanId = spanIdOrNull(event);
+  return spanId === null ? `name:${event.name}` : `id:${spanId}`;
+}
+
+function spanPidKey(pid) {
+  return pid === undefined || pid === null ? UNKNOWN_PID_KEY : String(pid);
+}
+
+function popUnmatched(stack, matched) {
+  while (stack?.length > 0 && matched.has(stack.at(-1))) {
+    stack.pop();
+  }
+  return stack?.pop() ?? null;
 }
 
 function summarizeKeySpans({ spanEvents, openSpans }) {
@@ -425,6 +480,7 @@ function compactTimedEvent(event) {
     provider: event.provider ?? event.attributes?.provider ?? null,
     operation: event.operation ?? event.attributes?.operation ?? null,
     pluginId: event.pluginId ?? event.attributes?.pluginId ?? null,
+    pid: event.pid ?? null,
     exitCode: event.exitCode ?? event.code ?? null,
     signal: event.signal ?? null,
     errorName: event.errorName ?? event.attributes?.errorName ?? null,
@@ -491,19 +547,34 @@ function parsedTimestampMs(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function spanIdentity(event) {
-  if (event.spanId !== undefined && event.spanId !== null && String(event.spanId).length > 0) {
-    return `id:${event.spanId}`;
+function spanIdOrNull(event) {
+  if (event.spanId === undefined || event.spanId === null || String(event.spanId).length === 0) {
+    return null;
   }
-  return null;
+  return String(event.spanId);
 }
 
-function countNames(events) {
-  const counts = new Map();
+function gatewayProcessPids(events) {
+  const pids = [];
   for (const event of events) {
-    counts.set(event.name, (counts.get(event.name) ?? 0) + 1);
+    if (event.pid === undefined || event.pid === null || !isGatewayLifecycleEvent(event)) {
+      continue;
+    }
+    const existing = pids.indexOf(event.pid);
+    if (existing !== -1) {
+      pids.splice(existing, 1);
+    }
+    pids.push(event.pid);
   }
-  return counts;
+  return pids;
+}
+
+function isGatewayLifecycleEvent(event) {
+  return event.name === "gateway.startup" ||
+    event.name === "gateway.ready" ||
+    event.name === "http.bound" ||
+    event.name === "http.listen" ||
+    String(event.spanId ?? "").startsWith("gateway-startup-");
 }
 
 function latestEventTimestamp(events) {

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -125,6 +125,7 @@ export function evaluateRecord(record, scenario, options = {}) {
   const metadataScanMentions = countLogMetric(record, "metadataScanMentions", allResults);
   const configNormalizationMentions = countLogMetric(record, "configNormalizationMentions", allResults);
   const gatewayRestartCount = countGatewayRestarts(record, allResults);
+  const intentionalRestartSourcePids = collectIntentionalRestartSourcePids(record);
   const providerLoadMentions = countLogMetric(record, "providerLoadMentions", allResults);
   const modelCatalogMentions = countLogMetric(record, "modelCatalogMentions", allResults);
   const providerTimeoutMentions = countLogMetric(record, "providerTimeoutMentions", allResults);
@@ -144,12 +145,12 @@ export function evaluateRecord(record, scenario, options = {}) {
   const diagnosticReportBytes = countDiagnosticReportMetric(record, "artifactBytes");
   const gatewayExpected = recordExpectsGateway(record);
   const openclawDiagnostics = collectOpenClawDiagnostics(record);
-  const timelineSummary = collectTimelineSummary(record);
+  const timelineSummary = collectTimelineSummary(record, { intentionalRestartSourcePids });
   const logSummary = collectLogSummary(record);
   const runtimeDepsLogEvidence = collectRuntimeDepsLogEvidence(record);
   const timelineRequirement = timelineRequirementFor(options);
   const requiredOpenSpans = requiredTimelineSpans(options);
-  const openRequiredSpans = timelineSummary.openSpans.filter((span) => requiredOpenSpans.has(span.name));
+  const openRequiredSpans = timelineSummary.openSpansAll.filter((span) => requiredOpenSpans.has(span.name));
   const missingRequiredSpans = missingTimelineSpans(timelineSummary, requiredOpenSpans);
   const diagnosticContract = diagnosticSpanContractFor(options);
   const runtimeDepsStagingMs = maxNullable(
@@ -1152,6 +1153,9 @@ export function evaluateRecord(record, scenario, options = {}) {
     openclawMissingRequiredSpanSeverity: diagnosticContract.missingSpanSeverity,
     openclawDiagnosticsContract: diagnosticContract,
     openclawOpenSpans: timelineSummary.openSpans,
+    openclawInterruptedRestartSpanCount: timelineSummary.interruptedRestartSpanCount,
+    openclawInterruptedRestartSpans: timelineSummary.interruptedRestartSpans,
+    openclawTerminalGatewayPid: timelineSummary.terminalGatewayPid,
     openclawKeySpans: timelineSummary.keySpans,
     openclawEventLoopMaxMs: timelineSummary.eventLoopMaxMs,
     openclawLogEventLoopMaxMs: logSummary.livenessWarnings.maxEventLoopDelayMaxMs,
@@ -2715,6 +2719,45 @@ function countGatewayRestarts(record, results = collectResults(record)) {
   return commandRestarts > 0 ? commandRestarts : null;
 }
 
+function collectIntentionalRestartSourcePids(record) {
+  const sourcePids = new Set();
+  let previousTimeline = null;
+  let restartPending = false;
+
+  for (const phase of record.phases ?? []) {
+    restartPending ||= (phase.results ?? []).some((result) =>
+      result.command?.startsWith("ocm service restart ") && commandResultPassed(result)
+    );
+    const timeline = phase.metrics?.timeline;
+    if (!timeline?.available) {
+      continue;
+    }
+    const gatewayPids = timeline.gatewayPids ?? [];
+    const transitionIsAdjacent = previousTimeline?.terminalGatewayPid !== null &&
+      previousTimeline?.terminalGatewayPid !== undefined &&
+      gatewayPids.at(-2) === previousTimeline.terminalGatewayPid &&
+      gatewayPids.at(-1) === timeline.terminalGatewayPid;
+    if (restartPending && transitionIsAdjacent) {
+      sourcePids.add(previousTimeline.terminalGatewayPid);
+    }
+    restartPending = false;
+    previousTimeline = timeline;
+  }
+
+  const finalTimeline = record.finalMetrics?.timeline;
+  if (restartPending && finalTimeline?.available && finalTimeline !== previousTimeline) {
+    const gatewayPids = finalTimeline.gatewayPids ?? [];
+    if (previousTimeline?.terminalGatewayPid !== null &&
+      previousTimeline?.terminalGatewayPid !== undefined &&
+      gatewayPids.at(-2) === previousTimeline.terminalGatewayPid &&
+      gatewayPids.at(-1) === finalTimeline.terminalGatewayPid) {
+      sourcePids.add(previousTimeline.terminalGatewayPid);
+    }
+  }
+
+  return sourcePids;
+}
+
 function collectSoakEvidence(results) {
   const loops = results
     .filter((result) => result.command?.includes("run-soak-loop.mjs"))
@@ -3801,6 +3844,7 @@ export function compactEvaluatedTimelineEvidence(record) {
 
   const retained = new Set([currentTimeline, attributionTimeline].filter(Boolean));
   for (const timeline of timelines) {
+    delete timeline.openSpansAll;
     if (retained.has(timeline)) {
       continue;
     }
@@ -3809,7 +3853,7 @@ export function compactEvaluatedTimelineEvidence(record) {
   }
 }
 
-function collectTimelineSummary(record) {
+function collectTimelineSummary(record, { intentionalRestartSourcePids = new Set() } = {}) {
   const timelines = recordTimelines(record);
 
   const available = timelines.some((timeline) => timeline.available);
@@ -3834,8 +3878,19 @@ function collectTimelineSummary(record) {
   let repeatedSpanCount = 0;
   let runtimeDepsStageMaxMs = null;
   let slowestRuntimeDepsPlugin = null;
-  const latestOpenSpanCount = currentTimeline?.openSpanCount ?? currentTimeline?.openSpans?.length ?? 0;
-  const latestOpenSpans = [...(currentTimeline?.openSpans ?? [])]
+  const terminalGatewayPid = currentTimeline?.terminalGatewayPid ?? null;
+  const rawOpenSpans = currentTimeline?.openSpansAll ?? currentTimeline?.openSpans ?? [];
+  const interruptedRestartSpans = terminalGatewayPid !== null
+    ? rawOpenSpans.filter((span) =>
+      span.pid !== null &&
+      span.pid !== terminalGatewayPid &&
+      intentionalRestartSourcePids.has(span.pid)
+    )
+    : [];
+  const interruptedRestartSpanSet = new Set(interruptedRestartSpans);
+  const latestOpenSpansAll = rawOpenSpans.filter((span) => !interruptedRestartSpanSet.has(span));
+  const latestOpenSpanCount = latestOpenSpansAll.length;
+  const latestOpenSpans = latestOpenSpansAll
     .toSorted((left, right) => (right.ageMs ?? -1) - (left.ageMs ?? -1))
     .slice(0, 25);
   const events = attributionTimeline?.events ?? [];
@@ -3880,6 +3935,8 @@ function collectTimelineSummary(record) {
     }
   }
 
+  replaceKeySpanOpenState(keySpans, latestOpenSpansAll);
+
   return {
     available,
     eventCount,
@@ -3889,6 +3946,10 @@ function collectTimelineSummary(record) {
     repeatedSpanCount,
     openSpanCount: latestOpenSpanCount,
     openSpans: latestOpenSpans,
+    openSpansAll: latestOpenSpansAll,
+    interruptedRestartSpanCount: interruptedRestartSpans.length,
+    interruptedRestartSpans: interruptedRestartSpans.slice(0, 25),
+    terminalGatewayPid,
     artifacts: [...artifacts],
     timelineArtifacts: [...artifacts],
     events,
@@ -3901,6 +3962,21 @@ function collectTimelineSummary(record) {
     runtimeDepsStageMaxMs,
     runtimeDepsStagePluginId: slowestRuntimeDepsPlugin?.pluginId ?? null
   };
+}
+
+function replaceKeySpanOpenState(keySpans, openSpans) {
+  for (const [name, summary] of Object.entries(keySpans)) {
+    const open = openSpans.filter((span) => keyTimelineSpanMatches(name, span.name));
+    summary.openCount = open.length;
+    summary.open = open.slice(0, 5);
+  }
+}
+
+function keyTimelineSpanMatches(keyName, spanName) {
+  if (keyName === "gateway.chat_send" || keyName === "auto_reply" || keyName === "reply") {
+    return spanName === keyName || spanName.startsWith(`${keyName}.`);
+  }
+  return spanName === keyName;
 }
 
 function recordTimelines(record) {

--- a/src/reporting/report.mjs
+++ b/src/reporting/report.mjs
@@ -765,6 +765,25 @@ function buildFindings(report) {
         evidence: missing.length > 0 ? [`missing spans: ${missing.slice(0, 5).join(", ")}`] : ["missing expected diagnostic spans"]
       });
     }
+    const interruptedRestartSpanCount = record.measurements?.openclawInterruptedRestartSpanCount ?? 0;
+    if (interruptedRestartSpanCount > 0) {
+      const interrupted = record.measurements?.openclawInterruptedRestartSpans ?? [];
+      const first = interrupted[0];
+      findings.push({
+        id: `${record.scenario}:${state ?? "none"}:restart-interrupted-spans:${index + 1}`,
+        severity: "warning",
+        kind: "diagnostics",
+        scenario: record.scenario ?? null,
+        state,
+        sampleIndex: record.repeat?.index ?? index + 1,
+        ownerArea: record.likelyOwner ?? null,
+        metric: "openclawInterruptedRestartSpanCount",
+        summary: `${interruptedRestartSpanCount} OpenClaw diagnostics span(s) from a prior gateway PID were interrupted by an intentional restart`,
+        expected: "terminal gateway PID spans close normally",
+        actual: first ? `${first.name} pid ${first.pid}` : "prior gateway PID span",
+        evidence: interrupted.slice(0, 5).map((span) => `${span.name} pid ${span.pid}`)
+      });
+    }
     const proofFindings = ledgerFindings(record, index, state);
     findings.push(...proofFindings);
     const failed = firstFailedCommand(record, { includeCleanup: true });
@@ -1278,6 +1297,9 @@ function summarizeSampleMetrics(measurements) {
       openRequiredSpanCount: measurements.openclawOpenRequiredSpanCount ?? null,
       missingRequiredSpanCount: measurements.openclawMissingRequiredSpanCount ?? null,
       openSpans: measurements.openclawOpenSpans?.slice(0, 5) ?? [],
+      interruptedRestartSpanCount: measurements.openclawInterruptedRestartSpanCount ?? null,
+      interruptedRestartSpans: measurements.openclawInterruptedRestartSpans?.slice(0, 5) ?? [],
+      terminalGatewayPid: measurements.openclawTerminalGatewayPid ?? null,
       eventLoopMaxMs: measurements.openclawEventLoopMaxMs ?? null,
       providerRequestMaxMs: measurements.openclawProviderRequestMaxMs ?? null
     }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveScriptStep } from "mock-ai-provider/dist/providers/openai/common/scripted-response.js";
 import { quoteShell, runCommand } from "./commands.mjs";
@@ -65,7 +66,7 @@ import {
   readinessThresholdForPhase,
   tagCommandResult
 } from "./measurement-contract.mjs";
-import { parseTimelineText } from "./collectors/timeline.mjs";
+import { collectTimelineMetrics, parseTimelineText } from "./collectors/timeline.mjs";
 import { assertNetworkFrontageCommandSafe, networkFrontageCommandEnv, stopNetworkFrontage, waitForProxyReady, waitForTcp } from "./network-frontage.mjs";
 import { resolveGatewayEndpoint } from "../support/gateway-endpoint.mjs";
 import {
@@ -11622,6 +11623,7 @@ async function diagnosticsTimelineCheck() {
 }
 
 async function diagnosticsOpenSpanCheck() {
+  let artifactDir = null;
   try {
     const text = await readFile("fixtures/diagnostics/timeline-open-span.jsonl", "utf8");
     const timeline = parseTimelineText(text);
@@ -11629,7 +11631,41 @@ async function diagnosticsOpenSpanCheck() {
     assertEqual(timeline.openSpanCount, 1, "open span count");
     assertEqual(timeline.openSpans[0]?.name, "runtimeDeps.stage", "open span name");
     assertEqual(timeline.openSpans[0]?.ageMs, 5000, "open span age");
+    assertEqual(timeline.openSpans[0]?.pid, 100, "open span pid");
     assertEqual(timeline.keySpans["runtimeDeps.stage"].openCount, 1, "key open span count");
+    const partialPidTimeline = parseTimelineText([
+      '{"type":"span.start","timestamp":"2026-04-29T15:30:00.000Z","name":"runtimeDeps.stage","spanId":"partial-pid","pid":100}',
+      '{"type":"span.end","timestamp":"2026-04-29T15:30:01.000Z","name":"runtimeDeps.stage","spanId":"partial-pid","durationMs":1000}'
+    ].join("\n"));
+    assertEqual(partialPidTimeline.openSpanCount, 0, "span pair tolerates PID omitted from one event");
+    const duplicatePartialPidTimeline = parseTimelineText([
+      '{"type":"span.start","timestamp":"2026-04-29T15:30:00.000Z","name":"runtimeDeps.stage","spanId":"partial-pid","pid":100}',
+      '{"type":"span.start","timestamp":"2026-04-29T15:30:01.000Z","name":"runtimeDeps.stage","spanId":"partial-pid","pid":200}',
+      '{"type":"span.end","timestamp":"2026-04-29T15:30:02.000Z","name":"runtimeDeps.stage","spanId":"partial-pid","durationMs":1000}'
+    ].join("\n"));
+    assertEqual(duplicatePartialPidTimeline.openSpanCount, 1, "PID-less terminal closes newest reused span");
+    assertEqual(duplicatePartialPidTimeline.openSpans[0]?.pid, 100, "prior reused span stays open");
+    const terminalBeforeReuseTimeline = parseTimelineText([
+      '{"type":"span.start","timestamp":"2026-04-29T15:30:00.000Z","name":"runtimeDeps.stage","spanId":"partial-pid","pid":100}',
+      '{"type":"span.end","timestamp":"2026-04-29T15:30:01.000Z","name":"runtimeDeps.stage","spanId":"partial-pid","durationMs":1000}',
+      '{"type":"span.start","timestamp":"2026-04-29T15:30:02.000Z","name":"runtimeDeps.stage","spanId":"partial-pid","pid":200}'
+    ].join("\n"));
+    assertEqual(terminalBeforeReuseTimeline.openSpanCount, 1, "earlier terminal cannot close later reused span");
+    assertEqual(terminalBeforeReuseTimeline.openSpans[0]?.pid, 200, "later reused span stays open");
+    const partialPidNoIdTimeline = parseTimelineText([
+      '{"type":"span.start","timestamp":"2026-04-29T15:30:00.000Z","name":"runtimeDeps.stage","pid":100}',
+      '{"type":"span.end","timestamp":"2026-04-29T15:30:01.000Z","name":"runtimeDeps.stage","durationMs":1000}'
+    ].join("\n"));
+    assertEqual(partialPidNoIdTimeline.openSpanCount, 0, "name fallback tolerates PID omitted from one event");
+    artifactDir = await mkdtemp(join(tmpdir(), "kova-timeline-"));
+    await mkdir(join(artifactDir, "openclaw"));
+    await writeFile(join(artifactDir, "openclaw", "timeline.jsonl"), [
+      '{"type":"span.end","timestamp":"2026-04-29T15:30:00.000Z","name":"gateway.startup","spanId":"ordinary","pid":100,"durationMs":100}',
+      '{"type":"span.end","timestamp":"2026-04-29T15:30:01.000Z","name":"gateway.startup","spanId":"ordinary","pid":200,"durationMs":100}'
+    ].join("\n"));
+    const collected = await collectTimelineMetrics(artifactDir);
+    assertEqual(collected.gatewayPids.join(","), "100,200", "collector gateway PID history");
+    assertEqual(collected.terminalGatewayPid, 200, "collector terminal gateway PID");
     return {
       id: "diagnostics-open-span-parser",
       status: "PASS",
@@ -11644,6 +11680,10 @@ async function diagnosticsOpenSpanCheck() {
       durationMs: 0,
       message: error.message
     };
+  } finally {
+    if (artifactDir) {
+      await rm(artifactDir, { recursive: true, force: true });
+    }
   }
 }
 
@@ -11838,6 +11878,11 @@ function diagnosticsTimelineEvaluationCheck() {
       2,
       "latest cumulative timeline events retained"
     );
+    assertEqual(
+      cumulativeTimelineRecord.finalMetrics.timeline.openSpansAll,
+      undefined,
+      "uncapped evaluation-only open spans compacted"
+    );
 
     const openSpanRecord = {
       scenario: "diagnostic-open-span",
@@ -11884,6 +11929,139 @@ function diagnosticsTimelineEvaluationCheck() {
       true,
       "brief evidence includes open required spans"
     );
+
+    const restartedTimeline = parseTimelineText([
+      '{"type":"mark","timestamp":"2026-04-29T15:30:00.000Z","name":"gateway.ready","pid":100}',
+      '{"type":"span.start","timestamp":"2026-04-29T15:30:01.000Z","name":"plugins.metadata.scan","spanId":"reused","pid":100}',
+      '{"type":"span.start","timestamp":"2026-04-29T15:30:02.000Z","name":"gateway.ready","spanId":"gateway-startup-33","pid":200}',
+      '{"type":"span.end","timestamp":"2026-04-29T15:30:03.000Z","name":"gateway.ready","spanId":"gateway-startup-33","pid":200,"durationMs":1000}',
+      '{"type":"span.start","timestamp":"2026-04-29T15:30:04.000Z","name":"plugins.metadata.scan","spanId":"reused","pid":200}',
+      '{"type":"span.end","timestamp":"2026-04-29T15:30:05.000Z","name":"plugins.metadata.scan","spanId":"reused","pid":200,"durationMs":1000}'
+    ].join("\n"));
+    assertEqual(restartedTimeline.openSpanCount, 1, "PID identity preserves prior interrupted span");
+    assertEqual(restartedTimeline.openSpans[0]?.pid, 100, "prior gateway PID preserved in compact evidence");
+    assertEqual(restartedTimeline.terminalGatewayPid, 200, "terminal gateway PID");
+
+    const restartedSpanRecord = {
+      scenario: "diagnostic-restarted-span",
+      status: "PASS",
+      phases: [
+        {
+          id: "before-restart",
+          metrics: {
+            timeline: parseTimelineText(restartedTimeline.events
+              .filter((event) => event.pid === 100)
+              .map((event) => JSON.stringify(event))
+              .join("\n"))
+          }
+        },
+        {
+          id: "warm-restart",
+          results: [{ command: "ocm service restart 'fixture'", status: 0 }]
+        }
+      ],
+      finalMetrics: {
+        service: { gatewayState: "running" },
+        logs: zeroLogMetrics(),
+        timeline: restartedTimeline
+      }
+    };
+    const pluginTimelineOptions = {
+      ...runtimeDepsTimelineOptions,
+      surface: {
+        id: "gateway-performance",
+        diagnostics: { expectedSpans: ["plugins.metadata.scan"] },
+        thresholds: {}
+      }
+    };
+    evaluateRecord(restartedSpanRecord, { thresholds: {} }, pluginTimelineOptions);
+    assertEqual(restartedSpanRecord.status, "PASS", "intentional restart interrupted span does not fail terminal gateway");
+    assertEqual(restartedSpanRecord.measurements.openclawOpenRequiredSpanCount, 0, "prior PID span is not terminal-open");
+    assertEqual(restartedSpanRecord.measurements.openclawInterruptedRestartSpanCount, 1, "restart interruption evidence count");
+    assertEqual(restartedSpanRecord.measurements.openclawInterruptedRestartSpans[0]?.pid, 100, "restart interruption evidence PID");
+
+    const terminalOpenTimeline = parseTimelineText([
+      ...restartedTimeline.events.map((event) => JSON.stringify(event)),
+      ...Array.from({ length: 30 }, (_, index) => JSON.stringify({
+        type: "span.start",
+        timestamp: `2026-04-29T15:31:${String(index).padStart(2, "0")}.000Z`,
+        name: "plugins.metadata.scan",
+        spanId: `terminal-open-${index}`,
+        pid: 200
+      }))
+    ].join("\n"));
+    const terminalOpenRecord = structuredClone(restartedSpanRecord);
+    terminalOpenRecord.status = "PASS";
+    terminalOpenRecord.measurements = undefined;
+    terminalOpenRecord.finalMetrics.timeline = terminalOpenTimeline;
+    evaluateRecord(terminalOpenRecord, { thresholds: {} }, pluginTimelineOptions);
+    assertEqual(terminalOpenRecord.status, "FAIL", "terminal gateway PID open span stays strict");
+    assertEqual(terminalOpenRecord.measurements.openclawOpenRequiredSpanCount, 30, "terminal PID required open span count");
+    assertEqual(terminalOpenRecord.measurements.openclawOpenSpanCount, 30, "uncapped terminal open span count");
+    assertEqual(terminalOpenRecord.measurements.openclawOpenSpans.length, 25, "terminal open span evidence cap");
+    assertEqual(terminalOpenRecord.measurements.openclawKeySpans["plugins.metadata.scan"].openCount, 30, "key span count stays uncapped");
+    assertEqual(terminalOpenRecord.measurements.openclawOpenSpans[0]?.pid, 200, "terminal PID evidence preserved");
+
+    const unexpectedRestartTimeline = parseTimelineText([
+      ...restartedTimeline.events.map((event) => JSON.stringify(event)),
+      '{"type":"span.start","timestamp":"2026-04-29T15:30:06.000Z","name":"plugins.metadata.scan","spanId":"unexpected-interrupted","pid":200}',
+      '{"type":"span.end","timestamp":"2026-04-29T15:30:07.000Z","name":"gateway.startup","spanId":"gateway-300","pid":300,"durationMs":100}'
+    ].join("\n"));
+    const unexpectedRestartRecord = structuredClone(restartedSpanRecord);
+    unexpectedRestartRecord.status = "PASS";
+    unexpectedRestartRecord.measurements = undefined;
+    unexpectedRestartRecord.finalMetrics.timeline = unexpectedRestartTimeline;
+    evaluateRecord(unexpectedRestartRecord, { thresholds: {} }, pluginTimelineOptions);
+    assertEqual(unexpectedRestartRecord.status, "FAIL", "unexpected later restart remains strict");
+    assertEqual(unexpectedRestartRecord.measurements.openclawOpenRequiredSpanCount, 2, "ambiguous restart chain fails closed");
+    assertEqual(
+      unexpectedRestartRecord.measurements.openclawOpenSpans.some((span) => span.pid === 200),
+      true,
+      "unexpected prior PID evidence preserved"
+    );
+
+    const manyInterruptedLines = Array.from({ length: 30 }, (_, index) =>
+      JSON.stringify({
+        type: "span.start",
+        timestamp: `2026-04-29T15:30:${String(index).padStart(2, "0")}.000Z`,
+        name: "plugins.metadata.scan",
+        spanId: `prior-${index}`,
+        pid: 100
+      })
+    );
+    const crowdedRestartTimeline = parseTimelineText([
+      '{"type":"mark","timestamp":"2026-04-29T15:29:59.000Z","name":"gateway.ready","pid":100}',
+      ...manyInterruptedLines,
+      '{"type":"span.end","timestamp":"2026-04-29T15:31:00.000Z","name":"gateway.startup","spanId":"gateway-200","pid":200,"durationMs":100}',
+      '{"type":"span.start","timestamp":"2026-04-29T15:31:01.000Z","name":"plugins.metadata.scan","spanId":"terminal-crowded","pid":200}'
+    ].join("\n"));
+    const crowdedRestartRecord = {
+      scenario: "diagnostic-crowded-restart",
+      status: "PASS",
+      phases: [
+        {
+          id: "before-restart",
+          metrics: { timeline: parseTimelineText([
+            '{"type":"mark","timestamp":"2026-04-29T15:29:59.000Z","name":"gateway.ready","pid":100}',
+            ...manyInterruptedLines
+          ].join("\n")) }
+        },
+        {
+          id: "warm-restart",
+          results: [{ command: "ocm service restart 'fixture'", status: 0 }],
+          metrics: { timeline: crowdedRestartTimeline }
+        }
+      ],
+      finalMetrics: {
+        service: { gatewayState: "running" },
+        logs: zeroLogMetrics(),
+        timeline: crowdedRestartTimeline
+      }
+    };
+    evaluateRecord(crowdedRestartRecord, { thresholds: {} }, pluginTimelineOptions);
+    assertEqual(crowdedRestartRecord.status, "FAIL", "terminal open span survives compact evidence cap");
+    assertEqual(crowdedRestartRecord.measurements.openclawOpenRequiredSpanCount, 1, "crowded terminal required span count");
+    assertEqual(crowdedRestartRecord.measurements.openclawInterruptedRestartSpanCount, 30, "all crowded restart spans classified");
 
     return {
       id: "diagnostics-timeline-evaluation",

--- a/tests/snapshots/report-fail-json.snap
+++ b/tests/snapshots/report-fail-json.snap
@@ -288,6 +288,9 @@
           "openRequiredSpanCount": null,
           "missingRequiredSpanCount": null,
           "openSpans": [],
+          "interruptedRestartSpanCount": null,
+          "interruptedRestartSpans": [],
+          "terminalGatewayPid": null,
           "eventLoopMaxMs": null,
           "providerRequestMaxMs": null
         }
@@ -404,6 +407,9 @@
           "openRequiredSpanCount": null,
           "missingRequiredSpanCount": null,
           "openSpans": [],
+          "interruptedRestartSpanCount": null,
+          "interruptedRestartSpans": [],
+          "terminalGatewayPid": null,
           "eventLoopMaxMs": null,
           "providerRequestMaxMs": null
         }

--- a/tests/snapshots/report-pass-json.snap
+++ b/tests/snapshots/report-pass-json.snap
@@ -219,6 +219,9 @@
           "openRequiredSpanCount": null,
           "missingRequiredSpanCount": null,
           "openSpans": [],
+          "interruptedRestartSpanCount": null,
+          "interruptedRestartSpans": [],
+          "terminalGatewayPid": null,
           "eventLoopMaxMs": null,
           "providerRequestMaxMs": null
         }
@@ -327,6 +330,9 @@
           "openRequiredSpanCount": null,
           "missingRequiredSpanCount": null,
           "openSpans": [],
+          "interruptedRestartSpanCount": null,
+          "interruptedRestartSpans": [],
+          "terminalGatewayPid": null,
           "eventLoopMaxMs": null,
           "providerRequestMaxMs": null
         }


### PR DESCRIPTION
## Problem

OpenClaw performance validation retains cumulative diagnostics across an intentional warm gateway restart. A span started by the prior gateway PID can therefore remain open after that process exits, even though the replacement gateway starts and becomes ready normally. Kova treated that interrupted prior-process span as a terminal-process failure, making LTS performance evidence fail on repeat one while repeats two and three passed.

## Change

- Pair diagnostic spans with PID-aware, event-ordered, amortized-linear matching, including safe handling for partial PID data and reused span IDs.
- Carry gateway PID history and the terminal gateway PID through collection and evaluation.
- Suppress only open spans from a proven intentional restart source PID; terminal/current PID spans remain strict failures.
- Preserve interrupted spans as structured warning and report evidence.
- Keep evaluation counts uncapped while capping only rendered evidence.

## Evidence

- Focused self-checks pass: `diagnostics-timeline-parser`, `diagnostics-open-span-parser`, `diagnostics-timeline-evaluation`.
- Full self-check: 226/230 pass; the four unchanged failures require locally unavailable OCM/setup prerequisites.
- Report snapshot cases covering the new fields pass; the full snapshot command still reports unrelated host/plan baseline drift.
- `git diff --check` passes.
- Fresh Codex autoreview: clean, no actionable findings.

This repairs the deterministic failure in OpenClaw product-performance run 29179335780 without weakening terminal gateway span enforcement.
