### PR TITLE
fix(runtime): require canonical decimal PIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Kova are documented in this file.
 ### Fixed
 
 - Hardened command execution with bounded streaming redaction, POSIX process-group cleanup, strict optional-log matching, and direct scenario command validation.
-- Hardened mock-provider and diagnostic process handling to migrate active legacy providers safely, reject stale startup metadata, avoid signaling unrelated processes, retain retryable PID state, and preserve colliding diagnostic artifacts.
+- Hardened mock-provider and diagnostic process handling to reject non-decimal PID state, migrate active legacy providers safely, reject stale startup metadata, avoid signaling unrelated processes, retain retryable PID state, and preserve colliding diagnostic artifacts.
 - Fixed OpenClaw inventory discovery to recognize canonical JSON5 plugin manifests consistently across platforms while deterministically bounding scans.
 - Isolated concurrent self-check OCM identities, child environments, runtime names, and temp cleanup ownership.
 - Hardened performance baseline persistence, unstable-group detection, and repeated-work audit isolation.

--- a/src/process-safety.mjs
+++ b/src/process-safety.mjs
@@ -8,8 +8,11 @@ const mockProviderOwnerSchema = "kova.mock-provider-owner.v1";
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function positiveProcessId(value, label = "pid") {
-  const text = typeof value === "string" ? value.trim() : value;
-  const pid = typeof text === "number" ? text : Number(text);
+  const text = typeof value === "string" ? value.trim() : null;
+  if (text !== null && !/^[1-9][0-9]*$/.test(text)) {
+    throw new Error(`${label} must be a positive integer, got ${JSON.stringify(value)}`);
+  }
+  const pid = typeof value === "number" ? value : text === null ? Number.NaN : Number(text);
   if (!Number.isSafeInteger(pid) || pid <= 0) {
     throw new Error(`${label} must be a positive integer, got ${JSON.stringify(value)}`);
   }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -158,6 +158,7 @@ import {
   mockProviderOwnerRecord,
   mockProviderStopFile,
   mockProviderSupervisorArgs,
+  positiveProcessId,
   stopOwnedMockProvider
 } from "./process-safety.mjs";
 import { envNameFor, maxOcmEnvNameLength } from "./run/env-name.mjs";
@@ -8422,6 +8423,16 @@ async function mockProviderProcessSafetyCheck(tmp) {
   const ownerText = (pid, generation = ownerGeneration) => `${JSON.stringify(mockProviderOwnerRecord(pid, generation))}\n`;
 
   try {
+    assertEqual(positiveProcessId("12345\n"), 12345, "canonical decimal pid");
+    for (const invalidPid of ["", "0", "-1", "+1", "01", "1e2", "0x10", "1.0", "123x", "9007199254740992"]) {
+      let rejected = false;
+      try {
+        positiveProcessId(invalidPid);
+      } catch (error) {
+        rejected = error.message.includes("must be a positive integer");
+      }
+      assertEqual(rejected, true, `non-canonical pid ${JSON.stringify(invalidPid)} rejected`);
+    }
     assertEqual(
       isOwnedMockProviderSupervisorCommand(expectedCommand, stopOptions),
       true,


### PR DESCRIPTION
## What Problem This Solves

The process-safety parser introduced by #45 accepted numeric string forms such as `1e2` and `0x10`. JavaScript converts those to valid integers, so malformed PID state could still select an unrelated operating-system process.

## Why This Change Was Made

- Accept numeric PID values only when they are positive safe integers.
- Accept PID-file strings only as trimmed canonical positive decimal digits.
- Reject exponential, hexadecimal, signed, zero-padded, decimal, empty, mixed-character, and unsafe-range forms.
- Preserve the normal newline-terminated decimal PID-file contract.

## User Impact

Malformed PID files can no longer authorize inspection or signaling of a different process through JavaScript numeric coercion.

## Evidence

- Focused canonical PID parser probe passed.
- `NO_COLOR=1 npm run check`: concurrent isolation passed; Kova self-check 242/242 passed in 64.5s.
- Codex Sol/high autoreview: clean, confidence 0.95.
- `git diff --check origin/main...HEAD` passed.
- One scoped commit; rebase merge requested, no squash.