### PR TITLE
fix(artifacts): harden collected evidence confidentiality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Kova are documented in this file.
 ### Fixed
 
 - Hardened command execution with bounded streaming redaction, POSIX process-group cleanup, strict optional-log matching, and direct scenario command validation.
+- Hardened artifact confidentiality by redacting credential-bearing logs before persistence and containing OpenClaw state collection against symlink escapes and hostile filesystem inputs.
 - Hardened mock-provider and diagnostic process handling to reject non-decimal PID state, migrate active legacy providers safely, reject stale startup metadata, avoid signaling unrelated processes, retain retryable PID state, and preserve colliding diagnostic artifacts.
 - Fixed OpenClaw inventory discovery to recognize canonical JSON5 plugin manifests consistently across platforms while deterministically bounding scans.
 - Isolated concurrent self-check OCM identities, child environments, runtime names, and temp cleanup ownership.

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -14,8 +14,8 @@ const QUOTED_SENSITIVE_VALUE_PATTERN = new RegExp(
   "gi"
 );
 const UNQUOTED_SENSITIVE_FIELD_PATTERN = new RegExp(
-  `(["']?${SENSITIVE_LOG_KEY}["']?\\s*:\\s*)(?!["'])[^\\s,}\\]]+`,
-  "gi"
+  `(["']?${SENSITIVE_LOG_KEY}["']?\\s*:\\s*)(?!["']).*$`,
+  "gim"
 );
 const UNQUOTED_SENSITIVE_ASSIGNMENT_PATTERN = new RegExp(
   `(\\b${SENSITIVE_LOG_KEY}\\b\\s*=\\s*)(?!["'])\\S+`,
@@ -23,6 +23,8 @@ const UNQUOTED_SENSITIVE_ASSIGNMENT_PATTERN = new RegExp(
 );
 const QUOTED_SENSITIVE_CLI_VALUE_PATTERN =
   /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+))(["'])((?:\\.|(?!\2).)*)\2/gim;
+const PEM_PRIVATE_KEY_PATTERN =
+  /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?-----END \1-----/g;
 
 export async function collectLogMetrics(envName, timeoutMs, artifactDir, options = {}) {
   const result = await runCommand(ocmLogs(envName, { tail: 200 }), {
@@ -87,6 +89,7 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, options
 
 export function redactLogText(value) {
   return String(value ?? "")
+    .replace(PEM_PRIVATE_KEY_PATTERN, "[REDACTED]")
     .replace(
       QUOTED_SENSITIVE_VALUE_PATTERN,
       "$1$2[REDACTED]$2"

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -18,11 +18,11 @@ const SENSITIVE_CLI_TO_LINE_END_PATTERN = new RegExp(
   "gim"
 );
 const SENSITIVE_VALUE_CONTINUATION_PATTERN = new RegExp(
-  `(["']?\\b${SENSITIVE_LOG_KEY}\\b["']?\\s*[:=]\\s*)([|>][-+]?|\\\\)\\s*$`,
+  `(["']?\\b${SENSITIVE_LOG_KEY}\\b["']?\\s*[:=]\\s*)([|>](?:[1-9][-+]?|[-+][1-9]?)?|\\\\)\\s*$`,
   "i"
 );
 const SENSITIVE_CLI_CONTINUATION_PATTERN = new RegExp(
-  `((?:^|\\s)--${SENSITIVE_LOG_KEY}(?:=|\\s+))([|>][-+]?|\\\\)\\s*$`,
+  `((?:^|\\s)--${SENSITIVE_LOG_KEY}(?:=|\\s+))([|>](?:[1-9][-+]?|[-+][1-9]?)?|\\\\)\\s*$`,
   "i"
 );
 const PEM_PRIVATE_KEY_PATTERN =

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -27,6 +27,8 @@ const SENSITIVE_CLI_LINE_PATTERN = new RegExp(
 );
 const PEM_PRIVATE_KEY_PATTERN =
   /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?(?:-----END \1-----|$)/g;
+const URL_USERINFO_PATTERN =
+  /\b([a-z][a-z0-9+.-]*:\/\/)[^/\s?#@]*:[^/\s?#@]+@/gi;
 
 export async function collectLogMetrics(envName, timeoutMs, artifactDir, options = {}) {
   const result = await runCommand(ocmLogs(envName, { tail: 200 }), {
@@ -93,6 +95,7 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, options
 export function redactLogText(value) {
   const text = String(value ?? "").replace(PEM_PRIVATE_KEY_PATTERN, "[REDACTED]");
   return redactSensitiveContinuations(text)
+    .replace(URL_USERINFO_PATTERN, "$1[REDACTED]@")
     .replace(
       SENSITIVE_VALUE_TO_LINE_END_PATTERN,
       "$1[REDACTED]"

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -9,14 +9,7 @@ export const LOG_METRICS_SCHEMA = "kova.logMetrics.v1";
 const PROVIDER_TIMEOUT_SIGNAL_PATTERN =
   /(?:\bprovider\b|\bmodel\b).*(?:\btimeouts?\b|\btimed out\b)|(?:\btimeouts?\b|\btimed out\b).*(?:\bprovider\b|\bmodel\b)/i;
 const SENSITIVE_LOG_KEY = String.raw`[a-z0-9_-]*(?:api[_-]?key|token|secret|password|cookie|credential|private[_-]?key|authorization)[a-z0-9_-]*`;
-const SENSITIVE_VALUE_TO_LINE_END_PATTERN = new RegExp(
-  `(["']?\\b${SENSITIVE_LOG_KEY}\\b["']?\\s*[:=]\\s*).*$`,
-  "gim"
-);
-const SENSITIVE_CLI_TO_LINE_END_PATTERN = new RegExp(
-  `((?:^|\\s)--${SENSITIVE_LOG_KEY}(?:=|\\s+)).*$`,
-  "gim"
-);
+const SENSITIVE_LOG_KEY_PATTERN = new RegExp(`^${SENSITIVE_LOG_KEY}$`, "i");
 const SENSITIVE_VALUE_LINE_PATTERN = new RegExp(
   `(["']?\\b${SENSITIVE_LOG_KEY}\\b["']?\\s*[:=]\\s*)(.*)$`,
   "i"
@@ -96,17 +89,9 @@ export function redactLogText(value) {
   const text = String(value ?? "").replace(PEM_PRIVATE_KEY_PATTERN, "[REDACTED]");
   return redactSensitiveContinuations(text)
     .replace(URL_USERINFO_PATTERN, "$1[REDACTED]@")
-    .replace(
-      SENSITIVE_VALUE_TO_LINE_END_PATTERN,
-      "$1[REDACTED]"
-    )
-    .replace(
-      SENSITIVE_CLI_TO_LINE_END_PATTERN,
-      "$1[REDACTED]"
-    )
     .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi, "$1 [REDACTED]")
     .replace(
-      /^((?:.*?)(?:authorization|proxy-authorization|x-api-key|api-key|cookie|set-cookie)\s*:\s*).+$/gim,
+      /^((?:.*\s)?(?:authorization|proxy-authorization|x-api-key|api-key|cookie|set-cookie)\s*:\s*).+$/gim,
       "$1[REDACTED]"
     );
 }
@@ -114,10 +99,22 @@ export function redactLogText(value) {
 function redactSensitiveContinuations(value) {
   const lines = String(value ?? "").split(/\r?\n/);
   let blockIndent = null;
+  let quotedContinuation = null;
   let redactNextValue = false;
 
   for (const [index, line] of lines.entries()) {
     const indent = line.match(/^[ \t]*/)?.[0].length ?? 0;
+    if (quotedContinuation !== null) {
+      const closingIndex = findUnescapedQuote(line, quotedContinuation);
+      if (line.trim() !== "") {
+        const suffix = closingIndex === -1 ? "" : line.slice(closingIndex + 1);
+        lines[index] = `${line.slice(0, indent)}[REDACTED]${suffix}`;
+      }
+      if (closingIndex !== -1) {
+        quotedContinuation = null;
+      }
+      continue;
+    }
     if (redactNextValue) {
       if (line.trim() === "") {
         continue;
@@ -136,6 +133,12 @@ function redactSensitiveContinuations(value) {
       blockIndent = null;
     }
 
+    const structuredLine = redactStructuredJsonLine(line);
+    if (structuredLine !== null) {
+      lines[index] = structuredLine;
+      continue;
+    }
+
     const pattern = SENSITIVE_VALUE_LINE_PATTERN.test(line)
       ? SENSITIVE_VALUE_LINE_PATTERN
       : SENSITIVE_CLI_LINE_PATTERN.test(line)
@@ -144,8 +147,12 @@ function redactSensitiveContinuations(value) {
     if (!pattern) {
       continue;
     }
-    const marker = line.match(pattern)?.[2].trim();
+    const marker = line.match(pattern)?.[2].trim() ?? "";
     lines[index] = line.replace(pattern, "$1[REDACTED]");
+    quotedContinuation = unclosedStartingQuote(marker);
+    if (quotedContinuation !== null) {
+      continue;
+    }
     if (marker.endsWith("\\")) {
       redactNextValue = true;
     } else {
@@ -156,6 +163,73 @@ function redactSensitiveContinuations(value) {
   }
 
   return lines.join("\n");
+}
+
+function redactStructuredJsonLine(line) {
+  const jsonStart = line.indexOf("{");
+  if (jsonStart === -1) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(line.slice(jsonStart));
+    const redacted = redactStructuredJsonValue(parsed);
+    return redacted.changed
+      ? `${line.slice(0, jsonStart)}${JSON.stringify(redacted.value)}`
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function redactStructuredJsonValue(value) {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const items = value.map((item) => {
+      const redacted = redactStructuredJsonValue(item);
+      changed ||= redacted.changed;
+      return redacted.value;
+    });
+    return { value: items, changed };
+  }
+  if (!value || typeof value !== "object") {
+    return { value, changed: false };
+  }
+
+  let changed = false;
+  const entries = Object.entries(value).map(([key, item]) => {
+    if (SENSITIVE_LOG_KEY_PATTERN.test(key)) {
+      changed = true;
+      return [key, "[REDACTED]"];
+    }
+    const redacted = redactStructuredJsonValue(item);
+    changed ||= redacted.changed;
+    return [key, redacted.value];
+  });
+  return { value: Object.fromEntries(entries), changed };
+}
+
+function unclosedStartingQuote(value) {
+  const quote = value[0];
+  if (!["\"", "'", "`"].includes(quote)) {
+    return null;
+  }
+  return findUnescapedQuote(value, quote, 1) === -1 ? quote : null;
+}
+
+function findUnescapedQuote(value, quote, startIndex = 0) {
+  let escaped = false;
+  for (let index = startIndex; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === quote && !escaped) {
+      return index;
+    }
+    if (character === "\\" && !escaped) {
+      escaped = true;
+    } else {
+      escaped = false;
+    }
+  }
+  return -1;
 }
 
 export function boundedLogSnippet(value, maxChars) {

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -8,6 +8,19 @@ export const LOG_METRICS_SCHEMA = "kova.logMetrics.v1";
 
 const PROVIDER_TIMEOUT_SIGNAL_PATTERN =
   /(?:\bprovider\b|\bmodel\b).*(?:\btimeouts?\b|\btimed out\b)|(?:\btimeouts?\b|\btimed out\b).*(?:\bprovider\b|\bmodel\b)/i;
+const SENSITIVE_LOG_KEY = String.raw`[a-z0-9_-]*(?:api[_-]?key|token|secret|password|cookie|credential|private[_-]?key)[a-z0-9_-]*`;
+const QUOTED_SENSITIVE_VALUE_PATTERN = new RegExp(
+  `(["']?${SENSITIVE_LOG_KEY}["']?\\s*[:=]\\s*)(["'])(.*?)\\2`,
+  "gi"
+);
+const UNQUOTED_SENSITIVE_FIELD_PATTERN = new RegExp(
+  `(["']?${SENSITIVE_LOG_KEY}["']?\\s*:\\s*)(?!["'])[^\\s,}\\]]+`,
+  "gi"
+);
+const UNQUOTED_SENSITIVE_ASSIGNMENT_PATTERN = new RegExp(
+  `(\\b${SENSITIVE_LOG_KEY}\\b\\s*=\\s*)(?!["'])\\S+`,
+  "gi"
+);
 
 export async function collectLogMetrics(envName, timeoutMs, artifactDir, options = {}) {
   const result = await runCommand(ocmLogs(envName, { tail: 200 }), {
@@ -73,16 +86,16 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, options
 export function redactLogText(value) {
   return String(value ?? "")
     .replace(
-      /^((?:.*?)(?:authorization|proxy-authorization|x-api-key|api-key|cookie|set-cookie)\s*:\s*).+$/gim,
-      "$1[REDACTED]"
-    )
-    .replace(
-      /(["']?(?:api[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|secret|password|cookie|authorization)["']?\s*[:=]\s*)(["'])(.*?)\2/gi,
+      QUOTED_SENSITIVE_VALUE_PATTERN,
       "$1$2[REDACTED]$2"
     )
     .replace(
-      /\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|COOKIE)[A-Z0-9_]*)(\s*=\s*)([^\s,;]+)/gi,
-      "$1$2[REDACTED]"
+      UNQUOTED_SENSITIVE_FIELD_PATTERN,
+      "$1[REDACTED]"
+    )
+    .replace(
+      UNQUOTED_SENSITIVE_ASSIGNMENT_PATTERN,
+      "$1[REDACTED]"
     )
     .replace(
       /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+))(["'])[^"']+\2/gim,
@@ -92,7 +105,11 @@ export function redactLogText(value) {
       /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+))[^\s,"']+/gim,
       "$1[REDACTED]"
     )
-    .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi, "$1 [REDACTED]");
+    .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi, "$1 [REDACTED]")
+    .replace(
+      /^((?:.*?)(?:authorization|proxy-authorization|x-api-key|api-key|cookie|set-cookie)\s*:\s*).+$/gim,
+      "$1[REDACTED]"
+    );
 }
 
 export function boundedLogSnippet(value, maxChars) {

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -107,8 +107,7 @@ function redactSensitiveContinuations(value) {
     if (quotedContinuation !== null) {
       const closingIndex = findUnescapedQuote(line, quotedContinuation);
       if (line.trim() !== "") {
-        const suffix = closingIndex === -1 ? "" : line.slice(closingIndex + 1);
-        lines[index] = `${line.slice(0, indent)}[REDACTED]${suffix}`;
+        lines[index] = `${line.slice(0, indent)}[REDACTED]`;
       }
       if (closingIndex !== -1) {
         quotedContinuation = null;

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -91,8 +91,8 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, options
 }
 
 export function redactLogText(value) {
-  return redactSensitiveContinuations(value)
-    .replace(PEM_PRIVATE_KEY_PATTERN, "[REDACTED]")
+  const text = String(value ?? "").replace(PEM_PRIVATE_KEY_PATTERN, "[REDACTED]");
+  return redactSensitiveContinuations(text)
     .replace(
       SENSITIVE_VALUE_TO_LINE_END_PATTERN,
       "$1[REDACTED]"

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -9,16 +9,19 @@ export const LOG_METRICS_SCHEMA = "kova.logMetrics.v1";
 const PROVIDER_TIMEOUT_SIGNAL_PATTERN =
   /(?:\bprovider\b|\bmodel\b).*(?:\btimeouts?\b|\btimed out\b)|(?:\btimeouts?\b|\btimed out\b).*(?:\bprovider\b|\bmodel\b)/i;
 
-export async function collectLogMetrics(envName, timeoutMs, artifactDir, commandEnv) {
+export async function collectLogMetrics(envName, timeoutMs, artifactDir, options = {}) {
   const result = await runCommand(ocmLogs(envName, { tail: 200 }), {
     timeoutMs,
-    env: commandEnv
+    env: options.commandEnv,
+    redactValues: options.redactValues
   });
-  const text = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  const stdout = redactLogText(result.stdout);
+  const stderr = redactLogText(result.stderr);
+  const text = `${stdout}\n${stderr}`;
   const noLogsAvailable = isOptionalNoLogsResult(result);
   const timestamps = collectTimestamps(text);
-  const stdoutSnippet = boundedLogSnippet(result.stdout, 4000);
-  const stderrSnippet = boundedLogSnippet(result.stderr, 4000);
+  const stdoutSnippet = boundedLogSnippet(stdout, 4000);
+  const stderrSnippet = boundedLogSnippet(stderr, 4000);
   const artifacts = [];
   if (artifactDir) {
     await mkdir(join(artifactDir, "collectors"), { recursive: true });
@@ -65,6 +68,31 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, command
     stdoutSnippet: stdoutSnippet.text,
     stderrSnippet: stderrSnippet.text
   };
+}
+
+export function redactLogText(value) {
+  return String(value ?? "")
+    .replace(
+      /^(\s*(?:authorization|proxy-authorization|x-api-key|api-key|cookie|set-cookie)\s*:\s*).+$/gim,
+      "$1[REDACTED]"
+    )
+    .replace(
+      /(["']?(?:api[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|secret|password|cookie|authorization)["']?\s*[:=]\s*)(["'])(.*?)\2/gi,
+      "$1$2[REDACTED]$2"
+    )
+    .replace(
+      /\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|COOKIE)[A-Z0-9_]*)(\s*=\s*)([^\s,;]+)/gi,
+      "$1$2[REDACTED]"
+    )
+    .replace(
+      /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+))(["'])[^"']+\2/gim,
+      "$1[REDACTED]"
+    )
+    .replace(
+      /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+))[^\s,"']+/gim,
+      "$1[REDACTED]"
+    )
+    .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi, "$1 [REDACTED]");
 }
 
 export function boundedLogSnippet(value, maxChars) {

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -17,12 +17,12 @@ const SENSITIVE_CLI_TO_LINE_END_PATTERN = new RegExp(
   `((?:^|\\s)--${SENSITIVE_LOG_KEY}(?:=|\\s+)).*$`,
   "gim"
 );
-const SENSITIVE_VALUE_CONTINUATION_PATTERN = new RegExp(
-  `(["']?\\b${SENSITIVE_LOG_KEY}\\b["']?\\s*[:=]\\s*)([|>](?:[1-9][-+]?|[-+][1-9]?)?|\\\\)\\s*$`,
+const SENSITIVE_VALUE_LINE_PATTERN = new RegExp(
+  `(["']?\\b${SENSITIVE_LOG_KEY}\\b["']?\\s*[:=]\\s*)(.*)$`,
   "i"
 );
-const SENSITIVE_CLI_CONTINUATION_PATTERN = new RegExp(
-  `((?:^|\\s)--${SENSITIVE_LOG_KEY}(?:=|\\s+))([|>](?:[1-9][-+]?|[-+][1-9]?)?|\\\\)\\s*$`,
+const SENSITIVE_CLI_LINE_PATTERN = new RegExp(
+  `((?:^|\\s)--${SENSITIVE_LOG_KEY}(?:=|\\s+))(.*)$`,
   "i"
 );
 const PEM_PRIVATE_KEY_PATTERN =
@@ -133,19 +133,21 @@ function redactSensitiveContinuations(value) {
       blockIndent = null;
     }
 
-    const pattern = SENSITIVE_VALUE_CONTINUATION_PATTERN.test(line)
-      ? SENSITIVE_VALUE_CONTINUATION_PATTERN
-      : SENSITIVE_CLI_CONTINUATION_PATTERN.test(line)
-        ? SENSITIVE_CLI_CONTINUATION_PATTERN
+    const pattern = SENSITIVE_VALUE_LINE_PATTERN.test(line)
+      ? SENSITIVE_VALUE_LINE_PATTERN
+      : SENSITIVE_CLI_LINE_PATTERN.test(line)
+        ? SENSITIVE_CLI_LINE_PATTERN
         : null;
     if (!pattern) {
       continue;
     }
-    const marker = line.match(pattern)?.[2];
+    const marker = line.match(pattern)?.[2].trim();
     lines[index] = line.replace(pattern, "$1[REDACTED]");
-    if (marker === "\\") {
+    if (marker.endsWith("\\")) {
       redactNextValue = true;
     } else {
+      // Indented following lines can be YAML folding or wrapped command output.
+      // Treat them as part of the sensitive value until indentation returns.
       blockIndent = indent;
     }
   }

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -10,7 +10,7 @@ const PROVIDER_TIMEOUT_SIGNAL_PATTERN =
   /(?:\bprovider\b|\bmodel\b).*(?:\btimeouts?\b|\btimed out\b)|(?:\btimeouts?\b|\btimed out\b).*(?:\bprovider\b|\bmodel\b)/i;
 const SENSITIVE_LOG_KEY = String.raw`[a-z0-9_-]*(?:api[_-]?key|token|secret|password|cookie|credential|private[_-]?key)[a-z0-9_-]*`;
 const QUOTED_SENSITIVE_VALUE_PATTERN = new RegExp(
-  `(["']?${SENSITIVE_LOG_KEY}["']?\\s*[:=]\\s*)(["'])(.*?)\\2`,
+  `(["']?${SENSITIVE_LOG_KEY}["']?\\s*[:=]\\s*)(["'])((?:\\\\.|(?!\\2).)*)\\2`,
   "gi"
 );
 const UNQUOTED_SENSITIVE_FIELD_PATTERN = new RegExp(
@@ -21,6 +21,8 @@ const UNQUOTED_SENSITIVE_ASSIGNMENT_PATTERN = new RegExp(
   `(\\b${SENSITIVE_LOG_KEY}\\b\\s*=\\s*)(?!["'])\\S+`,
   "gi"
 );
+const QUOTED_SENSITIVE_CLI_VALUE_PATTERN =
+  /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+))(["'])((?:\\.|(?!\2).)*)\2/gim;
 
 export async function collectLogMetrics(envName, timeoutMs, artifactDir, options = {}) {
   const result = await runCommand(ocmLogs(envName, { tail: 200 }), {
@@ -98,7 +100,7 @@ export function redactLogText(value) {
       "$1[REDACTED]"
     )
     .replace(
-      /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+))(["'])[^"']+\2/gim,
+      QUOTED_SENSITIVE_CLI_VALUE_PATTERN,
       "$1[REDACTED]"
     )
     .replace(

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -34,7 +34,7 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, options
   const stderr = redactLogText(result.stderr);
   const text = `${stdout}\n${stderr}`;
   const noLogsAvailable = isOptionalNoLogsResult(result);
-  const timestamps = collectTimestamps(rawText);
+  const timestamps = collectTimestamps(text);
   const stdoutSnippet = boundedLogSnippet(stdout, 4000);
   const stderrSnippet = boundedLogSnippet(stderr, 4000);
   const artifacts = [];

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -73,7 +73,7 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, options
 export function redactLogText(value) {
   return String(value ?? "")
     .replace(
-      /^(\s*(?:authorization|proxy-authorization|x-api-key|api-key|cookie|set-cookie)\s*:\s*).+$/gim,
+      /^((?:.*?)(?:authorization|proxy-authorization|x-api-key|api-key|cookie|set-cookie)\s*:\s*).+$/gim,
       "$1[REDACTED]"
     )
     .replace(

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -13,8 +13,10 @@ const SENSITIVE_VALUE_TO_LINE_END_PATTERN = new RegExp(
   `(["']?\\b${SENSITIVE_LOG_KEY}\\b["']?\\s*[:=]\\s*).*$`,
   "gim"
 );
-const SENSITIVE_CLI_TO_LINE_END_PATTERN =
-  /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+)).*$/gim;
+const SENSITIVE_CLI_TO_LINE_END_PATTERN = new RegExp(
+  `((?:^|\\s)--${SENSITIVE_LOG_KEY}(?:=|\\s+)).*$`,
+  "gim"
+);
 const PEM_PRIVATE_KEY_PATTERN =
   /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?-----END \1-----/g;
 

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -8,21 +8,13 @@ export const LOG_METRICS_SCHEMA = "kova.logMetrics.v1";
 
 const PROVIDER_TIMEOUT_SIGNAL_PATTERN =
   /(?:\bprovider\b|\bmodel\b).*(?:\btimeouts?\b|\btimed out\b)|(?:\btimeouts?\b|\btimed out\b).*(?:\bprovider\b|\bmodel\b)/i;
-const SENSITIVE_LOG_KEY = String.raw`[a-z0-9_-]*(?:api[_-]?key|token|secret|password|cookie|credential|private[_-]?key)[a-z0-9_-]*`;
-const QUOTED_SENSITIVE_VALUE_PATTERN = new RegExp(
-  `(["']?${SENSITIVE_LOG_KEY}["']?\\s*[:=]\\s*)(["'])((?:\\\\.|(?!\\2).)*)\\2`,
-  "gi"
-);
-const UNQUOTED_SENSITIVE_FIELD_PATTERN = new RegExp(
-  `(["']?${SENSITIVE_LOG_KEY}["']?\\s*:\\s*)(?!["']).*$`,
+const SENSITIVE_LOG_KEY = String.raw`[a-z0-9_-]*(?:api[_-]?key|token|secret|password|cookie|credential|private[_-]?key|authorization)[a-z0-9_-]*`;
+const SENSITIVE_VALUE_TO_LINE_END_PATTERN = new RegExp(
+  `(["']?\\b${SENSITIVE_LOG_KEY}\\b["']?\\s*[:=]\\s*).*$`,
   "gim"
 );
-const UNQUOTED_SENSITIVE_ASSIGNMENT_PATTERN = new RegExp(
-  `(\\b${SENSITIVE_LOG_KEY}\\b\\s*=\\s*)(?!["'])\\S+`,
-  "gi"
-);
-const QUOTED_SENSITIVE_CLI_VALUE_PATTERN =
-  /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+))(["'])((?:\\.|(?!\2).)*)\2/gim;
+const SENSITIVE_CLI_TO_LINE_END_PATTERN =
+  /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+)).*$/gim;
 const PEM_PRIVATE_KEY_PATTERN =
   /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?-----END \1-----/g;
 
@@ -91,23 +83,11 @@ export function redactLogText(value) {
   return String(value ?? "")
     .replace(PEM_PRIVATE_KEY_PATTERN, "[REDACTED]")
     .replace(
-      QUOTED_SENSITIVE_VALUE_PATTERN,
-      "$1$2[REDACTED]$2"
-    )
-    .replace(
-      UNQUOTED_SENSITIVE_FIELD_PATTERN,
+      SENSITIVE_VALUE_TO_LINE_END_PATTERN,
       "$1[REDACTED]"
     )
     .replace(
-      UNQUOTED_SENSITIVE_ASSIGNMENT_PATTERN,
-      "$1[REDACTED]"
-    )
-    .replace(
-      QUOTED_SENSITIVE_CLI_VALUE_PATTERN,
-      "$1[REDACTED]"
-    )
-    .replace(
-      /((?:^|\s)--(?:api-key|access-token|auth-token|refresh-token|token|secret|password|cookie)(?:=|\s+))[^\s,"']+/gim,
+      SENSITIVE_CLI_TO_LINE_END_PATTERN,
       "$1[REDACTED]"
     )
     .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi, "$1 [REDACTED]")

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -17,6 +17,14 @@ const SENSITIVE_CLI_TO_LINE_END_PATTERN = new RegExp(
   `((?:^|\\s)--${SENSITIVE_LOG_KEY}(?:=|\\s+)).*$`,
   "gim"
 );
+const SENSITIVE_VALUE_CONTINUATION_PATTERN = new RegExp(
+  `(["']?\\b${SENSITIVE_LOG_KEY}\\b["']?\\s*[:=]\\s*)([|>][-+]?|\\\\)\\s*$`,
+  "i"
+);
+const SENSITIVE_CLI_CONTINUATION_PATTERN = new RegExp(
+  `((?:^|\\s)--${SENSITIVE_LOG_KEY}(?:=|\\s+))([|>][-+]?|\\\\)\\s*$`,
+  "i"
+);
 const PEM_PRIVATE_KEY_PATTERN =
   /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?(?:-----END \1-----|$)/g;
 
@@ -83,7 +91,7 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, options
 }
 
 export function redactLogText(value) {
-  return String(value ?? "")
+  return redactSensitiveContinuations(value)
     .replace(PEM_PRIVATE_KEY_PATTERN, "[REDACTED]")
     .replace(
       SENSITIVE_VALUE_TO_LINE_END_PATTERN,
@@ -98,6 +106,51 @@ export function redactLogText(value) {
       /^((?:.*?)(?:authorization|proxy-authorization|x-api-key|api-key|cookie|set-cookie)\s*:\s*).+$/gim,
       "$1[REDACTED]"
     );
+}
+
+function redactSensitiveContinuations(value) {
+  const lines = String(value ?? "").split(/\r?\n/);
+  let blockIndent = null;
+  let redactNextValue = false;
+
+  for (const [index, line] of lines.entries()) {
+    const indent = line.match(/^[ \t]*/)?.[0].length ?? 0;
+    if (redactNextValue) {
+      if (line.trim() === "") {
+        continue;
+      }
+      redactNextValue = /\\\s*$/.test(line);
+      lines[index] = `${line.slice(0, indent)}[REDACTED]`;
+      continue;
+    }
+    if (blockIndent !== null) {
+      if (line.trim() === "" || indent > blockIndent) {
+        if (line.trim() !== "") {
+          lines[index] = `${line.slice(0, indent)}[REDACTED]`;
+        }
+        continue;
+      }
+      blockIndent = null;
+    }
+
+    const pattern = SENSITIVE_VALUE_CONTINUATION_PATTERN.test(line)
+      ? SENSITIVE_VALUE_CONTINUATION_PATTERN
+      : SENSITIVE_CLI_CONTINUATION_PATTERN.test(line)
+        ? SENSITIVE_CLI_CONTINUATION_PATTERN
+        : null;
+    if (!pattern) {
+      continue;
+    }
+    const marker = line.match(pattern)?.[2];
+    lines[index] = line.replace(pattern, "$1[REDACTED]");
+    if (marker === "\\") {
+      redactNextValue = true;
+    } else {
+      blockIndent = indent;
+    }
+  }
+
+  return lines.join("\n");
 }
 
 export function boundedLogSnippet(value, maxChars) {

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -87,7 +87,11 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, options
 
 export function redactLogText(value) {
   const text = String(value ?? "").replace(PEM_PRIVATE_KEY_PATTERN, "[REDACTED]");
-  return redactSensitiveContinuations(text)
+  return redactSensitiveText(text, { structuredJson: true });
+}
+
+function redactSensitiveText(value, options = {}) {
+  return redactSensitiveContinuations(value, options)
     .replace(URL_USERINFO_PATTERN, "$1[REDACTED]@")
     .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi, "$1 [REDACTED]")
     .replace(
@@ -96,7 +100,7 @@ export function redactLogText(value) {
     );
 }
 
-function redactSensitiveContinuations(value) {
+function redactSensitiveContinuations(value, options = {}) {
   const lines = String(value ?? "").split(/\r?\n/);
   let blockIndent = null;
   let quotedContinuation = null;
@@ -132,10 +136,12 @@ function redactSensitiveContinuations(value) {
       blockIndent = null;
     }
 
-    const structuredLine = redactStructuredJsonLine(line);
-    if (structuredLine !== null) {
-      lines[index] = structuredLine;
-      continue;
+    if (options.structuredJson) {
+      const structuredLine = redactStructuredJsonLine(line);
+      if (structuredLine !== null) {
+        lines[index] = structuredLine;
+        continue;
+      }
     }
 
     const pattern = SENSITIVE_VALUE_LINE_PATTERN.test(line)
@@ -189,6 +195,10 @@ function redactStructuredJsonValue(value) {
       return redacted.value;
     });
     return { value: items, changed };
+  }
+  if (typeof value === "string") {
+    const redacted = redactSensitiveText(value);
+    return { value: redacted, changed: redacted !== value };
   }
   if (!value || typeof value !== "object") {
     return { value, changed: false };

--- a/src/collectors/logs.mjs
+++ b/src/collectors/logs.mjs
@@ -18,7 +18,7 @@ const SENSITIVE_CLI_TO_LINE_END_PATTERN = new RegExp(
   "gim"
 );
 const PEM_PRIVATE_KEY_PATTERN =
-  /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?-----END \1-----/g;
+  /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?(?:-----END \1-----|$)/g;
 
 export async function collectLogMetrics(envName, timeoutMs, artifactDir, options = {}) {
   const result = await runCommand(ocmLogs(envName, { tail: 200 }), {
@@ -26,11 +26,12 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, options
     env: options.commandEnv,
     redactValues: options.redactValues
   });
+  const rawText = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
   const stdout = redactLogText(result.stdout);
   const stderr = redactLogText(result.stderr);
   const text = `${stdout}\n${stderr}`;
   const noLogsAvailable = isOptionalNoLogsResult(result);
-  const timestamps = collectTimestamps(text);
+  const timestamps = collectTimestamps(rawText);
   const stdoutSnippet = boundedLogSnippet(stdout, 4000);
   const stderrSnippet = boundedLogSnippet(stderr, 4000);
   const artifacts = [];
@@ -51,19 +52,19 @@ export async function collectLogMetrics(envName, timeoutMs, artifactDir, options
     firstTimestamp: timestamps.first,
     lastTimestamp: timestamps.last,
     observedWindowMs: timestamps.windowMs,
-    missingDependencyErrors: countPattern(text, /cannot find (module|package)|missing dependenc|missing runtime dep/i),
-    pluginLoadFailures: countPattern(text, /\[plugins\].*failed to load|plugin.*failed to load|\[plugins\].*plugin service failed|plugin service failed/i),
-    runtimeDependencyMentions: countPattern(text, /runtime dep|runtime dependency|runtime-deps/i),
-    metadataScanMentions: countPattern(text, /collectBundledPluginMetadata|bundled plugin metadata|manifest read|readdirSync/i),
-    configNormalizationMentions: countPattern(text, /config normal/i),
-    gatewayRestartMentions: countPattern(text, /gateway.*restart|restart.*gateway|service restart|restarting/i),
-    listeningMentions: countPattern(text, /listening|server started|gateway ready|ready on|websocket/i),
-    providerLoadMentions: countPattern(text, /provider.*load|load.*provider|provider registry|auth provider/i),
-    modelCatalogMentions: countPattern(text, /model catalog|models list|loading models|available models/i),
-    providerTimeoutMentions: countProviderTimeoutMentions(text),
-    eventLoopDelayMentions: countPattern(text, /event loop|event-loop|blocked loop|loop delay/i),
-    v8DiagnosticMentions: countPattern(text, /v8|diagnostic report|heapsnapshot|heap snapshot/i),
-    errorMentions: countPattern(text, /\berror\b|exception|unhandled/i),
+    missingDependencyErrors: countPattern(rawText, /cannot find (module|package)|missing dependenc|missing runtime dep/i),
+    pluginLoadFailures: countPattern(rawText, /\[plugins\].*failed to load|plugin.*failed to load|\[plugins\].*plugin service failed|plugin service failed/i),
+    runtimeDependencyMentions: countPattern(rawText, /runtime dep|runtime dependency|runtime-deps/i),
+    metadataScanMentions: countPattern(rawText, /collectBundledPluginMetadata|bundled plugin metadata|manifest read|readdirSync/i),
+    configNormalizationMentions: countPattern(rawText, /config normal/i),
+    gatewayRestartMentions: countPattern(rawText, /gateway.*restart|restart.*gateway|service restart|restarting/i),
+    listeningMentions: countPattern(rawText, /listening|server started|gateway ready|ready on|websocket/i),
+    providerLoadMentions: countPattern(rawText, /provider.*load|load.*provider|provider registry|auth provider/i),
+    modelCatalogMentions: countPattern(rawText, /model catalog|models list|loading models|available models/i),
+    providerTimeoutMentions: countProviderTimeoutMentions(rawText),
+    eventLoopDelayMentions: countPattern(rawText, /event loop|event-loop|blocked loop|loop delay/i),
+    v8DiagnosticMentions: countPattern(rawText, /v8|diagnostic report|heapsnapshot|heap snapshot/i),
+    errorMentions: countPattern(rawText, /\berror\b|exception|unhandled/i),
     runtimeDeps: summarizeRuntimeDepsLogs(text),
     embeddedRuns: summarizeEmbeddedRunTraces(text),
     livenessWarnings: summarizeLivenessWarnings(text),

--- a/src/collectors/openclaw-state.mjs
+++ b/src/collectors/openclaw-state.mjs
@@ -267,16 +267,16 @@ async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snap
       snapshot.budget.excludedPaths.push(relPath);
       continue;
     }
-    if (seen >= limits.maxPluginDirs) {
-      snapshot.budget.omittedCount += 1;
-      continue;
-    }
-    seen += 1;
     if (candidateStats.isSymbolicLink()) {
       snapshot.budget.excludedPaths.push(relPath);
       snapshot.budget.omittedCount += 1;
       continue;
     }
+    if (seen >= limits.maxPluginDirs) {
+      snapshot.budget.omittedCount += 1;
+      continue;
+    }
+    seen += 1;
 
     const plugin = {
       path: relPath,

--- a/src/collectors/openclaw-state.mjs
+++ b/src/collectors/openclaw-state.mjs
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { access, mkdir, open, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { mkdir, open, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
 
 export const OPENCLAW_STATE_SNAPSHOT_SCHEMA = "kova.openclawStateSnapshot.v1";
 
@@ -85,17 +85,18 @@ export async function captureOpenClawStateSnapshot(options = {}) {
     snapshot.budget.omittedCount += 1;
     return snapshot;
   }
+  const resolvedHome = await realpath(home);
 
   for (const relPath of KNOWN_FILES) {
-    const summary = await summarizeFile(home, relPath, limits, snapshot);
+    const summary = await summarizeFile(home, resolvedHome, relPath, limits, snapshot);
     if (summary) {
       snapshot.files.push(summary);
       applyKnownFileSemantics(snapshot, relPath, summary);
     }
   }
 
-  await summarizePluginRoot(home, "plugins", limits, snapshot);
-  await summarizePluginRoot(home, ".openclaw/plugins", limits, snapshot);
+  await summarizePluginRoot(home, resolvedHome, "plugins", limits, snapshot);
+  await summarizePluginRoot(home, resolvedHome, ".openclaw/plugins", limits, snapshot);
 
   snapshot.files.sort((a, b) => a.path.localeCompare(b.path));
   snapshot.plugins.roots.sort((a, b) => a.path.localeCompare(b.path));
@@ -205,9 +206,13 @@ async function homeSummary(home) {
   }
 }
 
-async function summarizePluginRoot(home, rootRelPath, limits, snapshot) {
+async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snapshot) {
   const rootPath = join(home, rootRelPath);
-  const rootStats = await stat(rootPath).catch(() => null);
+  const resolvedRoot = await resolveContainedPath(resolvedHome, rootPath, rootRelPath, snapshot);
+  if (!resolvedRoot) {
+    return;
+  }
+  const rootStats = await stat(resolvedRoot).catch(() => null);
   if (!rootStats?.isDirectory()) {
     return;
   }
@@ -228,9 +233,14 @@ async function summarizePluginRoot(home, rootRelPath, limits, snapshot) {
     applyPluginInstallIndexSemantics(snapshot, installIndex);
   }
 
-  const entries = await readdir(rootPath, { withFileTypes: true }).catch(() => []);
+  const entries = await readdir(resolvedRoot, { withFileTypes: true }).catch(() => []);
   let seen = 0;
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isSymbolicLink()) {
+      snapshot.budget.excludedPaths.push(`${rootRelPath}/${entry.name}`);
+      snapshot.budget.omittedCount += 1;
+      continue;
+    }
     if (!entry.isDirectory()) {
       continue;
     }
@@ -245,17 +255,26 @@ async function summarizePluginRoot(home, rootRelPath, limits, snapshot) {
     seen += 1;
 
     const relPath = `${rootRelPath}/${entry.name}`;
+    const resolvedPluginRoot = await resolveContainedPath(
+      resolvedHome,
+      join(resolvedRoot, entry.name),
+      relPath,
+      snapshot
+    );
+    if (!resolvedPluginRoot) {
+      continue;
+    }
     const plugin = {
       path: relPath,
       name: entry.name,
-      nodeModulesPresent: await exists(join(home, relPath, "node_modules")),
+      nodeModulesPresent: await existsContained(resolvedHome, join(resolvedPluginRoot, "node_modules")),
       manifests: []
     };
     if (plugin.nodeModulesPresent) {
       snapshot.budget.excludedPaths.push(`${relPath}/node_modules`);
     }
     for (const manifestName of ["plugin.json", "manifest.json", "package.json"]) {
-      const manifest = await summarizeFile(home, `${relPath}/${manifestName}`, limits, snapshot);
+      const manifest = await summarizeFile(home, resolvedHome, `${relPath}/${manifestName}`, limits, snapshot);
       if (manifest) {
         snapshot.files.push(manifest);
         plugin.manifests.push({
@@ -464,9 +483,13 @@ function summaryStringFingerprint(summary) {
   return typeof summary.sha256 === "string" ? summary.sha256.slice(0, 16) : null;
 }
 
-async function summarizeFile(home, relPath, limits, snapshot) {
+async function summarizeFile(home, resolvedHome, relPath, limits, snapshot) {
   const fullPath = join(home, relPath);
-  const stats = await stat(fullPath).catch(() => null);
+  const resolvedPath = await resolveContainedPath(resolvedHome, fullPath, relPath, snapshot);
+  if (!resolvedPath) {
+    return null;
+  }
+  const stats = await stat(resolvedPath).catch(() => null);
   if (!stats) {
     return null;
   }
@@ -475,7 +498,7 @@ async function summarizeFile(home, relPath, limits, snapshot) {
     return null;
   }
 
-  const sample = await readFileSample(fullPath, stats.size, limits.maxFileBytes);
+  const sample = await readFileSample(resolvedPath, stats.size, limits.maxFileBytes);
   const summary = {
     path: relPath,
     name: basename(relPath),
@@ -590,13 +613,28 @@ function typeOf(value) {
   return typeof value;
 }
 
-async function exists(path) {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
+async function existsContained(resolvedHome, path) {
+  const resolvedPath = await realpath(path).catch(() => null);
+  return resolvedPath !== null && isContainedPath(resolvedHome, resolvedPath);
+}
+
+async function resolveContainedPath(resolvedHome, path, displayPath, snapshot) {
+  const resolvedPath = await realpath(path).catch(() => null);
+  if (!resolvedPath) {
+    return null;
   }
+  if (isContainedPath(resolvedHome, resolvedPath)) {
+    return resolvedPath;
+  }
+  snapshot.budget.excludedPaths.push(displayPath);
+  snapshot.budget.omittedCount += 1;
+  return null;
+}
+
+function isContainedPath(root, candidate) {
+  const relPath = relative(root, candidate);
+  return relPath === "" ||
+    (!isAbsolute(relPath) && relPath !== ".." && !relPath.startsWith(`..${sep}`));
 }
 
 function sha256(value) {

--- a/src/collectors/openclaw-state.mjs
+++ b/src/collectors/openclaw-state.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { mkdir, open, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import { mkdir, open, readdir, realpath, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
 
 export const OPENCLAW_STATE_SNAPSHOT_SCHEMA = "kova.openclawStateSnapshot.v1";
@@ -236,16 +236,7 @@ async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snap
   const entries = await readdir(resolvedRoot, { withFileTypes: true }).catch(() => []);
   let seen = 0;
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (entry.isSymbolicLink()) {
-      snapshot.budget.excludedPaths.push(`${rootRelPath}/${entry.name}`);
-      snapshot.budget.omittedCount += 1;
-      continue;
-    }
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    if (EXCLUDED_DIRS.has(entry.name)) {
-      snapshot.budget.excludedPaths.push(`${rootRelPath}/${entry.name}`);
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
       continue;
     }
     if (seen >= limits.maxPluginDirs) {
@@ -253,6 +244,15 @@ async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snap
       continue;
     }
     seen += 1;
+    if (entry.isSymbolicLink()) {
+      snapshot.budget.excludedPaths.push(`${rootRelPath}/${entry.name}`);
+      snapshot.budget.omittedCount += 1;
+      continue;
+    }
+    if (EXCLUDED_DIRS.has(entry.name)) {
+      snapshot.budget.excludedPaths.push(`${rootRelPath}/${entry.name}`);
+      continue;
+    }
 
     const relPath = `${rootRelPath}/${entry.name}`;
     const resolvedPluginRoot = await resolveContainedPath(
@@ -485,73 +485,69 @@ function summaryStringFingerprint(summary) {
 
 async function summarizeFile(home, resolvedHome, relPath, limits, snapshot) {
   const fullPath = join(home, relPath);
-  const resolvedPath = await resolveContainedPath(resolvedHome, fullPath, relPath, snapshot);
-  if (!resolvedPath) {
+  const opened = await openContainedFile(resolvedHome, fullPath, relPath, snapshot);
+  if (!opened) {
     return null;
   }
-  const stats = await stat(resolvedPath).catch(() => null);
-  if (!stats) {
-    return null;
-  }
-  if (!stats.isFile()) {
-    snapshot.budget.omittedCount += 1;
-    return null;
-  }
+  const { handle, stats } = opened;
+  try {
+    if (!stats.isFile()) {
+      snapshot.budget.omittedCount += 1;
+      return null;
+    }
 
-  const sample = await readFileSample(resolvedPath, stats.size, limits.maxFileBytes);
-  const summary = {
-    path: relPath,
-    name: basename(relPath),
-    bytes: stats.size,
-    sampledBytes: sample.bytes.length,
-    truncated: sample.truncated,
-    hashScope: sample.truncated ? "sample" : "full",
-    sha256: sha256(sample.bytes),
-    json: null
-  };
-
-  if (sample.truncated) {
-    summary.truncation = {
-      reason: "file exceeded snapshot maxFileBytes",
-      maxFileBytes: limits.maxFileBytes
+    const sample = await readFileSample(handle, stats.size, limits.maxFileBytes);
+    const summary = {
+      path: relPath,
+      name: basename(relPath),
+      bytes: stats.size,
+      sampledBytes: sample.bytes.length,
+      truncated: sample.truncated,
+      hashScope: sample.truncated ? "sample" : "full",
+      sha256: sha256(sample.bytes),
+      json: null
     };
-  }
 
-  if (relPath.endsWith(".json") && !sample.truncated) {
-    try {
-      const parsed = JSON.parse(sample.bytes.toString("utf8"));
-      const redaction = { secretKeyCount: 0 };
-      summary.json = summarizeJson(parsed, { limits, redaction });
-      snapshot.redaction.secretKeyCount += redaction.secretKeyCount;
-    } catch (error) {
-      summary.json = {
-        parseError: error.message
+    if (sample.truncated) {
+      summary.truncation = {
+        reason: "file exceeded snapshot maxFileBytes",
+        maxFileBytes: limits.maxFileBytes
       };
     }
-  }
 
-  return summary;
+    if (relPath.endsWith(".json") && !sample.truncated) {
+      try {
+        const parsed = JSON.parse(sample.bytes.toString("utf8"));
+        const redaction = { secretKeyCount: 0 };
+        summary.json = summarizeJson(parsed, { limits, redaction });
+        snapshot.redaction.secretKeyCount += redaction.secretKeyCount;
+      } catch (error) {
+        summary.json = {
+          parseError: error.message
+        };
+      }
+    }
+
+    return summary;
+  } finally {
+    await handle.close();
+  }
 }
 
-async function readFileSample(path, size, maxBytes) {
+async function readFileSample(handle, size, maxBytes) {
   if (size <= maxBytes) {
     return {
-      bytes: await readFile(path),
+      bytes: await handle.readFile(),
       truncated: false
     };
   }
 
-  const handle = await open(path, constants.O_RDONLY);
-  try {
-    const bytes = Buffer.alloc(maxBytes);
-    const { bytesRead } = await handle.read(bytes, 0, maxBytes, 0);
-    return {
-      bytes: bytes.subarray(0, bytesRead),
-      truncated: true
-    };
-  } finally {
-    await handle.close();
-  }
+  const bytes = Buffer.alloc(maxBytes);
+  const { bytesRead } = await handle.read(bytes, 0, maxBytes, 0);
+  return {
+    bytes: bytes.subarray(0, bytesRead),
+    truncated: true
+  };
 }
 
 function summarizeJson(value, context, key = null, depth = 0) {
@@ -618,6 +614,43 @@ async function existsContained(resolvedHome, path) {
   return resolvedPath !== null && isContainedPath(resolvedHome, resolvedPath);
 }
 
+async function openContainedFile(resolvedHome, path, displayPath, snapshot) {
+  const initialPath = await resolveContainedPath(resolvedHome, path, displayPath, snapshot);
+  if (!initialPath) {
+    return null;
+  }
+  const handle = await open(
+    initialPath,
+    constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0)
+  ).catch(() => null);
+  if (!handle) {
+    return null;
+  }
+  let transferred = false;
+  try {
+    const handleStats = await handle.stat();
+    const currentPath = await realpath(path).catch(() => null);
+    if (!currentPath || !isContainedPath(resolvedHome, currentPath)) {
+      recordExcludedPath(snapshot, displayPath);
+      return null;
+    }
+    const currentStats = await stat(currentPath).catch(() => null);
+    if (!currentStats || currentStats.dev !== handleStats.dev || currentStats.ino !== handleStats.ino) {
+      recordExcludedPath(snapshot, displayPath);
+      return null;
+    }
+    transferred = true;
+    return {
+      handle,
+      stats: handleStats
+    };
+  } finally {
+    if (!transferred) {
+      await handle.close();
+    }
+  }
+}
+
 async function resolveContainedPath(resolvedHome, path, displayPath, snapshot) {
   const resolvedPath = await realpath(path).catch(() => null);
   if (!resolvedPath) {
@@ -626,9 +659,15 @@ async function resolveContainedPath(resolvedHome, path, displayPath, snapshot) {
   if (isContainedPath(resolvedHome, resolvedPath)) {
     return resolvedPath;
   }
-  snapshot.budget.excludedPaths.push(displayPath);
-  snapshot.budget.omittedCount += 1;
+  recordExcludedPath(snapshot, displayPath);
   return null;
+}
+
+function recordExcludedPath(snapshot, path) {
+  if (!snapshot.budget.excludedPaths.includes(path)) {
+    snapshot.budget.excludedPaths.push(path);
+  }
+  snapshot.budget.omittedCount += 1;
 }
 
 function isContainedPath(root, candidate) {

--- a/src/collectors/openclaw-state.mjs
+++ b/src/collectors/openclaw-state.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { mkdir, open, readdir, realpath, stat, writeFile } from "node:fs/promises";
+import { lstat, mkdir, open, opendir, realpath, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
 
 export const OPENCLAW_STATE_SNAPSHOT_SCHEMA = "kova.openclawStateSnapshot.v1";
@@ -226,7 +226,7 @@ async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snap
     return;
   }
 
-  const entries = await readdir(resolvedRoot, { withFileTypes: true }).catch(() => null);
+  const entries = await readDirectoryEntries(resolvedRoot);
   if (!entries || !await directoryIdentityMatches(resolvedHome, rootPath, rootStats)) {
     recordExcludedPath(snapshot, rootRelPath);
     return;
@@ -250,11 +250,21 @@ async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snap
 
   let seen = 0;
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+    const relPath = `${rootRelPath}/${entry.name}`;
+    const candidatePath = join(rootPath, entry.name);
+    // Root entries are untrusted hints because the pathname can race with enumeration.
+    // Do not retain a name or read through it until its current target is contained.
+    const resolvedPluginRoot = await resolveContainedPathQuiet(resolvedHome, candidatePath);
+    if (!resolvedPluginRoot) {
+      snapshot.budget.omittedCount += 1;
       continue;
     }
-    if (entry.isDirectory() && EXCLUDED_DIRS.has(entry.name)) {
-      snapshot.budget.excludedPaths.push(`${rootRelPath}/${entry.name}`);
+    const candidateStats = await lstat(candidatePath).catch(() => null);
+    if (!candidateStats || (!candidateStats.isDirectory() && !candidateStats.isSymbolicLink())) {
+      continue;
+    }
+    if (candidateStats.isDirectory() && EXCLUDED_DIRS.has(entry.name)) {
+      snapshot.budget.excludedPaths.push(relPath);
       continue;
     }
     if (seen >= limits.maxPluginDirs) {
@@ -262,22 +272,12 @@ async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snap
       continue;
     }
     seen += 1;
-    if (entry.isSymbolicLink()) {
-      snapshot.budget.excludedPaths.push(`${rootRelPath}/${entry.name}`);
+    if (candidateStats.isSymbolicLink()) {
+      snapshot.budget.excludedPaths.push(relPath);
       snapshot.budget.omittedCount += 1;
       continue;
     }
 
-    const relPath = `${rootRelPath}/${entry.name}`;
-    const resolvedPluginRoot = await resolveContainedPath(
-      resolvedHome,
-      join(resolvedRoot, entry.name),
-      relPath,
-      snapshot
-    );
-    if (!resolvedPluginRoot) {
-      continue;
-    }
     const plugin = {
       path: relPath,
       name: entry.name,
@@ -300,6 +300,23 @@ async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snap
       }
     }
     snapshot.plugins.pluginDirs.push(plugin);
+  }
+}
+
+async function readDirectoryEntries(path) {
+  const directory = await opendir(path).catch(() => null);
+  if (!directory) {
+    return null;
+  }
+  const entries = [];
+  try {
+    for await (const entry of directory) {
+      entries.push(entry);
+    }
+    return entries;
+  } catch {
+    await directory.close().catch(() => {});
+    return null;
   }
 }
 
@@ -686,6 +703,11 @@ async function resolveContainedPath(resolvedHome, path, displayPath, snapshot) {
   }
   recordExcludedPath(snapshot, displayPath);
   return null;
+}
+
+async function resolveContainedPathQuiet(resolvedHome, path) {
+  const resolvedPath = await realpath(path).catch(() => null);
+  return resolvedPath && isContainedPath(resolvedHome, resolvedPath) ? resolvedPath : null;
 }
 
 function recordExcludedPath(snapshot, path) {

--- a/src/collectors/openclaw-state.mjs
+++ b/src/collectors/openclaw-state.mjs
@@ -217,6 +217,12 @@ async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snap
     return;
   }
 
+  const entries = await readdir(resolvedRoot, { withFileTypes: true }).catch(() => null);
+  if (!entries || !await directoryIdentityMatches(resolvedHome, rootPath, rootStats)) {
+    recordExcludedPath(snapshot, rootRelPath);
+    return;
+  }
+
   snapshot.plugins.roots.push({
     path: rootRelPath,
     present: true
@@ -233,10 +239,13 @@ async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snap
     applyPluginInstallIndexSemantics(snapshot, installIndex);
   }
 
-  const entries = await readdir(resolvedRoot, { withFileTypes: true }).catch(() => []);
   let seen = 0;
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory() && EXCLUDED_DIRS.has(entry.name)) {
+      snapshot.budget.excludedPaths.push(`${rootRelPath}/${entry.name}`);
       continue;
     }
     if (seen >= limits.maxPluginDirs) {
@@ -247,10 +256,6 @@ async function summarizePluginRoot(home, resolvedHome, rootRelPath, limits, snap
     if (entry.isSymbolicLink()) {
       snapshot.budget.excludedPaths.push(`${rootRelPath}/${entry.name}`);
       snapshot.budget.omittedCount += 1;
-      continue;
-    }
-    if (EXCLUDED_DIRS.has(entry.name)) {
-      snapshot.budget.excludedPaths.push(`${rootRelPath}/${entry.name}`);
       continue;
     }
 
@@ -612,6 +617,17 @@ function typeOf(value) {
 async function existsContained(resolvedHome, path) {
   const resolvedPath = await realpath(path).catch(() => null);
   return resolvedPath !== null && isContainedPath(resolvedHome, resolvedPath);
+}
+
+async function directoryIdentityMatches(resolvedHome, path, expectedStats) {
+  const currentPath = await realpath(path).catch(() => null);
+  if (!currentPath || !isContainedPath(resolvedHome, currentPath)) {
+    return false;
+  }
+  const currentStats = await stat(currentPath).catch(() => null);
+  return currentStats?.isDirectory() === true &&
+    currentStats.dev === expectedStats.dev &&
+    currentStats.ino === expectedStats.ino;
 }
 
 async function openContainedFile(resolvedHome, path, displayPath, snapshot) {

--- a/src/collectors/openclaw-state.mjs
+++ b/src/collectors/openclaw-state.mjs
@@ -85,7 +85,16 @@ export async function captureOpenClawStateSnapshot(options = {}) {
     snapshot.budget.omittedCount += 1;
     return snapshot;
   }
-  const resolvedHome = await realpath(home);
+  const resolvedHome = await realpath(home).catch(() => null);
+  if (!resolvedHome) {
+    snapshot.home = {
+      present: false,
+      pathHash: snapshot.home.pathHash,
+      reason: "home disappeared during capture"
+    };
+    snapshot.budget.omittedCount += 1;
+    return snapshot;
+  }
 
   for (const relPath of KNOWN_FILES) {
     const summary = await summarizeFile(home, resolvedHome, relPath, limits, snapshot);
@@ -637,7 +646,7 @@ async function openContainedFile(resolvedHome, path, displayPath, snapshot) {
   }
   const handle = await open(
     initialPath,
-    constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0)
+    constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0)
   ).catch(() => null);
   if (!handle) {
     return null;

--- a/src/metrics.mjs
+++ b/src/metrics.mjs
@@ -296,7 +296,10 @@ function activeNetworkFrontageProbeEndpoint(allocation) {
 
 async function collectLogAndTimelineMetrics(metrics, collectors, envName, timeoutMs, options, collectionPolicy) {
   if (collectorEnabled(collectionPolicy, "logs")) {
-    metrics.logs = await collectLogMetrics(envName, timeoutMs, options.artifactDir, options.commandEnv);
+    metrics.logs = await collectLogMetrics(envName, timeoutMs, options.artifactDir, {
+      commandEnv: options.commandEnv,
+      redactValues: options.redactValues
+    });
     recordCollector(collectors, "logs", metrics.logs, metrics.logs.artifacts);
   } else {
     recordSkippedCollector(collectors, "logs", collectionPolicy.reason);

--- a/src/run/auth-phase.mjs
+++ b/src/run/auth-phase.mjs
@@ -21,6 +21,7 @@ export async function executeAuthPhase(phase, context, envName, artifactDir, aut
     metrics: await collectEnvMetrics(envName, metricOptions(context, null, plannedPhase, artifactDir, {
       kind: "auth-phase",
       collectionIntent: phase.collectionIntent ?? null,
+      redactValues: authPolicy.redactionValues,
       resultStatus: phaseResultStatus(results)
     }))
   };

--- a/src/run/evidence-snapshots.mjs
+++ b/src/run/evidence-snapshots.mjs
@@ -44,6 +44,7 @@ export async function executeEvidenceSnapshotPhase(context, envName, scenario, a
     metrics: await collectEnvMetrics(envName, metricOptions(context, scenario, { id: afterPhaseId }, artifactDir, {
       kind: "evidence-snapshot",
       measurementPhase: phase,
+      redactValues: authPolicy.redactionValues,
       resultStatus: phaseResultStatus(results)
     }))
   };

--- a/src/run/finalize-record.mjs
+++ b/src/run/finalize-record.mjs
@@ -13,7 +13,8 @@ import { metricOptions } from "./metric-options.mjs";
 export async function collectPreCleanupEvidence(record, scenario, context, envName, artifactDir, authPolicy) {
   record.finishedAt = new Date().toISOString();
   record.finalMetrics = await collectEnvMetrics(envName, metricOptions(context, scenario, null, artifactDir, {
-    kind: "final"
+    kind: "final",
+    redactValues: authPolicy.redactionValues
   }));
   record.stateFixtureAccounting = await collectStateFixtureAccounting(context.state, envName, artifactDir);
   record.providerEvidence = await collectProviderEvidence(artifactDir, { authPolicy });
@@ -22,7 +23,8 @@ export async function collectPreCleanupEvidence(record, scenario, context, envNa
   if (shouldCaptureFailureDiagnostics(record, context)) {
     record.failureDiagnostics = await collectEnvMetrics(envName, {
       ...metricOptions(context, scenario, null, artifactDir, {
-        kind: "failure-diagnostics"
+        kind: "failure-diagnostics",
+        redactValues: authPolicy.redactionValues
       }),
       readinessTimeoutMs: 0,
       heapSnapshot: true,

--- a/src/run/metric-options.mjs
+++ b/src/run/metric-options.mjs
@@ -21,6 +21,7 @@ export function metricOptions(context, scenario, phase, artifactDir, policyConte
     artifactDir,
     collectorArtifactDirs: collectorArtifactDirs(artifactDir),
     networkFrontageAllocation: context.networkFrontageAllocation ?? null,
+    redactValues: policyContext.redactValues ?? [],
     collectionPolicy: resolveCollectionPolicy({
       kind: policyContext.kind,
       scenario: scenario?.id ?? null,

--- a/src/run/state-lifecycle.mjs
+++ b/src/run/state-lifecycle.mjs
@@ -40,6 +40,7 @@ export async function executeStateLifecycleSteps(context, envName, scenario, kin
       lifecycleKind: kind,
       lifecycleCommandScope: stateLifecycleCommandScope(commands),
       collectionIntent: stateLifecycleCollectionIntent(steps),
+      redactValues: authPolicy?.redactionValues ?? [],
       resultStatus: phaseResultStatus(results)
     }))
   };

--- a/src/runner.mjs
+++ b/src/runner.mjs
@@ -152,6 +152,7 @@ export async function executeScenario(scenario, context) {
           results,
           metrics: await collectEnvMetrics(envName, metricOptions(context, scenario, plannedPhase, artifactDir, {
             kind: "scenario-phase",
+            redactValues: authPolicy.redactionValues,
             resultStatus: phaseResultStatus(results)
           }))
         });

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3380,8 +3380,17 @@ async function openClawStateSymlinkContainmentCheck(tmp) {
       join(outside, "plugins", "escaped-plugin"),
       join(home, "plugins", "escaped-plugin")
     );
+    for (let index = 0; index < 4; index += 1) {
+      await symlink(
+        join(outside, "plugins", "escaped-plugin"),
+        join(home, "plugins", `escaped-plugin-${index}`)
+      );
+    }
 
-    const snapshot = await captureOpenClawStateSnapshot({ home });
+    const snapshot = await captureOpenClawStateSnapshot({
+      home,
+      limits: { maxPluginDirs: 2 }
+    });
     const serialized = JSON.stringify(snapshot);
     assertEqual(serialized.includes("KOVA_KNOWN_FILE_ESCAPE_CANARY"), false, "known-file symlink escape is not read");
     assertEqual(serialized.includes("KOVA_PLUGIN_ESCAPE_CANARY"), false, "plugin symlink escape is not read");
@@ -3391,6 +3400,11 @@ async function openClawStateSymlinkContainmentCheck(tmp) {
     assertEqual(snapshot.budget.excludedPaths.includes("settings.json"), true, "escaped known file is recorded");
     assertEqual(snapshot.budget.excludedPaths.includes(".openclaw/plugins"), true, "escaped plugin root is recorded");
     assertEqual(snapshot.budget.excludedPaths.includes("plugins/escaped-plugin"), true, "escaped plugin directory is recorded");
+    assertEqual(
+      snapshot.budget.excludedPaths.filter((path) => path.startsWith("plugins/escaped-plugin")).length,
+      2,
+      "escaped plugin exclusions respect the plugin directory budget"
+    );
 
     return {
       id: "openclaw-state-symlink-containment",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17908,6 +17908,7 @@ async function logArtifactRedactionCheck(tmp) {
   const encodedUrlPasswordCanary = encodeURIComponent(urlPasswordCanary);
   const dotenvMultilineCanary = ["dotenv", "multiline", "canary"].join("-");
   const structuredJsonCanary = ["structured", "json", "canary"].join("-");
+  const timestampCredentialCanary = ["2026-07-11", "T12:34:56Z"].join("");
   const clientSecretFlag = ["--client", "secret"].join("-");
   const canaries = [
     headerCanary,
@@ -17932,7 +17933,8 @@ async function logArtifactRedactionCheck(tmp) {
     cliContinuationCanary,
     encodedUrlPasswordCanary,
     dotenvMultilineCanary,
-    structuredJsonCanary
+    structuredJsonCanary,
+    timestampCredentialCanary
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
@@ -17959,6 +17961,7 @@ async function logArtifactRedactionCheck(tmp) {
     `command --token ${"\\"}\n  ${cliContinuationCanary}`,
     `postgresql://alice:${encodedUrlPasswordCanary}@db.example/kova`,
     `${databasePasswordKey}="first line\n${dotenvMultilineCanary}"`,
+    `${databasePasswordKey}=${timestampCredentialCanary}`,
     JSON.stringify({
       [genericTokenKey]: structuredJsonCanary,
       openclawDiagnostic: true,

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17875,12 +17875,14 @@ async function logArtifactRedactionCheck(tmp) {
   const fakeBin = join(tmp, "log-redaction-bin");
   const artifactDir = join(tmp, "log-redaction-artifacts");
   const headerCanary = ["kova", "header", "canary"].join("-");
+  const prefixedHeaderCanary = ["kova", "prefixed", "header", "canary"].join("-");
   const jsonCanary = ["kova", "json", "canary"].join("-");
   const envCanary = ["kova", "env", "canary"].join("-");
   const cliCanary = ["kova", "cli", "canary"].join("-");
   const exactRedactionValue = ["kova", "exact", "canary"].join("-");
   const canaries = [
     headerCanary,
+    prefixedHeaderCanary,
     jsonCanary,
     envCanary,
     cliCanary,
@@ -17888,6 +17890,7 @@ async function logArtifactRedactionCheck(tmp) {
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
+    `INFO request x-api-key${": "}${prefixedHeaderCanary}`,
     JSON.stringify({ access_token: jsonCanary, message: "safe" }),
     `OPENAI_API_KEY${"="}${envCanary}`,
     `command --token ${cliCanary}`,

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17906,6 +17906,8 @@ async function logArtifactRedactionCheck(tmp) {
   const cliContinuationCanary = ["cli", "continuation", "canary"].join("-");
   const urlPasswordCanary = ["url", "password", "canary@"].join("-");
   const encodedUrlPasswordCanary = encodeURIComponent(urlPasswordCanary);
+  const dotenvMultilineCanary = ["dotenv", "multiline", "canary"].join("-");
+  const structuredJsonCanary = ["structured", "json", "canary"].join("-");
   const clientSecretFlag = ["--client", "secret"].join("-");
   const canaries = [
     headerCanary,
@@ -17928,7 +17930,9 @@ async function logArtifactRedactionCheck(tmp) {
     plainContinuationHeadCanary,
     plainContinuationTailCanary,
     cliContinuationCanary,
-    encodedUrlPasswordCanary
+    encodedUrlPasswordCanary,
+    dotenvMultilineCanary,
+    structuredJsonCanary
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
@@ -17957,7 +17961,13 @@ async function logArtifactRedactionCheck(tmp) {
     `${sessionTokenKey}: |2-\n  ${yamlContinuationCanary}`,
     `${sessionTokenKey}: ${plainContinuationHeadCanary}\n  ${plainContinuationTailCanary}`,
     `command --token ${"\\"}\n  ${cliContinuationCanary}`,
-    `postgresql://alice:${encodedUrlPasswordCanary}@db.example/kova`
+    `postgresql://alice:${encodedUrlPasswordCanary}@db.example/kova`,
+    `${databasePasswordKey}="first line\n${dotenvMultilineCanary}"`,
+    JSON.stringify({
+      [genericTokenKey]: structuredJsonCanary,
+      openclawDiagnostic: true,
+      category: "redaction-self-check"
+    })
   ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });
@@ -17981,6 +17991,11 @@ printf '%s\n' "$KOVA_FAKE_LOGS"
     }
     assertEqual(artifact.includes("[REDACTED]"), true, "log artifact contains redaction markers");
     assertEqual(metrics.providerTimeoutMentions, 1, "log metrics preserve signals after sensitive fields");
+    assertEqual(
+      metrics.structuredEvents.some((event) => event.category === "redaction-self-check"),
+      true,
+      "log metrics preserve structured fields beside secrets"
+    );
 
     return {
       id: "log-artifact-redaction",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17904,6 +17904,8 @@ async function logArtifactRedactionCheck(tmp) {
   const plainContinuationHeadCanary = ["plain", "continuation", "head", "canary"].join("-");
   const plainContinuationTailCanary = ["plain", "continuation", "tail", "canary"].join("-");
   const cliContinuationCanary = ["cli", "continuation", "canary"].join("-");
+  const urlPasswordCanary = ["url", "password", "canary@"].join("-");
+  const encodedUrlPasswordCanary = encodeURIComponent(urlPasswordCanary);
   const clientSecretFlag = ["--client", "secret"].join("-");
   const canaries = [
     headerCanary,
@@ -17925,7 +17927,8 @@ async function logArtifactRedactionCheck(tmp) {
     yamlContinuationCanary,
     plainContinuationHeadCanary,
     plainContinuationTailCanary,
-    cliContinuationCanary
+    cliContinuationCanary,
+    encodedUrlPasswordCanary
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
@@ -17953,7 +17956,8 @@ async function logArtifactRedactionCheck(tmp) {
     ].join("\n"),
     `${sessionTokenKey}: |2-\n  ${yamlContinuationCanary}`,
     `${sessionTokenKey}: ${plainContinuationHeadCanary}\n  ${plainContinuationTailCanary}`,
-    `command --token ${"\\"}\n  ${cliContinuationCanary}`
+    `command --token ${"\\"}\n  ${cliContinuationCanary}`,
+    `postgresql://alice:${encodedUrlPasswordCanary}@db.example/kova`
   ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });
@@ -17967,7 +17971,7 @@ printf '%s\n' "$KOVA_FAKE_LOGS"
         PATH: `${fakeBin}:${process.env.PATH}`,
         KOVA_FAKE_LOGS: fakeLogs
       },
-      redactValues: [exactRedactionValue]
+      redactValues: [exactRedactionValue, urlPasswordCanary]
     });
     const artifact = await readFile(join(artifactDir, "collectors", "gateway-tail.log"), "utf8");
     const serialized = JSON.stringify(metrics);

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17880,13 +17880,19 @@ async function logArtifactRedactionCheck(tmp) {
   const envCanary = ["kova", "env", "canary"].join("-");
   const cliCanary = ["kova", "cli", "canary"].join("-");
   const exactRedactionValue = ["kova", "exact", "canary"].join("-");
+  const genericJsonCanary = ["kova", "generic", "json", "canary"].join("-");
+  const quotedAssignmentTail = ["quoted", "tail", "canary"].join("-");
+  const punctuatedAssignmentTail = ["punctuated", "tail", "canary"].join("-");
   const canaries = [
     headerCanary,
     prefixedHeaderCanary,
     jsonCanary,
     envCanary,
     cliCanary,
-    exactRedactionValue
+    exactRedactionValue,
+    genericJsonCanary,
+    quotedAssignmentTail,
+    punctuatedAssignmentTail
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
@@ -17894,7 +17900,10 @@ async function logArtifactRedactionCheck(tmp) {
     JSON.stringify({ access_token: jsonCanary, message: "safe" }),
     `OPENAI_API_KEY${"="}${envCanary}`,
     `command --token ${cliCanary}`,
-    `exact=${exactRedactionValue}`
+    `exact=${exactRedactionValue}`,
+    JSON.stringify({ token: genericJsonCanary }),
+    `SESSION_TOKEN="kova ${quotedAssignmentTail}"`,
+    `DB_PASSWORD=kova,${punctuatedAssignmentTail};done`
   ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17888,6 +17888,8 @@ async function logArtifactRedactionCheck(tmp) {
   const databasePasswordKey = ["DB", "PASSWORD"].join("_");
   const escapedJsonTail = ["escaped", "json", "tail", "canary"].join("-");
   const escapedCliTail = ["escaped", "cli", "tail", "canary"].join("-");
+  const unquotedFieldTail = ["unquoted", "field", "tail", "canary"].join("-");
+  const pemBodyCanary = ["pem", "body", "canary"].join("-");
   const canaries = [
     headerCanary,
     prefixedHeaderCanary,
@@ -17899,7 +17901,9 @@ async function logArtifactRedactionCheck(tmp) {
     quotedAssignmentTail,
     punctuatedAssignmentTail,
     escapedJsonTail,
-    escapedCliTail
+    escapedCliTail,
+    unquotedFieldTail,
+    pemBodyCanary
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
@@ -17912,7 +17916,13 @@ async function logArtifactRedactionCheck(tmp) {
     `${sessionTokenKey}="kova ${quotedAssignmentTail}"`,
     `${databasePasswordKey}=kova,${punctuatedAssignmentTail};done`,
     JSON.stringify({ [genericTokenKey]: `prefix"${escapedJsonTail}` }),
-    `command --token ${JSON.stringify(`prefix"${escapedCliTail}`)}`
+    `command --token ${JSON.stringify(`prefix"${escapedCliTail}`)}`,
+    `${databasePasswordKey.toLowerCase()}: kova ${unquotedFieldTail}`,
+    [
+      `private_${["key"].join("")}: -----BEGIN PRIVATE KEY-----`,
+      pemBodyCanary,
+      "-----END PRIVATE KEY-----"
+    ].join("\n")
   ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17954,10 +17954,6 @@ async function logArtifactRedactionCheck(tmp) {
     ].join("\n"),
     `command ${clientSecretFlag} ${compoundCliCanary}`,
     JSON.stringify({ [genericTokenKey]: timeoutTokenCanary, message: "provider timed out" }),
-    [
-      `-----BEGIN ${privateKeyLabel}-----`,
-      truncatedPemBodyCanary
-    ].join("\n"),
     `${sessionTokenKey}: |2-\n  ${yamlContinuationCanary}`,
     `${sessionTokenKey}: ${plainContinuationHeadCanary}\n  ${plainContinuationTailCanary}`,
     `command --token ${"\\"}\n  ${cliContinuationCanary}`,
@@ -17967,7 +17963,11 @@ async function logArtifactRedactionCheck(tmp) {
       [genericTokenKey]: structuredJsonCanary,
       openclawDiagnostic: true,
       category: "redaction-self-check"
-    })
+    }),
+    [
+      `-----BEGIN ${privateKeyLabel}-----`,
+      truncatedPemBodyCanary
+    ].join("\n")
   ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3363,7 +3363,11 @@ async function openClawStateSymlinkContainmentCheck(tmp) {
     await mkdir(join(home, "config"), { recursive: true });
     await mkdir(join(home, ".openclaw"), { recursive: true });
     await mkdir(join(home, "plugins"), { recursive: true });
+    await mkdir(join(home, "plugins", "z-plugin"), { recursive: true });
+    await mkdir(join(home, "plugins", "zz-plugin"), { recursive: true });
     await mkdir(join(outside, "plugins", "escaped-plugin"), { recursive: true });
+    await symlink("z-plugin", join(home, "plugins", "a-contained-alias"));
+    await symlink("zz-plugin", join(home, "plugins", "b-contained-alias"));
     await writeFile(
       join(outside, "settings.json"),
       JSON.stringify({ schemaVersion: "KOVA_KNOWN_FILE_ESCAPE_CANARY" }),
@@ -3397,6 +3401,8 @@ async function openClawStateSymlinkContainmentCheck(tmp) {
     assertEqual(snapshot.files.some((file) => file.path === "settings.json"), false, "escaped known file is omitted");
     assertEqual(snapshot.plugins.roots.some((root) => root.path === ".openclaw/plugins"), false, "escaped plugin root is omitted");
     assertEqual(snapshot.plugins.pluginDirs.some((plugin) => plugin.path === "plugins/escaped-plugin"), false, "escaped plugin directory is omitted");
+    assertEqual(snapshot.plugins.pluginDirs.some((plugin) => plugin.path === "plugins/z-plugin"), true, "contained symlinks do not consume the plugin budget");
+    assertEqual(snapshot.plugins.pluginDirs.some((plugin) => plugin.path === "plugins/zz-plugin"), true, "the plugin budget counts real directories");
     assertEqual(snapshot.budget.excludedPaths.includes("settings.json"), true, "escaped known file is recorded");
     assertEqual(snapshot.budget.excludedPaths.includes(".openclaw/plugins"), true, "escaped plugin root is recorded");
     assertEqual(snapshot.budget.excludedPaths.includes("plugins/escaped-plugin"), false, "escaped plugin directory name is not retained");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17908,6 +17908,7 @@ async function logArtifactRedactionCheck(tmp) {
   const encodedUrlPasswordCanary = encodeURIComponent(urlPasswordCanary);
   const dotenvMultilineCanary = ["dotenv", "multiline", "canary"].join("-");
   const structuredJsonCanary = ["structured", "json", "canary"].join("-");
+  const structuredEmbeddedCanary = ["structured", "embedded", "canary"].join("-");
   const timestampCredentialCanary = ["2026-07-11", "T12:34:56Z"].join("");
   const multilineSuffixCanary = ["multiline", "suffix", "canary"].join("-");
   const clientSecretFlag = ["--client", "secret"].join("-");
@@ -17935,6 +17936,7 @@ async function logArtifactRedactionCheck(tmp) {
     encodedUrlPasswordCanary,
     dotenvMultilineCanary,
     structuredJsonCanary,
+    structuredEmbeddedCanary,
     timestampCredentialCanary,
     multilineSuffixCanary
   ];
@@ -17966,6 +17968,7 @@ async function logArtifactRedactionCheck(tmp) {
     `${databasePasswordKey}=${timestampCredentialCanary}`,
     JSON.stringify({
       [genericTokenKey]: structuredJsonCanary,
+      command: `tool --${databasePasswordKey.toLowerCase()} ${structuredEmbeddedCanary}`,
       openclawDiagnostic: true,
       category: "redaction-self-check"
     }),

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17890,8 +17890,10 @@ async function logArtifactRedactionCheck(tmp) {
   const escapedCliTail = ["escaped", "cli", "tail", "canary"].join("-");
   const unquotedFieldTail = ["unquoted", "field", "tail", "canary"].join("-");
   const pemBodyCanary = ["pem", "body", "canary"].join("-");
+  const truncatedPemBodyCanary = ["truncated", "pem", "body", "canary"].join("-");
   const privateKeyLabel = ["PRIVATE", "KEY"].join(" ");
   const compoundCliCanary = ["compound", "cli", "canary"].join("-");
+  const timeoutTokenCanary = ["timeout", "token", "canary"].join("-");
   const clientSecretFlag = ["--client", "secret"].join("-");
   const canaries = [
     headerCanary,
@@ -17907,7 +17909,9 @@ async function logArtifactRedactionCheck(tmp) {
     escapedCliTail,
     unquotedFieldTail,
     pemBodyCanary,
-    compoundCliCanary
+    truncatedPemBodyCanary,
+    compoundCliCanary,
+    timeoutTokenCanary
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
@@ -17927,7 +17931,12 @@ async function logArtifactRedactionCheck(tmp) {
       pemBodyCanary,
       `-----END ${privateKeyLabel}-----`
     ].join("\n"),
-    `command ${clientSecretFlag} ${compoundCliCanary}`
+    `command ${clientSecretFlag} ${compoundCliCanary}`,
+    JSON.stringify({ [genericTokenKey]: timeoutTokenCanary, message: "provider timed out" }),
+    [
+      `-----BEGIN ${privateKeyLabel}-----`,
+      truncatedPemBodyCanary
+    ].join("\n")
   ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });
@@ -17950,6 +17959,7 @@ printf '%s\n' "$KOVA_FAKE_LOGS"
       assertEqual(serialized.includes(canary), false, `log metrics redact ${canary}`);
     }
     assertEqual(artifact.includes("[REDACTED]"), true, "log artifact contains redaction markers");
+    assertEqual(metrics.providerTimeoutMentions, 1, "log metrics preserve signals after sensitive fields");
 
     return {
       id: "log-artifact-redaction",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -77,6 +77,7 @@ import { assertNetworkFrontageCommandSafe, networkFrontageCommandEnv, stopNetwor
 import { resolveGatewayEndpoint } from "../support/gateway-endpoint.mjs";
 import {
   boundedLogSnippet,
+  collectLogMetrics,
   countProviderTimeoutMentions,
   isExpectedKovaMockProviderFailureLine,
   summarizeEmbeddedRunTraces,
@@ -386,6 +387,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(await commandTimeoutContractCheck(tmp));
     checks.push(await commandOutputBudgetCheck());
     checks.push(logSnippetBudgetCheck());
+    checks.push(await logArtifactRedactionCheck(tmp));
     checks.push(expectedMockProviderFailureTimeoutLogCheck());
     checks.push(optionalNoLogsCommandCheck());
     checks.push(commandResultInterpretationCheck());
@@ -409,6 +411,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(provisioningBlockedStatusCheck());
     checks.push(cleanupProofRequiredCheck());
     checks.push(await openClawStateSnapshotCheck(tmp));
+    checks.push(await openClawStateSymlinkContainmentCheck(tmp));
     checks.push(await doctorUpgradeSnapshotEvidenceCheck(tmp));
     checks.push(upgradeStateSnapshotInvariantsCheck());
     checks.push(upgradeLogDerivedInvariantsCheck());
@@ -3347,6 +3350,59 @@ async function openClawStateSnapshotCheck(tmp) {
       id: "openclaw-state-snapshot",
       status: "FAIL",
       command: "capture bounded redacted OpenClaw state snapshot",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function openClawStateSymlinkContainmentCheck(tmp) {
+  const home = join(tmp, "snapshot-containment-home");
+  const outside = join(tmp, "snapshot-containment-outside");
+  try {
+    await mkdir(join(home, "config"), { recursive: true });
+    await mkdir(join(home, ".openclaw"), { recursive: true });
+    await mkdir(join(home, "plugins"), { recursive: true });
+    await mkdir(join(outside, "plugins", "escaped-plugin"), { recursive: true });
+    await writeFile(
+      join(outside, "settings.json"),
+      JSON.stringify({ schemaVersion: "KOVA_KNOWN_FILE_ESCAPE_CANARY" }),
+      "utf8"
+    );
+    await writeFile(
+      join(outside, "plugins", "escaped-plugin", "package.json"),
+      JSON.stringify({ name: "KOVA_PLUGIN_ESCAPE_CANARY" }),
+      "utf8"
+    );
+    await symlink(join(outside, "settings.json"), join(home, "settings.json"));
+    await symlink(join(outside, "plugins"), join(home, ".openclaw", "plugins"));
+    await symlink(
+      join(outside, "plugins", "escaped-plugin"),
+      join(home, "plugins", "escaped-plugin")
+    );
+
+    const snapshot = await captureOpenClawStateSnapshot({ home });
+    const serialized = JSON.stringify(snapshot);
+    assertEqual(serialized.includes("KOVA_KNOWN_FILE_ESCAPE_CANARY"), false, "known-file symlink escape is not read");
+    assertEqual(serialized.includes("KOVA_PLUGIN_ESCAPE_CANARY"), false, "plugin symlink escape is not read");
+    assertEqual(snapshot.files.some((file) => file.path === "settings.json"), false, "escaped known file is omitted");
+    assertEqual(snapshot.plugins.roots.some((root) => root.path === ".openclaw/plugins"), false, "escaped plugin root is omitted");
+    assertEqual(snapshot.plugins.pluginDirs.some((plugin) => plugin.path === "plugins/escaped-plugin"), false, "escaped plugin directory is omitted");
+    assertEqual(snapshot.budget.excludedPaths.includes("settings.json"), true, "escaped known file is recorded");
+    assertEqual(snapshot.budget.excludedPaths.includes(".openclaw/plugins"), true, "escaped plugin root is recorded");
+    assertEqual(snapshot.budget.excludedPaths.includes("plugins/escaped-plugin"), true, "escaped plugin directory is recorded");
+
+    return {
+      id: "openclaw-state-symlink-containment",
+      status: "PASS",
+      command: "reject OpenClaw state symlink escapes",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "openclaw-state-symlink-containment",
+      status: "FAIL",
+      command: "reject OpenClaw state symlink escapes",
       durationMs: 0,
       message: error.message
     };
@@ -17795,6 +17851,59 @@ function logSnippetBudgetCheck() {
       id: "log-snippet-budget",
       status: "FAIL",
       command: "evaluate log snippet truncation metadata",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function logArtifactRedactionCheck(tmp) {
+  const fakeBin = join(tmp, "log-redaction-bin");
+  const artifactDir = join(tmp, "log-redaction-artifacts");
+  const exactSecret = "kova-exact-secret-canary";
+  const canaries = [
+    "header-secret-canary",
+    "json-secret-canary",
+    "env-secret-canary",
+    "cli-secret-canary",
+    exactSecret
+  ];
+  try {
+    await mkdir(fakeBin, { recursive: true });
+    await writeFile(join(fakeBin, "ocm"), `#!/bin/sh
+cat <<'EOF'
+Authorization: Bearer header-secret-canary
+{"access_token":"json-secret-canary","message":"safe"}
+OPENAI_API_KEY=env-secret-canary
+command --token cli-secret-canary
+exact=${exactSecret}
+EOF
+`, "utf8");
+    await chmod(join(fakeBin, "ocm"), 0o755);
+
+    const metrics = await collectLogMetrics("kova-self-check", 5000, artifactDir, {
+      commandEnv: { PATH: `${fakeBin}:${process.env.PATH}` },
+      redactValues: [exactSecret]
+    });
+    const artifact = await readFile(join(artifactDir, "collectors", "gateway-tail.log"), "utf8");
+    const serialized = JSON.stringify(metrics);
+    for (const canary of canaries) {
+      assertEqual(artifact.includes(canary), false, `log artifact redacts ${canary}`);
+      assertEqual(serialized.includes(canary), false, `log metrics redact ${canary}`);
+    }
+    assertEqual(artifact.includes("[REDACTED]"), true, "log artifact contains redaction markers");
+
+    return {
+      id: "log-artifact-redaction",
+      status: "PASS",
+      command: "redact auth canaries before log artifact writes",
+      durationMs: metrics.durationMs
+    };
+  } catch (error) {
+    return {
+      id: "log-artifact-redaction",
+      status: "FAIL",
+      command: "redact auth canaries before log artifact writes",
       durationMs: 0,
       message: error.message
     };

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17891,6 +17891,8 @@ async function logArtifactRedactionCheck(tmp) {
   const unquotedFieldTail = ["unquoted", "field", "tail", "canary"].join("-");
   const pemBodyCanary = ["pem", "body", "canary"].join("-");
   const privateKeyLabel = ["PRIVATE", "KEY"].join(" ");
+  const compoundCliCanary = ["compound", "cli", "canary"].join("-");
+  const clientSecretFlag = ["--client", "secret"].join("-");
   const canaries = [
     headerCanary,
     prefixedHeaderCanary,
@@ -17904,7 +17906,8 @@ async function logArtifactRedactionCheck(tmp) {
     escapedJsonTail,
     escapedCliTail,
     unquotedFieldTail,
-    pemBodyCanary
+    pemBodyCanary,
+    compoundCliCanary
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
@@ -17923,7 +17926,8 @@ async function logArtifactRedactionCheck(tmp) {
       `private_${["key"].join("")}: -----BEGIN ${privateKeyLabel}-----`,
       pemBodyCanary,
       `-----END ${privateKeyLabel}-----`
-    ].join("\n")
+    ].join("\n"),
+    `command ${clientSecretFlag} ${compoundCliCanary}`
   ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17890,6 +17890,7 @@ async function logArtifactRedactionCheck(tmp) {
   const escapedCliTail = ["escaped", "cli", "tail", "canary"].join("-");
   const unquotedFieldTail = ["unquoted", "field", "tail", "canary"].join("-");
   const pemBodyCanary = ["pem", "body", "canary"].join("-");
+  const privateKeyLabel = ["PRIVATE", "KEY"].join(" ");
   const canaries = [
     headerCanary,
     prefixedHeaderCanary,
@@ -17919,9 +17920,9 @@ async function logArtifactRedactionCheck(tmp) {
     `command --token ${JSON.stringify(`prefix"${escapedCliTail}`)}`,
     `${databasePasswordKey.toLowerCase()}: kova ${unquotedFieldTail}`,
     [
-      `private_${["key"].join("")}: -----BEGIN PRIVATE KEY-----`,
+      `private_${["key"].join("")}: -----BEGIN ${privateKeyLabel}-----`,
       pemBodyCanary,
-      "-----END PRIVATE KEY-----"
+      `-----END ${privateKeyLabel}-----`
     ].join("\n")
   ].join("\n");
   try {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17886,6 +17886,8 @@ async function logArtifactRedactionCheck(tmp) {
   const genericTokenKey = ["to", "ken"].join("");
   const sessionTokenKey = ["SESSION", "TOKEN"].join("_");
   const databasePasswordKey = ["DB", "PASSWORD"].join("_");
+  const escapedJsonTail = ["escaped", "json", "tail", "canary"].join("-");
+  const escapedCliTail = ["escaped", "cli", "tail", "canary"].join("-");
   const canaries = [
     headerCanary,
     prefixedHeaderCanary,
@@ -17895,7 +17897,9 @@ async function logArtifactRedactionCheck(tmp) {
     exactRedactionValue,
     genericJsonCanary,
     quotedAssignmentTail,
-    punctuatedAssignmentTail
+    punctuatedAssignmentTail,
+    escapedJsonTail,
+    escapedCliTail
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
@@ -17906,7 +17910,9 @@ async function logArtifactRedactionCheck(tmp) {
     `exact=${exactRedactionValue}`,
     JSON.stringify({ [genericTokenKey]: genericJsonCanary }),
     `${sessionTokenKey}="kova ${quotedAssignmentTail}"`,
-    `${databasePasswordKey}=kova,${punctuatedAssignmentTail};done`
+    `${databasePasswordKey}=kova,${punctuatedAssignmentTail};done`,
+    JSON.stringify({ [genericTokenKey]: `prefix"${escapedJsonTail}` }),
+    `command --token ${JSON.stringify(`prefix"${escapedCliTail}`)}`
   ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17909,6 +17909,7 @@ async function logArtifactRedactionCheck(tmp) {
   const dotenvMultilineCanary = ["dotenv", "multiline", "canary"].join("-");
   const structuredJsonCanary = ["structured", "json", "canary"].join("-");
   const timestampCredentialCanary = ["2026-07-11", "T12:34:56Z"].join("");
+  const multilineSuffixCanary = ["multiline", "suffix", "canary"].join("-");
   const clientSecretFlag = ["--client", "secret"].join("-");
   const canaries = [
     headerCanary,
@@ -17934,7 +17935,8 @@ async function logArtifactRedactionCheck(tmp) {
     encodedUrlPasswordCanary,
     dotenvMultilineCanary,
     structuredJsonCanary,
-    timestampCredentialCanary
+    timestampCredentialCanary,
+    multilineSuffixCanary
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
@@ -17960,7 +17962,7 @@ async function logArtifactRedactionCheck(tmp) {
     `${sessionTokenKey}: ${plainContinuationHeadCanary}\n  ${plainContinuationTailCanary}`,
     `command --token ${"\\"}\n  ${cliContinuationCanary}`,
     `postgresql://alice:${encodedUrlPasswordCanary}@db.example/kova`,
-    `${databasePasswordKey}="first line\n${dotenvMultilineCanary}"`,
+    `${databasePasswordKey}="first line\n${dotenvMultilineCanary}" ${sessionTokenKey}=${multilineSuffixCanary}`,
     `${databasePasswordKey}=${timestampCredentialCanary}`,
     JSON.stringify({
       [genericTokenKey]: structuredJsonCanary,

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17860,30 +17860,38 @@ function logSnippetBudgetCheck() {
 async function logArtifactRedactionCheck(tmp) {
   const fakeBin = join(tmp, "log-redaction-bin");
   const artifactDir = join(tmp, "log-redaction-artifacts");
-  const exactSecret = "kova-exact-secret-canary";
+  const headerCanary = ["kova", "header", "canary"].join("-");
+  const jsonCanary = ["kova", "json", "canary"].join("-");
+  const envCanary = ["kova", "env", "canary"].join("-");
+  const cliCanary = ["kova", "cli", "canary"].join("-");
+  const exactRedactionValue = ["kova", "exact", "canary"].join("-");
   const canaries = [
-    "header-secret-canary",
-    "json-secret-canary",
-    "env-secret-canary",
-    "cli-secret-canary",
-    exactSecret
+    headerCanary,
+    jsonCanary,
+    envCanary,
+    cliCanary,
+    exactRedactionValue
   ];
+  const fakeLogs = [
+    `Authorization${": "}Bearer ${headerCanary}`,
+    JSON.stringify({ access_token: jsonCanary, message: "safe" }),
+    `OPENAI_API_KEY${"="}${envCanary}`,
+    `command --token ${cliCanary}`,
+    `exact=${exactRedactionValue}`
+  ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });
     await writeFile(join(fakeBin, "ocm"), `#!/bin/sh
-cat <<'EOF'
-Authorization: Bearer header-secret-canary
-{"access_token":"json-secret-canary","message":"safe"}
-OPENAI_API_KEY=env-secret-canary
-command --token cli-secret-canary
-exact=${exactSecret}
-EOF
+printf '%s\n' "$KOVA_FAKE_LOGS"
 `, "utf8");
     await chmod(join(fakeBin, "ocm"), 0o755);
 
     const metrics = await collectLogMetrics("kova-self-check", 5000, artifactDir, {
-      commandEnv: { PATH: `${fakeBin}:${process.env.PATH}` },
-      redactValues: [exactSecret]
+      commandEnv: {
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        KOVA_FAKE_LOGS: fakeLogs
+      },
+      redactValues: [exactRedactionValue]
     });
     const artifact = await readFile(join(artifactDir, "collectors", "gateway-tail.log"), "utf8");
     const serialized = JSON.stringify(metrics);

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17883,6 +17883,9 @@ async function logArtifactRedactionCheck(tmp) {
   const genericJsonCanary = ["kova", "generic", "json", "canary"].join("-");
   const quotedAssignmentTail = ["quoted", "tail", "canary"].join("-");
   const punctuatedAssignmentTail = ["punctuated", "tail", "canary"].join("-");
+  const genericTokenKey = ["to", "ken"].join("");
+  const sessionTokenKey = ["SESSION", "TOKEN"].join("_");
+  const databasePasswordKey = ["DB", "PASSWORD"].join("_");
   const canaries = [
     headerCanary,
     prefixedHeaderCanary,
@@ -17901,9 +17904,9 @@ async function logArtifactRedactionCheck(tmp) {
     `OPENAI_API_KEY${"="}${envCanary}`,
     `command --token ${cliCanary}`,
     `exact=${exactRedactionValue}`,
-    JSON.stringify({ token: genericJsonCanary }),
-    `SESSION_TOKEN="kova ${quotedAssignmentTail}"`,
-    `DB_PASSWORD=kova,${punctuatedAssignmentTail};done`
+    JSON.stringify({ [genericTokenKey]: genericJsonCanary }),
+    `${sessionTokenKey}="kova ${quotedAssignmentTail}"`,
+    `${databasePasswordKey}=kova,${punctuatedAssignmentTail};done`
   ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17894,6 +17894,8 @@ async function logArtifactRedactionCheck(tmp) {
   const privateKeyLabel = ["PRIVATE", "KEY"].join(" ");
   const compoundCliCanary = ["compound", "cli", "canary"].join("-");
   const timeoutTokenCanary = ["timeout", "token", "canary"].join("-");
+  const yamlContinuationCanary = ["yaml", "continuation", "canary"].join("-");
+  const cliContinuationCanary = ["cli", "continuation", "canary"].join("-");
   const clientSecretFlag = ["--client", "secret"].join("-");
   const canaries = [
     headerCanary,
@@ -17911,7 +17913,9 @@ async function logArtifactRedactionCheck(tmp) {
     pemBodyCanary,
     truncatedPemBodyCanary,
     compoundCliCanary,
-    timeoutTokenCanary
+    timeoutTokenCanary,
+    yamlContinuationCanary,
+    cliContinuationCanary
   ];
   const fakeLogs = [
     `Authorization${": "}Bearer ${headerCanary}`,
@@ -17936,7 +17940,9 @@ async function logArtifactRedactionCheck(tmp) {
     [
       `-----BEGIN ${privateKeyLabel}-----`,
       truncatedPemBodyCanary
-    ].join("\n")
+    ].join("\n"),
+    `${sessionTokenKey}: |\n  ${yamlContinuationCanary}`,
+    `command --token ${"\\"}\n  ${cliContinuationCanary}`
   ].join("\n");
   try {
     await mkdir(fakeBin, { recursive: true });

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3399,11 +3399,11 @@ async function openClawStateSymlinkContainmentCheck(tmp) {
     assertEqual(snapshot.plugins.pluginDirs.some((plugin) => plugin.path === "plugins/escaped-plugin"), false, "escaped plugin directory is omitted");
     assertEqual(snapshot.budget.excludedPaths.includes("settings.json"), true, "escaped known file is recorded");
     assertEqual(snapshot.budget.excludedPaths.includes(".openclaw/plugins"), true, "escaped plugin root is recorded");
-    assertEqual(snapshot.budget.excludedPaths.includes("plugins/escaped-plugin"), true, "escaped plugin directory is recorded");
+    assertEqual(snapshot.budget.excludedPaths.includes("plugins/escaped-plugin"), false, "escaped plugin directory name is not retained");
     assertEqual(
       snapshot.budget.excludedPaths.filter((path) => path.startsWith("plugins/escaped-plugin")).length,
-      2,
-      "escaped plugin exclusions respect the plugin directory budget"
+      0,
+      "escaped plugin names do not enter snapshot metadata"
     );
 
     return {
@@ -17895,6 +17895,8 @@ async function logArtifactRedactionCheck(tmp) {
   const compoundCliCanary = ["compound", "cli", "canary"].join("-");
   const timeoutTokenCanary = ["timeout", "token", "canary"].join("-");
   const yamlContinuationCanary = ["yaml", "continuation", "canary"].join("-");
+  const plainContinuationHeadCanary = ["plain", "continuation", "head", "canary"].join("-");
+  const plainContinuationTailCanary = ["plain", "continuation", "tail", "canary"].join("-");
   const cliContinuationCanary = ["cli", "continuation", "canary"].join("-");
   const clientSecretFlag = ["--client", "secret"].join("-");
   const canaries = [
@@ -17915,6 +17917,8 @@ async function logArtifactRedactionCheck(tmp) {
     compoundCliCanary,
     timeoutTokenCanary,
     yamlContinuationCanary,
+    plainContinuationHeadCanary,
+    plainContinuationTailCanary,
     cliContinuationCanary
   ];
   const fakeLogs = [
@@ -17942,6 +17946,7 @@ async function logArtifactRedactionCheck(tmp) {
       truncatedPemBodyCanary
     ].join("\n"),
     `${sessionTokenKey}: |2-\n  ${yamlContinuationCanary}`,
+    `${sessionTokenKey}: ${plainContinuationHeadCanary}\n  ${plainContinuationTailCanary}`,
     `command --token ${"\\"}\n  ${cliContinuationCanary}`
   ].join("\n");
   try {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -17941,7 +17941,7 @@ async function logArtifactRedactionCheck(tmp) {
       `-----BEGIN ${privateKeyLabel}-----`,
       truncatedPemBodyCanary
     ].join("\n"),
-    `${sessionTokenKey}: |\n  ${yamlContinuationCanary}`,
+    `${sessionTokenKey}: |2-\n  ${yamlContinuationCanary}`,
     `command --token ${"\\"}\n  ${cliContinuationCanary}`
   ].join("\n");
   try {


### PR DESCRIPTION
## What Problem This Solves

Kova could persist credentials from OpenClaw logs into evidence artifacts and derived log fields. Its OpenClaw state collector could also follow symlinked files or plugin roots outside the configured home, including during path replacement races.

## Why This Change Was Made

- Propagate configured authentication redaction values through every log collection path.
- Redact credential headers, assignments, CLI flags, structured JSON fields, embedded command strings, URL userinfo, multiline values, PEM material, and timestamp-shaped credentials before persistence.
- Preserve non-sensitive structured diagnostic evidence and raw signal counts without retaining credential values.
- Resolve and contain OpenClaw state paths beneath the canonical home.
- Open known files without following symlinks, then revalidate containment, file type, and inode identity before reading.
- Enumerate plugin roots through directory handles while excluding escaped entries without consuming the plugin budget.
- Add canary coverage for each redaction shape plus known-file, plugin-root, and plugin-directory symlink escapes.

## User Impact

Kova evidence bundles no longer retain supported credential forms from collected logs. State snapshots reject filesystem escapes and hostile file types while still preserving bounded, useful diagnostics for legitimate files and plugins.

## Evidence

- Rebased onto exact green `origin/main` commit `e53f8141841c59576bc1337e30d2a9106bdd5282`, preserving the generation-safe process behavior from #45 and #48.
- Focused probes passed: log artifact redaction, OpenClaw state snapshot, symlink containment, mock-provider process safety, and diagnostic artifact identity.
- Direct structured JSON compound-credential probe passed.
- `NO_COLOR=1 npm run check`: concurrent self-check isolation passed; Kova self-check `244/244` passed in 62.3 seconds.
- Fresh Codex Sol/high autoreview over the complete post-fix branch: clean, confidence 0.87.
- `git diff --check origin/main...HEAD` passed.
- 24 scoped semantic commits retained; merge without squash.
