### PR TITLE
fix(reporting): harden publication and recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to Kova are documented in this file.
 - Hardened interactive setup with no-echo secret input, JSON-clean stdout, terminal-state restoration, and real directory write probes.
 - Hardened CLI option and error contracts, release versioning and provenance checks, release archive packaging, pinned CI dependencies, and Crabbox hydration state.
 - Hardened collector evidence integrity across profiles, provider attribution, process sampling, diagnostics, timelines, state fixtures, redaction, and artifact retention.
+- Made report, bundle, retained-artifact, and baseline publication concurrency-safe, rollback-aware, and fail-closed on incomplete evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ All notable changes to Kova are documented in this file.
 - Hardened CLI option and error contracts, release versioning and provenance checks, release archive packaging, pinned CI dependencies, and Crabbox hydration state.
 - Hardened collector evidence integrity across profiles, provider attribution, process sampling, diagnostics, timelines, state fixtures, redaction, and artifact retention.
 - Made report, bundle, retained-artifact, and baseline publication concurrency-safe, rollback-aware, and fail-closed on incomplete evidence.
+- Kept installed release self-checks independent of source-only test fixtures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,5 @@ All notable changes to Kova are documented in this file.
 - Hardened interactive setup with no-echo secret input, JSON-clean stdout, terminal-state restoration, and real directory write probes.
 - Hardened CLI option and error contracts, release versioning and provenance checks, release archive packaging, pinned CI dependencies, and Crabbox hydration state.
 - Hardened collector evidence integrity across profiles, provider attribution, process sampling, diagnostics, timelines, state fixtures, redaction, and artifact retention.
-- Made report, bundle, retained-artifact, and baseline publication concurrency-safe, rollback-aware, and fail-closed on incomplete evidence.
+- Made report, portable USTAR bundle, retained-artifact, and baseline publication concurrency-safe, rollback-aware, crash-cleaning, and fail-closed on incomplete evidence.
 - Kept installed release self-checks independent of source-only test fixtures.

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -875,8 +875,8 @@ For non-ship gate runs, Kova retains a durable copy under
 report.md
 report.json
 paste-summary.txt
-<runId>-bundle.tar.gz
-<runId>-bundle.tar.gz.sha256
+<runId>-bundle-<sha256>.tar.gz
+<runId>-bundle-<sha256>.tar.gz.sha256
 retained-artifacts.json
 ```
 

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -80,9 +80,10 @@ whether Kova removed the generated temporary OCM runtime after execution, or why
 it retained that runtime.
 
 Report bundles include `artifact-index.json` at the archive root. The index
-lists every file staged into the bundle with relative path, byte size, and
-SHA-256 digest so agents can inspect evidence coverage without scraping raw log
-output or unpacking blindly.
+lists every file staged into the bundle with its original relative `path`,
+portable `archivePath`, byte size, and SHA-256 digest. Kova maps names that
+USTAR cannot represent to deterministic archive paths while preserving the
+original evidence name in the index.
 
 `outputPaths` records the Markdown, full JSON, and compact summary JSON paths
 for the report itself. The matrix receipt also includes bundle and checksum

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "json5": "2.2.3",
         "mock-ai-provider": "0.1.2",
         "tar-stream": "3.2.0",
+        "unicode-case-folding": "1.1.1",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -193,6 +194,12 @@
       "dependencies": {
         "b4a": "^1.6.4"
       }
+    },
+    "node_modules/unicode-case-folding": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unicode-case-folding/-/unicode-case-folding-1.1.1.tgz",
+      "integrity": "sha512-ZAYziAnMTBisO2dT5tyGvBFMNsIfonOS/BZTd3UZaKWtXMOZqK8s8HRUCrlKxGCTeCxCuCjS/6HW+4a6G+rbzw==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "json5": "2.2.3",
         "mock-ai-provider": "0.1.2",
+        "tar-stream": "3.2.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -18,6 +19,115 @@
       "engines": {
         "node": ">=22"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -41,6 +151,47 @@
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "json5": "2.2.3",
     "mock-ai-provider": "0.1.2",
+    "tar-stream": "3.2.0",
     "zod": "^4.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "json5": "2.2.3",
     "mock-ai-provider": "0.1.2",
     "tar-stream": "3.2.0",
+    "unicode-case-folding": "1.1.1",
     "zod": "^4.4.3"
   }
 }

--- a/src/commands/publish.mjs
+++ b/src/commands/publish.mjs
@@ -226,22 +226,44 @@ async function projectReportBundles(payload, report, { inputPath, outDir }) {
 
 async function findReportBundlePath(report, inputPath) {
   const runId = typeof report.runId === "string" ? report.runId : null;
-  const explicit = [
+  const explicit = [...new Set([
     report.bundle?.path,
     report.bundle?.outputPath,
     report.outputPaths?.bundle,
     report.outputPaths?.bundlePath,
     report.bundlePath,
-  ].filter((item) => typeof item === "string" && item.length > 0);
+  ]
+    .filter((item) => typeof item === "string" && item.length > 0)
+    .map((candidate) => (
+      isAbsolute(candidate) ? candidate : resolve(dirname(inputPath), candidate)
+    )))];
+  const invalidExplicit = [];
+  let verifiedExplicit = null;
 
-  for (const candidate of explicit) {
-    const resolved = isAbsolute(candidate) ? candidate : resolve(dirname(inputPath), candidate);
-    if (await pathExists(resolved)) {
-      const archive = await readVerifiedBundle(resolved, runId);
-      if (archive) {
-        return { path: resolved, archive };
-      }
+  for (const path of explicit) {
+    if (!await pathExists(path)) {
+      invalidExplicit.push(path);
+      continue;
     }
+    const archive = await readVerifiedBundle(path, runId);
+    if (!archive) {
+      invalidExplicit.push(path);
+      continue;
+    }
+    if (verifiedExplicit && !archive.equals(verifiedExplicit.archive)) {
+      invalidExplicit.push(path);
+      continue;
+    }
+    verifiedExplicit ??= { path, archive };
+  }
+  if (invalidExplicit.length > 0) {
+    throw new Error(
+      "kova publish: explicitly referenced report bundle failed integrity verification: " +
+      invalidExplicit.map((path) => displayPath(path)).join(", ")
+    );
+  }
+  if (verifiedExplicit) {
+    return verifiedExplicit;
   }
 
   const inputDir = dirname(inputPath);

--- a/src/commands/publish.mjs
+++ b/src/commands/publish.mjs
@@ -29,6 +29,7 @@ import {
   WEB_PAYLOAD_SCHEMA_VERSION,
 } from "../web-payload-contract.mjs";
 import { repoRoot, displayPath } from "../paths.mjs";
+import { artifactRunIdSegment } from "../reporting/artifact-names.mjs";
 import { resolveReportReference } from "../reporting/report-store.mjs";
 import { projectInternalReport } from "../web-publish/from-internal-report.mjs";
 import {
@@ -232,7 +233,9 @@ async function findReportBundlePath(report, inputPath) {
     if (await pathExists(candidate)) return candidate;
   }
   return findContentAddressedBundlePath(inputDir, [
-    safeBundlePrefix(runId),
+    typeof runId === "string"
+      ? safeBundlePrefix(artifactRunIdSegment(runId))
+      : null,
     safeBundlePrefix(inputBase),
     safeBundlePrefix(inputBase.replace(/-[^-]+$/, "")),
   ].filter(Boolean));

--- a/src/commands/publish.mjs
+++ b/src/commands/publish.mjs
@@ -72,7 +72,8 @@ export async function runPublishCommand(flags) {
     : DEFAULT_OUT_DIR;
 
   const inputPath = await resolveInputPath(inputArg, flags);
-  const inputJson = JSON.parse(await readFile(inputPath, "utf8"));
+  const inputBytes = await readFile(inputPath);
+  const inputJson = JSON.parse(inputBytes.toString("utf8"));
   const kind = classifyInput(inputJson);
 
   if (kind === "unknown") {
@@ -90,7 +91,7 @@ export async function runPublishCommand(flags) {
     })
     : inputJson;
   const bundleProjection = kind === "internal-report"
-    ? await projectReportBundles(projected, inputJson, { inputPath, outDir })
+    ? await projectReportBundles(projected, inputJson, { inputPath, inputBytes, outDir })
     : { payload: projected, bundles: [] };
 
   // Augment with deltas/comparison against the prior release in the target dir.
@@ -202,8 +203,8 @@ async function resolveReportReferenceInDir(reference, reportDir) {
   throw new Error(`report '${reference}' was not found in ${displayPath(reportDir)}`);
 }
 
-async function projectReportBundles(payload, report, { inputPath, outDir }) {
-  const source = await findReportBundlePath(report, inputPath);
+async function projectReportBundles(payload, report, { inputPath, inputBytes, outDir }) {
+  const source = await findReportBundlePath(report, inputPath, inputBytes);
   if (!source) return { payload, bundles: [] };
 
   const publicBundlesDir = resolvePublicBundlesDir(outDir);
@@ -225,8 +226,11 @@ async function projectReportBundles(payload, report, { inputPath, outDir }) {
   };
 }
 
-async function findReportBundlePath(report, inputPath) {
+async function findReportBundlePath(report, inputPath, inputBytes) {
   const runId = typeof report.runId === "string" ? report.runId : null;
+  const expectedReportSha256 = createHash("sha256")
+    .update(inputBytes)
+    .digest("hex");
   const explicit = [...new Set([
     report.bundle?.path,
     report.bundle?.outputPath,
@@ -246,7 +250,11 @@ async function findReportBundlePath(report, inputPath) {
       invalidExplicit.push(path);
       continue;
     }
-    const archive = await readVerifiedBundle(path, runId);
+    const archive = await readVerifiedBundle(
+      path,
+      runId,
+      expectedReportSha256
+    );
     if (!archive) {
       invalidExplicit.push(path);
       continue;
@@ -275,24 +283,9 @@ async function findReportBundlePath(report, inputPath) {
       : null,
     safeBundlePrefix(inputBase),
     safeBundlePrefix(inputBase.replace(/-[^-]+$/, "")),
-  ].filter(Boolean), runId);
+  ].filter(Boolean), runId, expectedReportSha256);
   if (contentAddressed) {
     return contentAddressed;
-  }
-
-  const inferred = [
-    runId ? join(inputDir, `${runId}-bundle.tar.gz`) : null,
-    join(inputDir, `${inputBase}-bundle.tar.gz`),
-    join(inputDir, `${inputBase.replace(/-[^-]+$/, "")}-bundle.tar.gz`),
-  ].filter(Boolean);
-
-  for (const candidate of inferred) {
-    if (await pathExists(candidate)) {
-      const archive = await readVerifiedBundle(candidate, runId);
-      if (archive) {
-        return { path: candidate, archive };
-      }
-    }
   }
   return null;
 }
@@ -304,7 +297,12 @@ function safeBundlePrefix(value) {
   return `${value}-bundle-`;
 }
 
-async function findContentAddressedBundlePath(inputDir, prefixes, runId) {
+async function findContentAddressedBundlePath(
+  inputDir,
+  prefixes,
+  runId,
+  expectedReportSha256
+) {
   const entries = await readdir(inputDir, { withFileTypes: true });
   for (const prefix of new Set(prefixes)) {
     let best = null;
@@ -320,7 +318,11 @@ async function findContentAddressedBundlePath(inputDir, prefixes, runId) {
       if (!/^[a-f0-9]{64}$/.test(digest)) continue;
 
       const path = join(inputDir, entry.name);
-      const archive = await readVerifiedBundle(path, runId);
+      const archive = await readVerifiedBundle(
+        path,
+        runId,
+        expectedReportSha256
+      );
       if (!archive) {
         continue;
       }
@@ -349,12 +351,13 @@ async function findContentAddressedBundlePath(inputDir, prefixes, runId) {
   return null;
 }
 
-async function readVerifiedBundle(path, runId, archive = null) {
+async function readVerifiedBundle(path, runId, expectedReportSha256, archive = null) {
   if (!runId) {
     return null;
   }
   const expectedManifest =
     `${artifactRunIdSegment(runId)}-bundle/manifest.json`;
+  const expectedReport = `${posix.dirname(expectedManifest)}/report.json`;
   try {
     const verifiedArchive = archive ?? (
       await readBoundedFile(
@@ -366,8 +369,15 @@ async function readVerifiedBundle(path, runId, archive = null) {
     if (!await contentAddressMatches(path, verifiedArchive)) {
       return null;
     }
-    const manifest = await readBundleManifest(verifiedArchive, expectedManifest);
-    return JSON.parse(manifest).runId === runId
+    const identity = await readBundleIdentity(
+      verifiedArchive,
+      expectedManifest,
+      expectedReport
+    );
+    return (
+      JSON.parse(identity.manifest).runId === runId &&
+      identity.reportSha256 === expectedReportSha256
+    )
       ? verifiedArchive
       : null;
   } catch {
@@ -378,7 +388,7 @@ async function readVerifiedBundle(path, runId, archive = null) {
 async function contentAddressMatches(path, archive) {
   const match = basename(path).match(/-bundle-([a-f0-9]{64})[.]tar[.]gz$/);
   if (!match) {
-    return true;
+    return false;
   }
   const digest = match[1];
   if (createHash("sha256").update(archive).digest("hex") !== digest) {
@@ -395,7 +405,7 @@ async function contentAddressMatches(path, archive) {
   return checksum === `${digest}  ${basename(path)}\n`;
 }
 
-async function readBundleManifest(archive, expectedManifest) {
+async function readBundleIdentity(archive, expectedManifest, expectedReport) {
   if (archive.length > MAX_BUNDLE_COMPRESSED_BYTES) {
     throw new Error("report bundle compressed archive exceeds the size limit");
   }
@@ -406,6 +416,7 @@ async function readBundleManifest(archive, expectedManifest) {
   let entryCount = 0;
   let declaredBytes = 0;
   let manifest = null;
+  let reportSha256 = null;
 
   extractor.on("entry", (header, stream, next) => {
     // Rejecting an entry destroys its tar-stream source too; consume that
@@ -449,9 +460,26 @@ async function readBundleManifest(archive, expectedManifest) {
       next(new Error("report bundle archive topology exceeds the size limit"));
       return;
     }
-    if (normalized.path !== expectedManifest) {
+    if (
+      normalized.path !== expectedManifest &&
+      normalized.path !== expectedReport
+    ) {
       stream.on("end", next);
       stream.resume();
+      return;
+    }
+    if (normalized.path === expectedReport) {
+      if (header.type !== "file" || reportSha256 !== null) {
+        stream.resume();
+        next(new Error("report bundle report must be one regular file"));
+        return;
+      }
+      const hash = createHash("sha256");
+      stream.on("data", (chunk) => hash.update(chunk));
+      stream.on("end", () => {
+        reportSha256 = hash.digest("hex");
+        next();
+      });
       return;
     }
     if (header.type !== "file" || manifest !== null) {
@@ -518,7 +546,10 @@ async function readBundleManifest(archive, expectedManifest) {
   if (manifest === null) {
     throw new Error("report bundle manifest is missing");
   }
-  return manifest;
+  if (reportSha256 === null) {
+    throw new Error("report bundle report is missing");
+  }
+  return { manifest, reportSha256 };
 }
 
 function archiveDestinationConflicts(

--- a/src/commands/publish.mjs
+++ b/src/commands/publish.mjs
@@ -223,6 +223,17 @@ async function findReportBundlePath(report, inputPath) {
   const inputDir = dirname(inputPath);
   const inputBase = basename(inputPath, ".json");
   const runId = report.runId;
+  const contentAddressed = await findContentAddressedBundlePath(inputDir, [
+    typeof runId === "string"
+      ? safeBundlePrefix(artifactRunIdSegment(runId))
+      : null,
+    safeBundlePrefix(inputBase),
+    safeBundlePrefix(inputBase.replace(/-[^-]+$/, "")),
+  ].filter(Boolean));
+  if (contentAddressed) {
+    return contentAddressed;
+  }
+
   const inferred = [
     runId ? join(inputDir, `${runId}-bundle.tar.gz`) : null,
     join(inputDir, `${inputBase}-bundle.tar.gz`),
@@ -232,13 +243,7 @@ async function findReportBundlePath(report, inputPath) {
   for (const candidate of inferred) {
     if (await pathExists(candidate)) return candidate;
   }
-  return findContentAddressedBundlePath(inputDir, [
-    typeof runId === "string"
-      ? safeBundlePrefix(artifactRunIdSegment(runId))
-      : null,
-    safeBundlePrefix(inputBase),
-    safeBundlePrefix(inputBase.replace(/-[^-]+$/, "")),
-  ].filter(Boolean));
+  return null;
 }
 
 function safeBundlePrefix(value) {

--- a/src/commands/publish.mjs
+++ b/src/commands/publish.mjs
@@ -19,9 +19,14 @@
  * store, so CI can run `kova publish <runId> --ver <version>` after a run.
  */
 
-import { copyFile, mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
-import { join, isAbsolute, resolve, basename, dirname, sep } from "node:path";
+import { mkdir, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { join, isAbsolute, resolve, basename, dirname, posix, sep } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
+import { Transform } from "node:stream";
+import { createGunzip } from "node:zlib";
+import { extract as extractTar } from "tar-stream";
+import { caseFold } from "unicode-case-folding";
 
 import {
   parseRelease,
@@ -40,6 +45,20 @@ import {
 } from "../web-publish/projector.mjs";
 
 const DEFAULT_OUT_DIR = join(repoRoot, "web", "src", "content", "releases");
+const MAX_BUNDLE_COMPRESSED_BYTES = 256 * 1024 * 1024;
+const MAX_BUNDLE_CHECKSUM_BYTES = 8 * 1024;
+const MAX_BUNDLE_UNPACKED_BYTES = 512 * 1024 * 1024;
+const MAX_BUNDLE_DECLARED_BYTES = 512 * 1024 * 1024;
+const MAX_BUNDLE_MANIFEST_BYTES = 64 * 1024;
+const MAX_BUNDLE_PHYSICAL_HEADERS = 10_000;
+const MAX_BUNDLE_ENTRIES = 10_000;
+const MAX_BUNDLE_NAME_BYTES = 4 * 1024;
+const MAX_BUNDLE_PATH_DEPTH = 64;
+const MAX_BUNDLE_ANCESTORS = 100_000;
+const TAR_EXTENSION_TYPES = new Set([0x4b, 0x4c, 0x4e, 0x67, 0x78]);
+const STRICT_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+const READ_ONLY_NONBLOCK =
+  fsConstants.O_RDONLY | (fsConstants.O_NONBLOCK ?? 0);
 
 export async function runPublishCommand(flags) {
   const [inputArg] = flags._;
@@ -186,11 +205,10 @@ async function projectReportBundles(payload, report, { inputPath, outDir }) {
   const source = await findReportBundlePath(report, inputPath);
   if (!source) return { payload, bundles: [] };
 
-  const bundleStat = await stat(source);
   const publicBundlesDir = resolvePublicBundlesDir(outDir);
-  const name = basename(source);
+  const name = basename(source.path);
   const href = `/bundles/${name}`;
-  const bundle = { name, bytes: bundleStat.size, href };
+  const bundle = { name, bytes: source.archive.length, href };
   const next = structuredClone(payload);
 
   if (Array.isArray(next.runs) && next.runs.length > 0) {
@@ -200,13 +218,14 @@ async function projectReportBundles(payload, report, { inputPath, outDir }) {
   return {
     payload: next,
     bundles: [{
-      source,
+      archive: source.archive,
       dest: join(publicBundlesDir, name),
     }],
   };
 }
 
 async function findReportBundlePath(report, inputPath) {
+  const runId = typeof report.runId === "string" ? report.runId : null;
   const explicit = [
     report.bundle?.path,
     report.bundle?.outputPath,
@@ -217,19 +236,23 @@ async function findReportBundlePath(report, inputPath) {
 
   for (const candidate of explicit) {
     const resolved = isAbsolute(candidate) ? candidate : resolve(dirname(inputPath), candidate);
-    if (await pathExists(resolved)) return resolved;
+    if (await pathExists(resolved)) {
+      const archive = await readVerifiedBundle(resolved, runId);
+      if (archive) {
+        return { path: resolved, archive };
+      }
+    }
   }
 
   const inputDir = dirname(inputPath);
   const inputBase = basename(inputPath, ".json");
-  const runId = report.runId;
   const contentAddressed = await findContentAddressedBundlePath(inputDir, [
     typeof runId === "string"
       ? safeBundlePrefix(artifactRunIdSegment(runId))
       : null,
     safeBundlePrefix(inputBase),
     safeBundlePrefix(inputBase.replace(/-[^-]+$/, "")),
-  ].filter(Boolean));
+  ].filter(Boolean), runId);
   if (contentAddressed) {
     return contentAddressed;
   }
@@ -241,7 +264,12 @@ async function findReportBundlePath(report, inputPath) {
   ].filter(Boolean);
 
   for (const candidate of inferred) {
-    if (await pathExists(candidate)) return candidate;
+    if (await pathExists(candidate)) {
+      const archive = await readVerifiedBundle(candidate, runId);
+      if (archive) {
+        return { path: candidate, archive };
+      }
+    }
   }
   return null;
 }
@@ -253,35 +281,502 @@ function safeBundlePrefix(value) {
   return `${value}-bundle-`;
 }
 
-async function findContentAddressedBundlePath(inputDir, prefixes) {
-  const candidates = [];
-  for (const entry of await readdir(inputDir, { withFileTypes: true })) {
-    if (!entry.isFile()) continue;
-    const prefix = prefixes.find((item) => entry.name.startsWith(item));
-    if (!prefix || !entry.name.endsWith(".tar.gz")) continue;
-    const digest = entry.name.slice(prefix.length, -".tar.gz".length);
-    if (!/^[a-f0-9]{64}$/.test(digest)) continue;
+async function findContentAddressedBundlePath(inputDir, prefixes, runId) {
+  const entries = await readdir(inputDir, { withFileTypes: true });
+  for (const prefix of new Set(prefixes)) {
+    let best = null;
+    for (const entry of entries) {
+      if (
+        !entry.isFile() ||
+        !entry.name.startsWith(prefix) ||
+        !entry.name.endsWith(".tar.gz")
+      ) {
+        continue;
+      }
+      const digest = entry.name.slice(prefix.length, -".tar.gz".length);
+      if (!/^[a-f0-9]{64}$/.test(digest)) continue;
 
-    const path = join(inputDir, entry.name);
-    const checksumPath = `${path}.sha256`;
-    if (!await pathExists(checksumPath)) continue;
-    const [archive, checksum, info] = await Promise.all([
-      readFile(path),
-      readFile(checksumPath, "utf8"),
-      stat(path),
-    ]);
-    const actualDigest = createHash("sha256").update(archive).digest("hex");
-    if (
-      actualDigest !== digest ||
-      checksum !== `${digest}  ${entry.name}\n`
-    ) {
-      continue;
+      const path = join(inputDir, entry.name);
+      const archive = await readVerifiedBundle(path, runId);
+      if (!archive) {
+        continue;
+      }
+      let info;
+      try {
+        info = await stat(path);
+      } catch {
+        continue;
+      }
+      const candidate = { path, archive, mtimeMs: info.mtimeMs };
+      if (
+        !best ||
+        candidate.mtimeMs > best.mtimeMs ||
+        (
+          candidate.mtimeMs === best.mtimeMs &&
+          candidate.path.localeCompare(best.path) < 0
+        )
+      ) {
+        best = candidate;
+      }
     }
-    candidates.push({ path, mtimeMs: info.mtimeMs });
+    if (best) {
+      return best;
+    }
   }
-  candidates.sort((left, right) =>
-    right.mtimeMs - left.mtimeMs || left.path.localeCompare(right.path));
-  return candidates[0]?.path ?? null;
+  return null;
+}
+
+async function readVerifiedBundle(path, runId, archive = null) {
+  if (!runId) {
+    return null;
+  }
+  const expectedManifest =
+    `${artifactRunIdSegment(runId)}-bundle/manifest.json`;
+  try {
+    const verifiedArchive = archive ?? (
+      await readBoundedFile(
+        path,
+        MAX_BUNDLE_COMPRESSED_BYTES,
+        "report bundle compressed archive"
+      )
+    ).content;
+    if (!await contentAddressMatches(path, verifiedArchive)) {
+      return null;
+    }
+    const manifest = await readBundleManifest(verifiedArchive, expectedManifest);
+    return JSON.parse(manifest).runId === runId
+      ? verifiedArchive
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function contentAddressMatches(path, archive) {
+  const match = basename(path).match(/-bundle-([a-f0-9]{64})[.]tar[.]gz$/);
+  if (!match) {
+    return true;
+  }
+  const digest = match[1];
+  if (createHash("sha256").update(archive).digest("hex") !== digest) {
+    return false;
+  }
+  const checksum = (
+    await readBoundedFile(
+      `${path}.sha256`,
+      MAX_BUNDLE_CHECKSUM_BYTES,
+      "report bundle checksum",
+      "utf8"
+    )
+  ).content;
+  return checksum === `${digest}  ${basename(path)}\n`;
+}
+
+async function readBundleManifest(archive, expectedManifest) {
+  if (archive.length > MAX_BUNDLE_COMPRESSED_BYTES) {
+    throw new Error("report bundle compressed archive exceeds the size limit");
+  }
+  const extractor = extractTar();
+  const destinations = new Map();
+  const requiredDirectories = new Set();
+  const expectedRoot = posix.dirname(expectedManifest);
+  let entryCount = 0;
+  let declaredBytes = 0;
+  let manifest = null;
+
+  extractor.on("entry", (header, stream, next) => {
+    // Rejecting an entry destroys its tar-stream source too; consume that
+    // paired error so the extractor's error remains the single failure path.
+    stream.on("error", () => {});
+    entryCount += 1;
+    const normalized = normalizeArchiveMember(header.name, header.type);
+    declaredBytes += header.size;
+    if (
+      entryCount > MAX_BUNDLE_ENTRIES ||
+      Buffer.byteLength(header.name) > MAX_BUNDLE_NAME_BYTES ||
+      declaredBytes > MAX_BUNDLE_DECLARED_BYTES ||
+      !normalized ||
+      (
+        normalized.path !== expectedRoot &&
+        !normalized.path.startsWith(`${expectedRoot}/`)
+      ) ||
+      !["file", "directory"].includes(header.type) ||
+      header.linkname ||
+      (header.type === "directory" && header.size !== 0) ||
+      archiveDestinationConflicts(
+        destinations,
+        requiredDirectories,
+        normalized,
+        header.type
+      )
+    ) {
+      stream.resume();
+      next(new Error("report bundle contains an unsafe archive entry"));
+      return;
+    }
+    if (
+      !recordArchiveDestination(
+        destinations,
+        requiredDirectories,
+        normalized,
+        header.type
+      )
+    ) {
+      stream.resume();
+      next(new Error("report bundle archive topology exceeds the size limit"));
+      return;
+    }
+    if (normalized.path !== expectedManifest) {
+      stream.on("end", next);
+      stream.resume();
+      return;
+    }
+    if (header.type !== "file" || manifest !== null) {
+      stream.resume();
+      next(new Error("report bundle manifest must be one regular file"));
+      return;
+    }
+    if (header.size > MAX_BUNDLE_MANIFEST_BYTES) {
+      stream.resume();
+      next(new Error("report bundle manifest exceeds the size limit"));
+      return;
+    }
+    const chunks = [];
+    let bytes = 0;
+    let oversized = false;
+    stream.on("data", (chunk) => {
+      bytes += chunk.length;
+      if (bytes > MAX_BUNDLE_MANIFEST_BYTES) {
+        oversized = true;
+        return;
+      }
+      chunks.push(chunk);
+    });
+    stream.on("end", () => {
+      if (oversized) {
+        next(new Error("report bundle manifest exceeds the size limit"));
+        return;
+      }
+      try {
+        manifest = STRICT_UTF8_DECODER.decode(Buffer.concat(chunks));
+        next();
+      } catch (error) {
+        next(error);
+      }
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    const gunzip = createGunzip();
+    const guard = createTarGuard();
+    let settled = false;
+    const fail = (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      gunzip.destroy();
+      guard.destroy();
+      extractor.destroy(error);
+      reject(error);
+    };
+    gunzip.on("error", fail);
+    guard.on("error", fail);
+    extractor.on("error", fail);
+    extractor.on("finish", () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    });
+    gunzip.pipe(guard).pipe(extractor);
+    gunzip.end(archive);
+  });
+  if (manifest === null) {
+    throw new Error("report bundle manifest is missing");
+  }
+  return manifest;
+}
+
+function archiveDestinationConflicts(
+  destinations,
+  requiredDirectories,
+  member,
+  type
+) {
+  const { portablePath, portableSegments } = member;
+  if (destinations.has(portablePath)) {
+    return true;
+  }
+  let ancestor = portableSegments[0];
+  for (let index = 1; index < portableSegments.length; index += 1) {
+    if (destinations.has(ancestor) && destinations.get(ancestor) !== "directory") {
+      return true;
+    }
+    ancestor += `/${portableSegments[index]}`;
+  }
+  return type !== "directory" && requiredDirectories.has(portablePath);
+}
+
+function recordArchiveDestination(
+  destinations,
+  requiredDirectories,
+  member,
+  type
+) {
+  const { portablePath, portableSegments } = member;
+  const newAncestors = [];
+  let ancestor = portableSegments[0];
+  for (let index = 1; index < portableSegments.length; index += 1) {
+    if (!requiredDirectories.has(ancestor)) {
+      newAncestors.push(ancestor);
+    }
+    ancestor += `/${portableSegments[index]}`;
+  }
+  if (
+    requiredDirectories.size + newAncestors.length >
+    MAX_BUNDLE_ANCESTORS
+  ) {
+    return false;
+  }
+  destinations.set(portablePath, type);
+  for (const requiredDirectory of newAncestors) {
+    requiredDirectories.add(requiredDirectory);
+  }
+  return true;
+}
+
+function createTarGuard() {
+  let buffered = Buffer.alloc(0);
+  let remaining = 0;
+  let total = 0;
+  let physicalHeaders = 0;
+  let declaredBytes = 0;
+  let terminated = false;
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      total += chunk.length;
+      if (total > MAX_BUNDLE_UNPACKED_BYTES) {
+        callback(new Error("report bundle expanded archive exceeds the size limit"));
+        return;
+      }
+      buffered = Buffer.concat([buffered, chunk]);
+      try {
+        while (buffered.length > 0) {
+          if (remaining > 0) {
+            const consumed = Math.min(remaining, buffered.length);
+            buffered = buffered.subarray(consumed);
+            remaining -= consumed;
+            continue;
+          }
+          if (buffered.length < 512) {
+            break;
+          }
+          const header = buffered.subarray(0, 512);
+          buffered = buffered.subarray(512);
+          if (header.every((byte) => byte === 0)) {
+            terminated = true;
+            continue;
+          }
+          if (terminated) {
+            throw new Error("report bundle tar archive has data after its terminator");
+          }
+          physicalHeaders += 1;
+          if (physicalHeaders > MAX_BUNDLE_PHYSICAL_HEADERS) {
+            throw new Error("report bundle tar archive has too many headers");
+          }
+          if (TAR_EXTENSION_TYPES.has(header[156])) {
+            throw new Error("report bundle tar extension headers are unsupported");
+          }
+          validateTarHeader(header);
+          const size = decodeTarSize(header.subarray(124, 136));
+          declaredBytes += size;
+          if (declaredBytes > MAX_BUNDLE_DECLARED_BYTES) {
+            throw new Error("report bundle declared content exceeds the size limit");
+          }
+          remaining = Math.ceil(size / 512) * 512;
+        }
+      } catch (error) {
+        callback(error);
+        return;
+      }
+      this.push(chunk);
+      callback();
+    },
+    flush(callback) {
+      if (!terminated || remaining !== 0 || buffered.some((byte) => byte !== 0)) {
+        callback(new Error("report bundle tar archive is incomplete"));
+        return;
+      }
+      callback();
+    }
+  });
+}
+
+function decodeTarSize(field) {
+  if (field[0] & 0x80) {
+    if (field[0] !== 0x80) {
+      throw new Error("report bundle tar entry has an invalid binary size");
+    }
+    let value = 0n;
+    for (const byte of field.subarray(1)) {
+      value = value * 256n + BigInt(byte);
+    }
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new Error("report bundle tar entry size is too large");
+    }
+    return Number(value);
+  }
+  return decodeTarOctal(field, "report bundle tar entry size");
+}
+
+function validateTarHeader(header) {
+  const onlyChecksumIsNonzero =
+    header.subarray(0, 148).every((byte) => byte === 0) &&
+    header.subarray(156).every((byte) => byte === 0);
+  if (onlyChecksumIsNonzero) {
+    throw new Error("report bundle tar archive has a malformed terminator");
+  }
+  let actual = 8 * 0x20;
+  for (const byte of header.subarray(0, 148)) {
+    actual += byte;
+  }
+  for (const byte of header.subarray(156)) {
+    actual += byte;
+  }
+  const expected = decodeTarOctal(
+    header.subarray(148, 156),
+    "report bundle tar header checksum"
+  );
+  if (actual !== expected) {
+    throw new Error("report bundle tar header checksum is invalid");
+  }
+  validateTarPathEncoding(header);
+}
+
+function decodeTarOctal(field, label) {
+  let start = 0;
+  while (start < field.length && field[start] === 0x20) {
+    start += 1;
+  }
+  if (
+    field.subarray(start).every((byte) => byte === 0 || byte === 0x20)
+  ) {
+    return 0;
+  }
+  let end = start;
+  while (end < field.length && field[end] >= 0x30 && field[end] <= 0x37) {
+    end += 1;
+  }
+  if (
+    end === start ||
+    !field.subarray(end).every((byte) => byte === 0 || byte === 0x20)
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  const octal = field.subarray(start, end).toString("ascii");
+  const value = Number.parseInt(octal, 8);
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function validateTarPathEncoding(header) {
+  const name = decodeTarStringField(
+    header.subarray(0, 100),
+    "report bundle tar entry name"
+  );
+  const prefix = decodeTarStringField(
+    header.subarray(345, 500),
+    "report bundle tar entry prefix"
+  );
+  STRICT_UTF8_DECODER.decode(Buffer.from(prefix ? `${prefix}/${name}` : name));
+}
+
+function decodeTarStringField(field, label) {
+  const nul = field.indexOf(0);
+  const end = nul === -1 ? field.length : nul;
+  if (
+    nul !== -1 &&
+    field.subarray(nul).some((byte) => byte !== 0)
+  ) {
+    throw new Error(`${label} has data after its terminator`);
+  }
+  try {
+    return STRICT_UTF8_DECODER.decode(field.subarray(0, end));
+  } catch {
+    throw new Error(`${label} is not valid UTF-8`);
+  }
+}
+
+function normalizeArchiveMember(name, type) {
+  if (
+    !name ||
+    !["file", "directory"].includes(type) ||
+    name.startsWith("/") ||
+    /[<>:"\\|?*]/.test(name) ||
+    /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u.test(name)
+  ) {
+    return null;
+  }
+  const hasTrailingSlash = name.endsWith("/");
+  if (hasTrailingSlash && type !== "directory") {
+    return null;
+  }
+  const canonicalName = hasTrailingSlash ? name.slice(0, -1) : name;
+  const normalized = posix.normalize(canonicalName);
+  const segments = canonicalName.split("/");
+  if (
+    normalized !== canonicalName ||
+    segments.length === 0 ||
+    segments.length > MAX_BUNDLE_PATH_DEPTH ||
+    segments.some((segment) =>
+      !segment ||
+      segment === "." ||
+      segment === ".." ||
+      segment.startsWith("-") ||
+      /[. ]$/.test(segment) ||
+      /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:[.]|$)/i.test(segment)
+    )
+  ) {
+    return null;
+  }
+  const portableSegments = segments.map((segment) =>
+    caseFold(segment.normalize("NFC")).normalize("NFC"));
+  return {
+    path: normalized,
+    portablePath: portableSegments.join("/"),
+    portableSegments
+  };
+}
+
+async function readBoundedFile(path, maxBytes, label, encoding = null) {
+  const handle = await open(path, READ_ONLY_NONBLOCK);
+  try {
+    const info = await handle.stat();
+    if (!info.isFile() || info.size > maxBytes) {
+      throw new Error(`${label} exceeds the size limit`);
+    }
+    const chunks = [];
+    let total = 0;
+    while (true) {
+      const chunk = Buffer.allocUnsafe(Math.min(64 * 1024, maxBytes + 1 - total));
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, null);
+      if (bytesRead === 0) {
+        break;
+      }
+      total += bytesRead;
+      if (total > maxBytes) {
+        throw new Error(`${label} exceeds the size limit`);
+      }
+      chunks.push(chunk.subarray(0, bytesRead));
+    }
+    const bytes = Buffer.concat(chunks, total);
+    return { content: encoding ? bytes.toString(encoding) : bytes, info };
+  } finally {
+    await handle.close();
+  }
 }
 
 function resolvePublicBundlesDir(outDir) {
@@ -296,7 +791,16 @@ function resolvePublicBundlesDir(outDir) {
 async function copyProjectedBundles(bundles) {
   for (const bundle of bundles) {
     await mkdir(dirname(bundle.dest), { recursive: true });
-    await copyFile(bundle.source, bundle.dest);
+    const tmp = join(
+      dirname(bundle.dest),
+      `.${basename(bundle.dest)}.${randomBytes(6).toString("hex")}.tmp`
+    );
+    try {
+      await writeFile(tmp, bundle.archive);
+      await rename(tmp, bundle.dest);
+    } finally {
+      await rm(tmp, { force: true });
+    }
   }
 }
 

--- a/src/commands/publish.mjs
+++ b/src/commands/publish.mjs
@@ -21,7 +21,7 @@
 
 import { copyFile, mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
 import { join, isAbsolute, resolve, basename, dirname, sep } from "node:path";
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 
 import {
   parseRelease,
@@ -231,7 +231,49 @@ async function findReportBundlePath(report, inputPath) {
   for (const candidate of inferred) {
     if (await pathExists(candidate)) return candidate;
   }
-  return null;
+  return findContentAddressedBundlePath(inputDir, [
+    safeBundlePrefix(runId),
+    safeBundlePrefix(inputBase),
+    safeBundlePrefix(inputBase.replace(/-[^-]+$/, "")),
+  ].filter(Boolean));
+}
+
+function safeBundlePrefix(value) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)) {
+    return null;
+  }
+  return `${value}-bundle-`;
+}
+
+async function findContentAddressedBundlePath(inputDir, prefixes) {
+  const candidates = [];
+  for (const entry of await readdir(inputDir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    const prefix = prefixes.find((item) => entry.name.startsWith(item));
+    if (!prefix || !entry.name.endsWith(".tar.gz")) continue;
+    const digest = entry.name.slice(prefix.length, -".tar.gz".length);
+    if (!/^[a-f0-9]{64}$/.test(digest)) continue;
+
+    const path = join(inputDir, entry.name);
+    const checksumPath = `${path}.sha256`;
+    if (!await pathExists(checksumPath)) continue;
+    const [archive, checksum, info] = await Promise.all([
+      readFile(path),
+      readFile(checksumPath, "utf8"),
+      stat(path),
+    ]);
+    const actualDigest = createHash("sha256").update(archive).digest("hex");
+    if (
+      actualDigest !== digest ||
+      checksum !== `${digest}  ${entry.name}\n`
+    ) {
+      continue;
+    }
+    candidates.push({ path, mtimeMs: info.mtimeMs });
+  }
+  candidates.sort((left, right) =>
+    right.mtimeMs - left.mtimeMs || left.path.localeCompare(right.path));
+  return candidates[0]?.path ?? null;
 }
 
 function resolvePublicBundlesDir(outDir) {

--- a/src/commands/publish.mjs
+++ b/src/commands/publish.mjs
@@ -26,7 +26,6 @@ import { createHash, randomBytes } from "node:crypto";
 import { Transform } from "node:stream";
 import { createGunzip } from "node:zlib";
 import { extract as extractTar } from "tar-stream";
-import { caseFold } from "unicode-case-folding";
 
 import {
   parseRelease,
@@ -35,6 +34,18 @@ import {
 } from "../web-payload-contract.mjs";
 import { repoRoot, displayPath } from "../paths.mjs";
 import { artifactRunIdSegment } from "../reporting/artifact-names.mjs";
+import {
+  MAX_BUNDLE_ANCESTORS,
+  MAX_BUNDLE_CHECKSUM_BYTES,
+  MAX_BUNDLE_COMPRESSED_BYTES,
+  MAX_BUNDLE_DECLARED_BYTES,
+  MAX_BUNDLE_ENTRIES,
+  MAX_BUNDLE_MANIFEST_BYTES,
+  MAX_BUNDLE_NAME_BYTES,
+  MAX_BUNDLE_PHYSICAL_HEADERS,
+  MAX_BUNDLE_UNPACKED_BYTES,
+  normalizeArchiveMember
+} from "../reporting/bundle-contract.mjs";
 import { resolveReportReference } from "../reporting/report-store.mjs";
 import { projectInternalReport } from "../web-publish/from-internal-report.mjs";
 import {
@@ -45,16 +56,6 @@ import {
 } from "../web-publish/projector.mjs";
 
 const DEFAULT_OUT_DIR = join(repoRoot, "web", "src", "content", "releases");
-const MAX_BUNDLE_COMPRESSED_BYTES = 256 * 1024 * 1024;
-const MAX_BUNDLE_CHECKSUM_BYTES = 8 * 1024;
-const MAX_BUNDLE_UNPACKED_BYTES = 512 * 1024 * 1024;
-const MAX_BUNDLE_DECLARED_BYTES = 512 * 1024 * 1024;
-const MAX_BUNDLE_MANIFEST_BYTES = 64 * 1024;
-const MAX_BUNDLE_PHYSICAL_HEADERS = 10_000;
-const MAX_BUNDLE_ENTRIES = 10_000;
-const MAX_BUNDLE_NAME_BYTES = 4 * 1024;
-const MAX_BUNDLE_PATH_DEPTH = 64;
-const MAX_BUNDLE_ANCESTORS = 100_000;
 const TAR_EXTENSION_TYPES = new Set([0x4b, 0x4c, 0x4e, 0x67, 0x78]);
 const STRICT_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 const READ_ONLY_NONBLOCK =
@@ -730,47 +731,6 @@ function decodeTarStringField(field, label) {
   } catch {
     throw new Error(`${label} is not valid UTF-8`);
   }
-}
-
-function normalizeArchiveMember(name, type) {
-  if (
-    !name ||
-    !["file", "directory"].includes(type) ||
-    name.startsWith("/") ||
-    /[<>:"\\|?*]/.test(name) ||
-    /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u.test(name)
-  ) {
-    return null;
-  }
-  const hasTrailingSlash = name.endsWith("/");
-  if (hasTrailingSlash && type !== "directory") {
-    return null;
-  }
-  const canonicalName = hasTrailingSlash ? name.slice(0, -1) : name;
-  const normalized = posix.normalize(canonicalName);
-  const segments = canonicalName.split("/");
-  if (
-    normalized !== canonicalName ||
-    segments.length === 0 ||
-    segments.length > MAX_BUNDLE_PATH_DEPTH ||
-    segments.some((segment) =>
-      !segment ||
-      segment === "." ||
-      segment === ".." ||
-      segment.startsWith("-") ||
-      /[. ]$/.test(segment) ||
-      /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:[.]|$)/i.test(segment)
-    )
-  ) {
-    return null;
-  }
-  const portableSegments = segments.map((segment) =>
-    caseFold(segment.normalize("NFC")).normalize("NFC"));
-  return {
-    path: normalized,
-    portablePath: portableSegments.join("/"),
-    portableSegments
-  };
 }
 
 async function readBoundedFile(path, maxBytes, label, encoding = null) {

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -1,6 +1,6 @@
-import { randomUUID } from "node:crypto";
-import { mkdir, open, readFile, rm, stat } from "node:fs/promises";
-import { dirname } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { link, mkdir, open, readFile, readdir, rm, stat } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 
 const DEFAULT_STALE_MS = 10 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 30 * 1000;
@@ -15,91 +15,177 @@ export async function withFileLock(lockPath, callback, options = {}) {
   const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
 
   while (true) {
+    if (await reclamationInProgress(lockPath, staleMs)) {
+      await waitForRetry(startedAt, timeoutMs, retryMs, lockPath);
+      continue;
+    }
     try {
-      await acquireLock(lockPath, token);
+      await writeExclusiveMetadata(lockPath, lockMetadata(token));
       break;
     } catch (error) {
       if (error?.code !== "EEXIST") {
         throw error;
       }
-      if (await removeAbandonedLock(lockPath, staleMs)) {
+      if (await reclaimAbandonedLock(lockPath, staleMs)) {
         continue;
       }
-      if (Date.now() - startedAt >= timeoutMs) {
-        throw new Error(`timed out waiting for Kova file lock: ${lockPath}`);
-      }
-      await sleep(retryMs);
+      await waitForRetry(startedAt, timeoutMs, retryMs, lockPath);
     }
   }
 
   try {
     return await callback();
   } finally {
-    await releaseOwnedLock(lockPath, token);
+    await removeOwnedFile(lockPath, token);
   }
 }
 
-async function acquireLock(lockPath, token) {
-  const handle = await open(lockPath, "wx", 0o600);
-  try {
-    await handle.writeFile(`${JSON.stringify({
-      token,
-      pid: process.pid,
-      createdAt: new Date().toISOString()
-    })}\n`, "utf8");
-    await handle.sync();
-  } finally {
-    await handle.close();
+async function reclaimAbandonedLock(lockPath, staleMs) {
+  const snapshot = await readSnapshot(lockPath);
+  if (!snapshot || !isAbandoned(snapshot, staleMs)) {
+    return false;
   }
-}
 
-async function removeAbandonedLock(lockPath, staleMs) {
-  let metadata;
+  const claimPath = `${lockPath}.reclaim-${snapshot.fingerprint}`;
+  const claimToken = randomUUID();
   try {
-    const [raw, info] = await Promise.all([
-      readFile(lockPath, "utf8"),
-      stat(lockPath)
-    ]);
-    metadata = {
-      owner: JSON.parse(raw),
-      ageMs: Date.now() - info.mtimeMs
-    };
+    await writeExclusiveMetadata(claimPath, lockMetadata(claimToken));
+  } catch (error) {
+    if (error?.code === "EEXIST") {
+      return false;
+    }
+    throw error;
+  }
+
+  try {
+    const current = await readSnapshot(lockPath);
+    if (!current) {
+      return true;
+    }
+    if (current.fingerprint !== snapshot.fingerprint || !isAbandoned(current, staleMs)) {
+      return false;
+    }
+    await rm(lockPath);
+    return true;
   } catch (error) {
     if (error?.code === "ENOENT") {
       return true;
     }
-    return false;
-  }
-
-  const ownerAlive = processIsAlive(metadata.owner?.pid);
-  if (ownerAlive || metadata.ageMs < staleMs) {
-    return false;
-  }
-  try {
-    await rm(lockPath);
-    return true;
-  } catch (error) {
-    return error?.code === "ENOENT";
+    throw error;
+  } finally {
+    await removeOwnedFile(claimPath, claimToken);
   }
 }
 
-async function releaseOwnedLock(lockPath, token) {
+async function reclamationInProgress(lockPath, staleMs) {
+  const directory = dirname(lockPath);
+  const prefix = `${basename(lockPath)}.reclaim-`;
+  let names;
   try {
-    const owner = JSON.parse(await readFile(lockPath, "utf8"));
-    if (owner?.token === token) {
-      await rm(lockPath);
-    }
+    names = await readdir(directory);
   } catch (error) {
-    if (error?.code !== "ENOENT") {
-      throw error;
+    if (error?.code === "ENOENT") {
+      return false;
     }
+    throw error;
   }
+
+  let active = false;
+  for (const name of names.filter((entry) => entry.startsWith(prefix))) {
+    const path = join(directory, name);
+    const snapshot = await readSnapshot(path);
+    if (!snapshot) {
+      continue;
+    }
+    if (isAbandoned(snapshot, staleMs)) {
+      await removeSnapshot(path, snapshot);
+      continue;
+    }
+    active = true;
+  }
+  return active;
+}
+
+async function writeExclusiveMetadata(path, metadata) {
+  const candidatePath = `${path}.candidate-${metadata.token}`;
+  const handle = await open(candidatePath, "wx", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(metadata)}\n`, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    // Linking a fully written candidate makes the visible lock complete at
+    // creation time and preserves O_EXCL semantics across processes.
+    await link(candidatePath, path);
+  } finally {
+    await rm(candidatePath, { force: true });
+  }
+}
+
+async function readSnapshot(path) {
+  try {
+    const [raw, info] = await Promise.all([
+      readFile(path, "utf8"),
+      stat(path)
+    ]);
+    let owner = null;
+    try {
+      owner = JSON.parse(raw);
+    } catch {
+      // Malformed lock files remain blocking until their age proves abandonment.
+    }
+    return {
+      owner,
+      ageMs: Date.now() - info.mtimeMs,
+      fingerprint: createHash("sha256")
+        .update(`${info.dev}:${info.ino}:${info.size}:${info.mtimeMs}:${raw}`)
+        .digest("hex")
+    };
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function removeSnapshot(path, snapshot) {
+  const current = await readSnapshot(path);
+  if (current?.fingerprint === snapshot.fingerprint) {
+    await rm(path).catch((error) => {
+      if (error?.code !== "ENOENT") {
+        throw error;
+      }
+    });
+  }
+}
+
+async function removeOwnedFile(path, token) {
+  const snapshot = await readSnapshot(path);
+  if (snapshot?.owner?.token === token) {
+    await removeSnapshot(path, snapshot);
+  }
+}
+
+function isAbandoned(snapshot, staleMs) {
+  const pid = snapshot.owner?.pid;
+  if (Number.isInteger(pid) && pid > 0) {
+    return !processIsAlive(pid);
+  }
+  return snapshot.ageMs >= staleMs;
+}
+
+function lockMetadata(token) {
+  return {
+    token,
+    pid: process.pid,
+    createdAt: new Date().toISOString()
+  };
 }
 
 function processIsAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) {
-    return false;
-  }
   try {
     process.kill(pid, 0);
     return true;
@@ -108,6 +194,9 @@ function processIsAlive(pid) {
   }
 }
 
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+async function waitForRetry(startedAt, timeoutMs, retryMs, lockPath) {
+  if (Date.now() - startedAt >= timeoutMs) {
+    throw new Error(`timed out waiting for Kova file lock: ${lockPath}`);
+  }
+  await new Promise((resolve) => setTimeout(resolve, retryMs));
 }

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -176,10 +176,29 @@ async function removeOwnedFile(path, token) {
 
 function isAbandoned(snapshot, staleMs) {
   const ownerDomain = snapshot.owner?.executionDomainIdentity;
-  if (ownerDomain && CURRENT_EXECUTION_DOMAIN && ownerDomain !== CURRENT_EXECUTION_DOMAIN) {
-    // A local PID probe says nothing about an owner on another host or PID
-    // namespace. Preserve mutual exclusion rather than reclaiming unsafely.
-    return false;
+  if (ownerDomain && CURRENT_EXECUTION_DOMAIN) {
+    if (typeof ownerDomain !== "object") {
+      return false;
+    }
+    if (ownerDomain.host !== CURRENT_EXECUTION_DOMAIN.host) {
+      return false;
+    }
+    if (
+      ownerDomain.boot &&
+      CURRENT_EXECUTION_DOMAIN.boot &&
+      ownerDomain.boot !== CURRENT_EXECUTION_DOMAIN.boot
+    ) {
+      return true;
+    }
+    if (
+      ownerDomain.pidNamespace &&
+      CURRENT_EXECUTION_DOMAIN.pidNamespace &&
+      ownerDomain.pidNamespace !== CURRENT_EXECUTION_DOMAIN.pidNamespace
+    ) {
+      // A local PID probe says nothing about an owner in another active PID
+      // namespace. Preserve mutual exclusion rather than reclaiming unsafely.
+      return false;
+    }
   }
   const pid = snapshot.owner?.pid;
   if (Number.isInteger(pid) && pid > 0) {
@@ -210,19 +229,17 @@ function lockMetadata(token) {
 }
 
 function readExecutionDomainIdentity() {
+  const host = hostname() || null;
   if (process.platform === "linux") {
     try {
       const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
       const pidNamespace = readlinkSync("/proc/self/ns/pid");
-      if (bootId && pidNamespace) {
-        return `linux:${bootId}:${pidNamespace}`;
-      }
+      return { host, boot: bootId || null, pidNamespace: pidNamespace || null };
     } catch {
       // Fall through to the host identity when procfs is unavailable.
     }
   }
-  const host = hostname();
-  return host ? `${process.platform}:${host}` : null;
+  return host ? { host, boot: null, pidNamespace: null } : null;
 }
 
 function readProcessIdentity(pid) {

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -176,35 +176,12 @@ async function removeOwnedFile(path, token) {
 
 function isAbandoned(snapshot, staleMs) {
   const ownerDomain = snapshot.owner?.executionDomainIdentity;
-  if (ownerDomain && CURRENT_EXECUTION_DOMAIN) {
-    if (typeof ownerDomain !== "object") {
-      return false;
-    }
-    if (
-      ownerDomain.host &&
-      CURRENT_EXECUTION_DOMAIN.host &&
-      ownerDomain.host !== CURRENT_EXECUTION_DOMAIN.host
-    ) {
-      // Boot IDs and PIDs are host-local. A foreign owner cannot be proven
-      // abandoned from this process, so preserve mutual exclusion.
-      return false;
-    }
-    if (
-      ownerDomain.boot &&
-      CURRENT_EXECUTION_DOMAIN.boot &&
-      ownerDomain.boot !== CURRENT_EXECUTION_DOMAIN.boot
-    ) {
-      return true;
-    }
-    if (
-      ownerDomain.pidNamespace &&
-      CURRENT_EXECUTION_DOMAIN.pidNamespace &&
-      ownerDomain.pidNamespace !== CURRENT_EXECUTION_DOMAIN.pidNamespace
-    ) {
-      // A local PID probe says nothing about an owner in another active PID
-      // namespace. Preserve mutual exclusion rather than reclaiming unsafely.
-      return false;
-    }
+  const domainRelation = classifyExecutionDomain(ownerDomain, CURRENT_EXECUTION_DOMAIN);
+  if (domainRelation === "unknown" || domainRelation === "foreign") {
+    return false;
+  }
+  if (domainRelation === "rebooted") {
+    return true;
   }
   const pid = snapshot.owner?.pid;
   if (Number.isInteger(pid) && pid > 0) {
@@ -223,6 +200,74 @@ function isAbandoned(snapshot, staleMs) {
   return snapshot.ageMs >= staleMs;
 }
 
+export function currentExecutionDomainIdentity() {
+  return CURRENT_EXECUTION_DOMAIN
+    ? structuredClone(CURRENT_EXECUTION_DOMAIN)
+    : null;
+}
+
+export function classifyExecutionDomain(owner, current) {
+  if (
+    !owner ||
+    !current ||
+    typeof owner !== "object" ||
+    typeof current !== "object"
+  ) {
+    return "unknown";
+  }
+  for (const domain of [owner, current]) {
+    for (const field of [
+      "host",
+      "hardwareMachine",
+      "installationMachine",
+      "boot",
+      "pidNamespace"
+    ]) {
+      if (domain[field] !== undefined && domain[field] !== null && typeof domain[field] !== "string") {
+        return "unknown";
+      }
+    }
+  }
+  if (owner.host && current.host && owner.host !== current.host) {
+    return "foreign";
+  }
+  for (const field of ["hardwareMachine", "installationMachine"]) {
+    if (owner[field] && current[field] && owner[field] !== current[field]) {
+      return "foreign";
+    }
+  }
+  const hardwareMachineMatch = Boolean(
+    owner.hardwareMachine &&
+    current.hardwareMachine &&
+    owner.hardwareMachine === current.hardwareMachine
+  );
+  if (
+    hardwareMachineMatch &&
+    owner.boot &&
+    current.boot &&
+    owner.boot !== current.boot
+  ) {
+    return "rebooted";
+  }
+  if (
+    !hardwareMachineMatch &&
+    (!owner.boot || !current.boot || owner.boot !== current.boot)
+  ) {
+    // Matching current boot IDs are the only fallback proof when a stable
+    // machine identity is unavailable.
+    return "unknown";
+  }
+  const ownerNamespace = owner.pidNamespace ?? null;
+  const currentNamespace = current.pidNamespace ?? null;
+  if (Boolean(ownerNamespace) !== Boolean(currentNamespace)) {
+    return "unknown";
+  }
+  if (ownerNamespace && ownerNamespace !== currentNamespace) {
+    return "foreign";
+  }
+  return "local";
+}
+
 function lockMetadata(token) {
   return {
     token,
@@ -236,16 +281,119 @@ function lockMetadata(token) {
 
 function readExecutionDomainIdentity() {
   const host = hostname() || null;
+  const machineIdentities = readMachineIdentities();
   if (process.platform === "linux") {
     try {
       const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
       const pidNamespace = readlinkSync("/proc/self/ns/pid");
-      return { host, boot: bootId || null, pidNamespace: pidNamespace || null };
+      return {
+        host,
+        hardwareMachine: machineIdentities.hardware,
+        installationMachine: machineIdentities.installation,
+        boot: bootId || null,
+        pidNamespace: pidNamespace || null
+      };
     } catch {
       // Fall through to the host identity when procfs is unavailable.
     }
   }
-  return host ? { host, boot: null, pidNamespace: null } : null;
+  return host || machineIdentities.hardware || machineIdentities.installation
+    ? {
+        host,
+        hardwareMachine: machineIdentities.hardware,
+        installationMachine: machineIdentities.installation,
+        boot: null,
+        pidNamespace: null
+      }
+    : null;
+}
+
+function readMachineIdentities() {
+  let hardware = "";
+  let installation = "";
+  if (process.platform === "linux") {
+    try {
+      hardware = normalizeMachineIdentity(
+        readFileSync("/sys/class/dmi/id/product_uuid", "utf8")
+      );
+    } catch {
+      // DMI is optional in containers and on some architectures.
+    }
+    for (const path of ["/etc/machine-id", "/var/lib/dbus/machine-id"]) {
+      try {
+        installation = normalizeMachineIdentity(readFileSync(path, "utf8"));
+        if (installation) {
+          break;
+        }
+      } catch {
+        // Try the next standard machine identity path.
+      }
+    }
+  } else if (process.platform === "darwin") {
+    const result = spawnSync("/usr/sbin/ioreg", [
+      "-rd1",
+      "-c",
+      "IOPlatformExpertDevice"
+    ], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1_000
+    });
+    hardware = result.status === 0
+      ? normalizeMachineIdentity(
+          result.stdout.match(/"IOPlatformUUID"\s*=\s*"([^"]+)"/)?.[1] ?? ""
+        )
+      : "";
+  } else if (process.platform === "win32") {
+    const systemRoot = process.env.SystemRoot;
+    if (systemRoot) {
+      const powershell = join(
+        systemRoot,
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe"
+      );
+      const result = spawnSync(powershell, [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "(Get-CimInstance Win32_ComputerSystemProduct).UUID"
+      ], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 2_000
+      });
+      hardware = result.status === 0
+        ? normalizeMachineIdentity(result.stdout)
+        : "";
+    }
+  }
+  return {
+    hardware: machineIdentityToken(hardware),
+    installation: machineIdentityToken(installation)
+  };
+}
+
+function machineIdentityToken(identity) {
+  return identity
+    ? `machine:${createHash("sha256").update(identity).digest("hex")}`
+    : null;
+}
+
+export function normalizeMachineIdentity(value) {
+  const compact = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replaceAll("-", "");
+  if (
+    !/^[0-9a-f]{32}$/.test(compact) ||
+    /^0+$/.test(compact) ||
+    /^f+$/.test(compact)
+  ) {
+    return "";
+  }
+  return compact;
 }
 
 function readProcessIdentity(pid) {

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -20,6 +20,9 @@ export async function withFileLock(lockPath, callback, options = {}) {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
   const fileMode = options.fileMode ?? 0o600;
+  const linkFile = options.linkFile ?? link;
+  const openFallbackFile = options.openFallbackFile ?? open;
+  let releaseAcquisitionHandle = null;
 
   while (true) {
     if (await reclamationInProgress(lockPath, staleMs)) {
@@ -27,13 +30,27 @@ export async function withFileLock(lockPath, callback, options = {}) {
       continue;
     }
     try {
-      await writeExclusiveMetadata(lockPath, lockMetadata(token), fileMode);
+      releaseAcquisitionHandle = await writeExclusiveMetadata(
+        lockPath,
+        lockMetadata(token),
+        fileMode,
+        linkFile,
+        openFallbackFile
+      );
       break;
     } catch (error) {
       if (error?.code !== "EEXIST") {
         throw error;
       }
-      if (await reclaimAbandonedLock(lockPath, staleMs, fileMode)) {
+      if (
+        await reclaimAbandonedLock(
+          lockPath,
+          staleMs,
+          fileMode,
+          linkFile,
+          openFallbackFile
+        )
+      ) {
         continue;
       }
       await waitForRetry(startedAt, timeoutMs, retryMs, lockPath);
@@ -43,11 +60,20 @@ export async function withFileLock(lockPath, callback, options = {}) {
   try {
     return await callback();
   } finally {
+    if (releaseAcquisitionHandle) {
+      await releaseAcquisitionHandle();
+    }
     await removeOwnedFile(lockPath, token);
   }
 }
 
-async function reclaimAbandonedLock(lockPath, staleMs, fileMode) {
+async function reclaimAbandonedLock(
+  lockPath,
+  staleMs,
+  fileMode,
+  linkFile,
+  openFallbackFile
+) {
   const snapshot = await readSnapshot(lockPath);
   if (!snapshot || !isAbandoned(snapshot, staleMs)) {
     return false;
@@ -55,8 +81,15 @@ async function reclaimAbandonedLock(lockPath, staleMs, fileMode) {
 
   const claimPath = `${lockPath}.reclaim-${snapshot.fingerprint}`;
   const claimToken = randomUUID();
+  let releaseClaimHandle = null;
   try {
-    await writeExclusiveMetadata(claimPath, lockMetadata(claimToken), fileMode);
+    releaseClaimHandle = await writeExclusiveMetadata(
+      claimPath,
+      lockMetadata(claimToken),
+      fileMode,
+      linkFile,
+      openFallbackFile
+    );
   } catch (error) {
     if (error?.code === "EEXIST") {
       return false;
@@ -80,6 +113,9 @@ async function reclaimAbandonedLock(lockPath, staleMs, fileMode) {
     }
     throw error;
   } finally {
+    if (releaseClaimHandle) {
+      await releaseClaimHandle();
+    }
     await removeOwnedFile(claimPath, claimToken);
   }
 }
@@ -119,14 +155,21 @@ async function reclamationInProgress(lockPath, staleMs) {
   return active;
 }
 
-async function writeExclusiveMetadata(path, metadata, fileMode) {
+async function writeExclusiveMetadata(
+  path,
+  metadata,
+  fileMode,
+  linkFile,
+  openFallbackFile
+) {
   const candidatePath = join(
     dirname(path),
     `.${basename(path)}.candidate-${metadata.token}`
   );
+  const content = `${JSON.stringify(metadata)}\n`;
   const handle = await open(candidatePath, "wx", fileMode);
   try {
-    await handle.writeFile(`${JSON.stringify(metadata)}\n`, "utf8");
+    await handle.writeFile(content, "utf8");
     await handle.chmod(fileMode);
     await handle.sync();
   } finally {
@@ -135,9 +178,60 @@ async function writeExclusiveMetadata(path, metadata, fileMode) {
   try {
     // Linking a fully written candidate makes the visible lock complete at
     // creation time and preserves O_EXCL semantics across processes.
-    await link(candidatePath, path);
+    await linkFile(candidatePath, path);
+  } catch (error) {
+    if (!linkIsUnsupported(error)) {
+      throw error;
+    }
+    // O_EXCL still preserves mutual exclusion on filesystems without hard
+    // links. Peers treat the brief incomplete-write window as fail-closed.
+    return await writeExclusiveMetadataWithoutLink(
+      path,
+      content,
+      fileMode,
+      openFallbackFile
+    );
   } finally {
     await rm(candidatePath, { force: true });
+  }
+  return null;
+}
+
+function linkIsUnsupported(error) {
+  return ["ENOSYS", "ENOTSUP", "EOPNOTSUPP", "EPERM"].includes(error?.code);
+}
+
+async function writeExclusiveMetadataWithoutLink(
+  path,
+  content,
+  fileMode,
+  openFallbackFile
+) {
+  const handle = await openFallbackFile(path, "wx", fileMode);
+  try {
+    await handle.writeFile(content, "utf8");
+    await handle.chmod(fileMode);
+    await handle.sync();
+  } catch (error) {
+    await handle.close().catch(() => {});
+    // A partial visible lock must remain fail-closed. Portable pathname APIs
+    // cannot prove ownership again before unlinking a possible replacement.
+    throw error;
+  }
+  try {
+    await handle.close();
+    return null;
+  } catch (error) {
+    if (error?.code === "EBADF") {
+      return null;
+    }
+    return async () => {
+      await handle.close().catch((closeError) => {
+        if (closeError?.code !== "EBADF") {
+          throw closeError;
+        }
+      });
+    };
   }
 }
 

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -181,6 +181,15 @@ function isAbandoned(snapshot, staleMs) {
       return false;
     }
     if (
+      ownerDomain.host &&
+      CURRENT_EXECUTION_DOMAIN.host &&
+      ownerDomain.host !== CURRENT_EXECUTION_DOMAIN.host
+    ) {
+      // Boot IDs and PIDs are host-local. A foreign owner cannot be proven
+      // abandoned from this process, so preserve mutual exclusion.
+      return false;
+    }
+    if (
       ownerDomain.boot &&
       CURRENT_EXECUTION_DOMAIN.boot &&
       ownerDomain.boot !== CURRENT_EXECUTION_DOMAIN.boot

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -103,6 +103,12 @@ async function reclamationInProgress(lockPath, staleMs) {
     if (!snapshot) {
       continue;
     }
+    if (isLegacyReclaimCandidate(name, prefix)) {
+      if (snapshot.ageMs >= staleMs) {
+        await removeSnapshot(path, snapshot);
+      }
+      continue;
+    }
     if (isAbandoned(snapshot, staleMs)) {
       await removeSnapshot(path, snapshot);
       continue;
@@ -113,7 +119,10 @@ async function reclamationInProgress(lockPath, staleMs) {
 }
 
 async function writeExclusiveMetadata(path, metadata, fileMode) {
-  const candidatePath = `${path}.candidate-${metadata.token}`;
+  const candidatePath = join(
+    dirname(path),
+    `.${basename(path)}.candidate-${metadata.token}`
+  );
   const handle = await open(candidatePath, "wx", fileMode);
   try {
     await handle.writeFile(`${JSON.stringify(metadata)}\n`, "utf8");
@@ -129,6 +138,21 @@ async function writeExclusiveMetadata(path, metadata, fileMode) {
   } finally {
     await rm(candidatePath, { force: true });
   }
+}
+
+function isLegacyReclaimCandidate(name, prefix) {
+  const suffix = name.slice(prefix.length);
+  const separator = ".candidate-";
+  const separatorIndex = suffix.indexOf(separator);
+  if (separatorIndex === -1) {
+    return false;
+  }
+  const fingerprint = suffix.slice(0, separatorIndex);
+  const token = suffix.slice(separatorIndex + separator.length);
+  return (
+    /^[a-f0-9]{64}$/.test(fingerprint) &&
+    /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/.test(token)
+  );
 }
 
 async function readSnapshot(path) {

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -1,0 +1,113 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rm, stat } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const DEFAULT_STALE_MS = 10 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 30 * 1000;
+const DEFAULT_RETRY_MS = 25;
+
+export async function withFileLock(lockPath, callback, options = {}) {
+  await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
+  const token = randomUUID();
+  const startedAt = Date.now();
+  const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
+
+  while (true) {
+    try {
+      await acquireLock(lockPath, token);
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        throw error;
+      }
+      if (await removeAbandonedLock(lockPath, staleMs)) {
+        continue;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new Error(`timed out waiting for Kova file lock: ${lockPath}`);
+      }
+      await sleep(retryMs);
+    }
+  }
+
+  try {
+    return await callback();
+  } finally {
+    await releaseOwnedLock(lockPath, token);
+  }
+}
+
+async function acquireLock(lockPath, token) {
+  const handle = await open(lockPath, "wx", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify({
+      token,
+      pid: process.pid,
+      createdAt: new Date().toISOString()
+    })}\n`, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function removeAbandonedLock(lockPath, staleMs) {
+  let metadata;
+  try {
+    const [raw, info] = await Promise.all([
+      readFile(lockPath, "utf8"),
+      stat(lockPath)
+    ]);
+    metadata = {
+      owner: JSON.parse(raw),
+      ageMs: Date.now() - info.mtimeMs
+    };
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return true;
+    }
+    return false;
+  }
+
+  const ownerAlive = processIsAlive(metadata.owner?.pid);
+  if (ownerAlive || metadata.ageMs < staleMs) {
+    return false;
+  }
+  try {
+    await rm(lockPath);
+    return true;
+  } catch (error) {
+    return error?.code === "ENOENT";
+  }
+}
+
+async function releaseOwnedLock(lockPath, token) {
+  try {
+    const owner = JSON.parse(await readFile(lockPath, "utf8"));
+    if (owner?.token === token) {
+      await rm(lockPath);
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -1,10 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { link, mkdir, open, readFile, readdir, rm, stat } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 
 const DEFAULT_STALE_MS = 10 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 30 * 1000;
 const DEFAULT_RETRY_MS = 25;
+const CURRENT_PROCESS_IDENTITY = readProcessIdentity(process.pid);
 
 export async function withFileLock(lockPath, callback, options = {}) {
   await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
@@ -172,9 +175,12 @@ async function removeOwnedFile(path, token) {
 function isAbandoned(snapshot, staleMs) {
   const pid = snapshot.owner?.pid;
   if (Number.isInteger(pid) && pid > 0) {
-    // PID liveness is useful for fast crash recovery, but PID reuse must not
-    // wedge these short publication critical sections forever.
-    return !processIsAlive(pid) || snapshot.ageMs >= staleMs;
+    if (!processIsAlive(pid)) {
+      return true;
+    }
+    const ownerIdentity = snapshot.owner?.processIdentity;
+    const currentIdentity = readProcessIdentity(pid);
+    return Boolean(ownerIdentity && currentIdentity && ownerIdentity !== currentIdentity);
   }
   return snapshot.ageMs >= staleMs;
 }
@@ -183,8 +189,48 @@ function lockMetadata(token) {
   return {
     token,
     pid: process.pid,
+    processIdentity: CURRENT_PROCESS_IDENTITY,
     createdAt: new Date().toISOString()
   };
+}
+
+function readProcessIdentity(pid) {
+  if (process.platform === "linux") {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const fields = stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/);
+      const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+      return fields[19] && bootId ? `proc:${bootId}:${fields[19]}` : null;
+    } catch {
+      return null;
+    }
+  }
+  if (process.platform === "win32") {
+    const systemRoot = process.env.SystemRoot;
+    if (!systemRoot) {
+      return null;
+    }
+    const powershell = join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+    const result = spawnSync(powershell, [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`
+    ], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2_000
+    });
+    const startedAt = result.status === 0 ? result.stdout.trim() : "";
+    return /^\d+$/.test(startedAt) ? `windows:${startedAt}` : null;
+  }
+  const result = spawnSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 1_000
+  });
+  const startedAt = result.status === 0 ? result.stdout.trim().replace(/\s+/g, " ") : "";
+  return startedAt ? `ps:${startedAt}` : null;
 }
 
 function processIsAlive(pid) {

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -18,6 +18,7 @@ export async function withFileLock(lockPath, callback, options = {}) {
   const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
+  const fileMode = options.fileMode ?? 0o600;
 
   while (true) {
     if (await reclamationInProgress(lockPath, staleMs)) {
@@ -25,13 +26,13 @@ export async function withFileLock(lockPath, callback, options = {}) {
       continue;
     }
     try {
-      await writeExclusiveMetadata(lockPath, lockMetadata(token));
+      await writeExclusiveMetadata(lockPath, lockMetadata(token), fileMode);
       break;
     } catch (error) {
       if (error?.code !== "EEXIST") {
         throw error;
       }
-      if (await reclaimAbandonedLock(lockPath, staleMs)) {
+      if (await reclaimAbandonedLock(lockPath, staleMs, fileMode)) {
         continue;
       }
       await waitForRetry(startedAt, timeoutMs, retryMs, lockPath);
@@ -45,7 +46,7 @@ export async function withFileLock(lockPath, callback, options = {}) {
   }
 }
 
-async function reclaimAbandonedLock(lockPath, staleMs) {
+async function reclaimAbandonedLock(lockPath, staleMs, fileMode) {
   const snapshot = await readSnapshot(lockPath);
   if (!snapshot || !isAbandoned(snapshot, staleMs)) {
     return false;
@@ -54,7 +55,7 @@ async function reclaimAbandonedLock(lockPath, staleMs) {
   const claimPath = `${lockPath}.reclaim-${snapshot.fingerprint}`;
   const claimToken = randomUUID();
   try {
-    await writeExclusiveMetadata(claimPath, lockMetadata(claimToken));
+    await writeExclusiveMetadata(claimPath, lockMetadata(claimToken), fileMode);
   } catch (error) {
     if (error?.code === "EEXIST") {
       return false;
@@ -111,11 +112,12 @@ async function reclamationInProgress(lockPath, staleMs) {
   return active;
 }
 
-async function writeExclusiveMetadata(path, metadata) {
+async function writeExclusiveMetadata(path, metadata, fileMode) {
   const candidatePath = `${path}.candidate-${metadata.token}`;
-  const handle = await open(candidatePath, "wx", 0o600);
+  const handle = await open(candidatePath, "wx", fileMode);
   try {
     await handle.writeFile(`${JSON.stringify(metadata)}\n`, "utf8");
+    await handle.chmod(fileMode);
     await handle.sync();
   } finally {
     await handle.close();

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -179,8 +179,13 @@ function isAbandoned(snapshot, staleMs) {
       return true;
     }
     const ownerIdentity = snapshot.owner?.processIdentity;
+    if (!ownerIdentity) {
+      return snapshot.owner?.processIdentityUnavailable === true
+        ? false
+        : snapshot.ageMs >= staleMs;
+    }
     const currentIdentity = readProcessIdentity(pid);
-    return Boolean(ownerIdentity && currentIdentity && ownerIdentity !== currentIdentity);
+    return Boolean(currentIdentity && ownerIdentity !== currentIdentity);
   }
   return snapshot.ageMs >= staleMs;
 }
@@ -190,6 +195,7 @@ function lockMetadata(token) {
     token,
     pid: process.pid,
     processIdentity: CURRENT_PROCESS_IDENTITY,
+    processIdentityUnavailable: CURRENT_PROCESS_IDENTITY === null,
     createdAt: new Date().toISOString()
   };
 }
@@ -226,6 +232,7 @@ function readProcessIdentity(pid) {
   }
   const result = spawnSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], {
     encoding: "utf8",
+    env: { LANG: "C", LC_ALL: "C" },
     stdio: ["ignore", "pipe", "ignore"],
     timeout: 1_000
   });

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -172,7 +172,9 @@ async function removeOwnedFile(path, token) {
 function isAbandoned(snapshot, staleMs) {
   const pid = snapshot.owner?.pid;
   if (Number.isInteger(pid) && pid > 0) {
-    return !processIsAlive(pid);
+    // PID liveness is useful for fast crash recovery, but PID reuse must not
+    // wedge these short publication critical sections forever.
+    return !processIsAlive(pid) || snapshot.ageMs >= staleMs;
   }
   return snapshot.ageMs >= staleMs;
 }

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -180,9 +180,6 @@ function isAbandoned(snapshot, staleMs) {
     if (typeof ownerDomain !== "object") {
       return false;
     }
-    if (ownerDomain.host !== CURRENT_EXECUTION_DOMAIN.host) {
-      return false;
-    }
     if (
       ownerDomain.boot &&
       CURRENT_EXECUTION_DOMAIN.boot &&

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -1,13 +1,15 @@
 import { createHash, randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, readlinkSync } from "node:fs";
 import { link, mkdir, open, readFile, readdir, rm, stat } from "node:fs/promises";
+import { hostname } from "node:os";
 import { basename, dirname, join } from "node:path";
 
 const DEFAULT_STALE_MS = 10 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 30 * 1000;
 const DEFAULT_RETRY_MS = 25;
 const CURRENT_PROCESS_IDENTITY = readProcessIdentity(process.pid);
+const CURRENT_EXECUTION_DOMAIN = readExecutionDomainIdentity();
 
 export async function withFileLock(lockPath, callback, options = {}) {
   await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
@@ -173,6 +175,12 @@ async function removeOwnedFile(path, token) {
 }
 
 function isAbandoned(snapshot, staleMs) {
+  const ownerDomain = snapshot.owner?.executionDomainIdentity;
+  if (ownerDomain && CURRENT_EXECUTION_DOMAIN && ownerDomain !== CURRENT_EXECUTION_DOMAIN) {
+    // A local PID probe says nothing about an owner on another host or PID
+    // namespace. Preserve mutual exclusion rather than reclaiming unsafely.
+    return false;
+  }
   const pid = snapshot.owner?.pid;
   if (Number.isInteger(pid) && pid > 0) {
     if (!processIsAlive(pid)) {
@@ -196,8 +204,25 @@ function lockMetadata(token) {
     pid: process.pid,
     processIdentity: CURRENT_PROCESS_IDENTITY,
     processIdentityUnavailable: CURRENT_PROCESS_IDENTITY === null,
+    executionDomainIdentity: CURRENT_EXECUTION_DOMAIN,
     createdAt: new Date().toISOString()
   };
+}
+
+function readExecutionDomainIdentity() {
+  if (process.platform === "linux") {
+    try {
+      const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+      const pidNamespace = readlinkSync("/proc/self/ns/pid");
+      if (bootId && pidNamespace) {
+        return `linux:${bootId}:${pidNamespace}`;
+      }
+    } catch {
+      // Fall through to the host identity when procfs is unavailable.
+    }
+  }
+  const host = hostname();
+  return host ? `${process.platform}:${host}` : null;
 }
 
 function readProcessIdentity(pid) {

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -8,6 +8,7 @@ import { basename, dirname, join } from "node:path";
 const DEFAULT_STALE_MS = 10 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 30 * 1000;
 const DEFAULT_RETRY_MS = 25;
+const MAX_DIAGNOSTIC_FIELD_LENGTH = 160;
 const CURRENT_PROCESS_IDENTITY = readProcessIdentity(process.pid);
 const CURRENT_EXECUTION_DOMAIN = readExecutionDomainIdentity();
 
@@ -473,7 +474,75 @@ function processIsAlive(pid) {
 
 async function waitForRetry(startedAt, timeoutMs, retryMs, lockPath) {
   if (Date.now() - startedAt >= timeoutMs) {
-    throw new Error(`timed out waiting for Kova file lock: ${lockPath}`);
+    const snapshot = await readSnapshot(lockPath);
+    const ownerSummary = describeLockOwner(snapshot);
+    const recovery = snapshot
+      ? "The lock fails closed across execution domains. Recovery requires quiescing all Kova " +
+        "writers, verifying the owner process or host is dead, and re-reading the lock immediately " +
+        "before removal to confirm its owner and fingerprint still match this timeout."
+      : "The lock disappeared during the timeout; retry without removing any file.";
+    throw new Error(
+      `timed out waiting for Kova file lock: ${formatDiagnosticField(lockPath)}${ownerSummary}. ` +
+      recovery
+    );
   }
   await new Promise((resolve) => setTimeout(resolve, retryMs));
+}
+
+function describeLockOwner(snapshot) {
+  if (!snapshot) {
+    return " (owner disappeared during timeout)";
+  }
+  const owner = snapshot.owner;
+  if (!owner || typeof owner !== "object") {
+    return (
+      ` (owner metadata invalid; ageMs=${Math.max(0, Math.round(snapshot.ageMs))}, ` +
+      `fingerprint=${snapshot.fingerprint})`
+    );
+  }
+  const domain = owner.executionDomainIdentity;
+  const fields = [
+    Number.isInteger(owner.pid) && owner.pid > 0 ? `pid=${owner.pid}` : null,
+    ownerField("host", domain && typeof domain === "object" ? domain.host : null),
+    domain && typeof domain === "object" && domain.hardwareMachine
+      ? ownerField("hardwareMachine", domain.hardwareMachine)
+      : null,
+    domain && typeof domain === "object" && domain.installationMachine
+      ? ownerField("installationMachine", domain.installationMachine)
+      : null,
+    `ageMs=${Math.max(0, Math.round(snapshot.ageMs))}`,
+    `fingerprint=${snapshot.fingerprint}`
+  ].filter(Boolean);
+  return ` (owner ${fields.join(", ")})`;
+}
+
+function ownerField(name, value) {
+  return typeof value === "string" && value
+    ? `${name}=${formatDiagnosticField(value, MAX_DIAGNOSTIC_FIELD_LENGTH)}`
+    : null;
+}
+
+function formatDiagnosticField(value, maxLength) {
+  const characters = Array.from(String(value));
+  const bounded =
+    maxLength && characters.length > maxLength
+      ? [...characters.slice(0, maxLength), ".", ".", "."]
+      : characters;
+  let encoded = '"';
+  for (const character of bounded) {
+    const codePoint = character.codePointAt(0);
+    if (character === '"' || character === "\\") {
+      encoded += `\\${character}`;
+    } else if (codePoint >= 0x20 && codePoint <= 0x7e) {
+      encoded += character;
+    } else if (codePoint <= 0xffff) {
+      encoded += `\\u${codePoint.toString(16).padStart(4, "0")}`;
+    } else {
+      const offset = codePoint - 0x10000;
+      const high = 0xd800 + (offset >> 10);
+      const low = 0xdc00 + (offset & 0x3ff);
+      encoded += `\\u${high.toString(16)}\\u${low.toString(16)}`;
+    }
+  }
+  return `${encoded}"`;
 }

--- a/src/file-lock.mjs
+++ b/src/file-lock.mjs
@@ -243,13 +243,21 @@ export function classifyExecutionDomain(owner, current) {
     current.hardwareMachine &&
     owner.hardwareMachine === current.hardwareMachine
   );
+  const ownerNamespace = owner.pidNamespace ?? null;
+  const currentNamespace = current.pidNamespace ?? null;
+  if (Boolean(ownerNamespace) !== Boolean(currentNamespace)) {
+    return "unknown";
+  }
+  if (ownerNamespace && ownerNamespace !== currentNamespace) {
+    return "foreign";
+  }
   if (
     hardwareMachineMatch &&
     owner.boot &&
     current.boot &&
     owner.boot !== current.boot
   ) {
-    return "rebooted";
+    return ownerNamespace ? "rebooted" : "unknown";
   }
   if (
     !hardwareMachineMatch &&
@@ -258,14 +266,6 @@ export function classifyExecutionDomain(owner, current) {
     // Matching current boot IDs are the only fallback proof when a stable
     // machine identity is unavailable.
     return "unknown";
-  }
-  const ownerNamespace = owner.pidNamespace ?? null;
-  const currentNamespace = current.pidNamespace ?? null;
-  if (Boolean(ownerNamespace) !== Boolean(currentNamespace)) {
-    return "unknown";
-  }
-  if (ownerNamespace && ownerNamespace !== currentNamespace) {
-    return "foreign";
   }
   return "local";
 }

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -110,16 +110,9 @@ export async function saveBaselineStore(path, store) {
 
 export async function withBaselineStoreLock(path, callback) {
   const writePath = await resolveBaselineWritePath(path);
-  const metadata = await stat(writePath).catch((error) => {
-    if (error.code === "ENOENT") {
-      return null;
-    }
-    throw error;
-  });
-  const lockIdentity = metadata
-    ? `inode:${metadata.dev}:${metadata.ino}`
-    : `path:${resolve(writePath)}`;
-  const identity = createHash("sha256").update(lockIdentity).digest("hex");
+  // The canonical path stays stable across the first create and every later
+  // replacement; inode-based keys would let old and new waiters split locks.
+  const identity = createHash("sha256").update(resolve(writePath)).digest("hex");
   const user = typeof process.getuid === "function" ? process.getuid() : "user";
   const lockPath = join(tmpdir(), `kova-baseline-locks-${user}`, `${identity}.lock`);
   return withFileLock(lockPath, callback);

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -1,6 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { chmod, lstat, mkdir, open, readFile, readlink, realpath, rename, rm, stat } from "node:fs/promises";
-import { userInfo } from "node:os";
+import { lstat, mkdir, open, readFile, readlink, realpath, rename, rm, stat } from "node:fs/promises";
 import { basename, dirname, join, posix, resolve, win32 } from "node:path";
 import { withFileLock } from "../file-lock.mjs";
 import { baselinesDir } from "../paths.mjs";
@@ -114,17 +113,20 @@ export async function withBaselineStoreLock(path, callback) {
   // replacement; inode-based keys would let old and new waiters split locks.
   // Folding case and Unicode only over-serializes distinct files on a
   // case-sensitive volume, while preventing aliases from splitting the lock.
-  const canonicalPath = (await canonicalizeBaselinePath(writePath))
+  const canonicalPath = await canonicalizeBaselinePath(writePath);
+  const canonicalName = basename(canonicalPath)
     .normalize("NFC")
     .toLowerCase();
-  const identity = createHash("sha256").update(canonicalPath).digest("hex");
-  const user = userInfo();
-  const lockRoot = process.platform === "win32"
-    ? join(process.env.LOCALAPPDATA || user.homedir, "Kova", "locks", "baselines")
-    : join("/tmp", `kova-baseline-locks-${user.uid}`);
-  await ensurePrivateLockDirectory(lockRoot);
-  const lockPath = join(lockRoot, `${identity}.lock`);
-  return withFileLock(lockPath, callback);
+  const identity = createHash("sha256")
+    .update(canonicalName)
+    .digest("hex");
+  const lockPath = join(
+    dirname(canonicalPath),
+    `.kova-baseline-${identity}.lock`
+  );
+  // The lock shares the baseline store's filesystem so every host and user
+  // participating in the same store observes one RMW serialization point.
+  return withFileLock(lockPath, callback, { fileMode: 0o644 });
 }
 
 async function canonicalizeBaselinePath(path) {
@@ -144,20 +146,6 @@ async function canonicalizeBaselinePath(path) {
       suffix.unshift(basename(current));
       current = parent;
     }
-  }
-}
-
-async function ensurePrivateLockDirectory(path) {
-  await mkdir(path, { recursive: true, mode: 0o700 });
-  const info = await lstat(path);
-  if (!info.isDirectory() || info.isSymbolicLink()) {
-    throw new Error(`Kova baseline lock path must be a real directory: ${path}`);
-  }
-  if (typeof process.getuid === "function" && info.uid !== process.getuid()) {
-    throw new Error(`Kova baseline lock directory is not owned by the current user: ${path}`);
-  }
-  if (process.platform !== "win32" && (info.mode & 0o077) !== 0) {
-    await chmod(path, 0o700);
   }
 }
 

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -1,8 +1,9 @@
 import { createHash, randomUUID } from "node:crypto";
-import { chmod, lstat, mkdir, open, readFile, readlink, rename, rm, stat } from "node:fs/promises";
-import { dirname, join, posix, resolve, win32 } from "node:path";
+import { chmod, lstat, mkdir, open, readFile, readlink, realpath, rename, rm, stat } from "node:fs/promises";
+import { userInfo } from "node:os";
+import { basename, dirname, join, posix, resolve, win32 } from "node:path";
 import { withFileLock } from "../file-lock.mjs";
-import { baselinesDir, kovaHome } from "../paths.mjs";
+import { baselinesDir } from "../paths.mjs";
 import {
   DEFAULT_REGRESSION_THRESHOLDS,
   PERFORMANCE_METRICS,
@@ -113,14 +114,37 @@ export async function withBaselineStoreLock(path, callback) {
   // replacement; inode-based keys would let old and new waiters split locks.
   // Folding case and Unicode only over-serializes distinct files on a
   // case-sensitive volume, while preventing aliases from splitting the lock.
-  const canonicalPath = resolve(writePath).normalize("NFC").toLowerCase();
+  const canonicalPath = (await canonicalizeBaselinePath(writePath))
+    .normalize("NFC")
+    .toLowerCase();
   const identity = createHash("sha256").update(canonicalPath).digest("hex");
-  // Baseline stores are per-user Kova state; following KOVA_HOME keeps every
-  // supported writer in one namespace and works in redirected sandboxes.
-  const lockRoot = join(kovaHome, "locks", "baselines");
+  const user = userInfo();
+  const lockRoot = process.platform === "win32"
+    ? join(process.env.LOCALAPPDATA || user.homedir, "Kova", "locks", "baselines")
+    : join("/tmp", `kova-baseline-locks-${user.uid}`);
   await ensurePrivateLockDirectory(lockRoot);
   const lockPath = join(lockRoot, `${identity}.lock`);
   return withFileLock(lockPath, callback);
+}
+
+async function canonicalizeBaselinePath(path) {
+  let current = dirname(resolve(path));
+  const suffix = [basename(path)];
+  while (true) {
+    try {
+      return join(await realpath(current), ...suffix);
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+      const parent = dirname(current);
+      if (parent === current) {
+        return resolve(path);
+      }
+      suffix.unshift(basename(current));
+      current = parent;
+    }
+  }
 }
 
 async function ensurePrivateLockDirectory(path) {

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -1,9 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
 import { chmod, lstat, mkdir, open, readFile, readlink, rename, rm, stat } from "node:fs/promises";
-import { userInfo } from "node:os";
 import { dirname, join, posix, resolve, win32 } from "node:path";
 import { withFileLock } from "../file-lock.mjs";
-import { baselinesDir } from "../paths.mjs";
+import { baselinesDir, kovaHome } from "../paths.mjs";
 import {
   DEFAULT_REGRESSION_THRESHOLDS,
   PERFORMANCE_METRICS,
@@ -112,8 +111,13 @@ export async function withBaselineStoreLock(path, callback) {
   const writePath = await resolveBaselineWritePath(path);
   // The canonical path stays stable across the first create and every later
   // replacement; inode-based keys would let old and new waiters split locks.
-  const identity = createHash("sha256").update(resolve(writePath)).digest("hex");
-  const lockRoot = join(userInfo().homedir, ".kova", "locks", "baselines");
+  // Folding case and Unicode only over-serializes distinct files on a
+  // case-sensitive volume, while preventing aliases from splitting the lock.
+  const canonicalPath = resolve(writePath).normalize("NFC").toLowerCase();
+  const identity = createHash("sha256").update(canonicalPath).digest("hex");
+  // Baseline stores are per-user Kova state; following KOVA_HOME keeps every
+  // supported writer in one namespace and works in redirected sandboxes.
+  const lockRoot = join(kovaHome, "locks", "baselines");
   await ensurePrivateLockDirectory(lockRoot);
   const lockPath = join(lockRoot, `${identity}.lock`);
   return withFileLock(lockPath, callback);

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -110,7 +110,16 @@ export async function saveBaselineStore(path, store) {
 
 export async function withBaselineStoreLock(path, callback) {
   const writePath = await resolveBaselineWritePath(path);
-  const identity = createHash("sha256").update(resolve(writePath)).digest("hex");
+  const metadata = await stat(writePath).catch((error) => {
+    if (error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+  const lockIdentity = metadata
+    ? `inode:${metadata.dev}:${metadata.ino}`
+    : `path:${resolve(writePath)}`;
+  const identity = createHash("sha256").update(lockIdentity).digest("hex");
   const user = typeof process.getuid === "function" ? process.getuid() : "user";
   const lockPath = join(tmpdir(), `kova-baseline-locks-${user}`, `${identity}.lock`);
   return withFileLock(lockPath, callback);

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
-import { lstat, mkdir, open, readFile, readlink, rename, rm, stat } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { chmod, lstat, mkdir, open, readFile, readlink, rename, rm, stat } from "node:fs/promises";
+import { userInfo } from "node:os";
 import { dirname, join, posix, resolve, win32 } from "node:path";
 import { withFileLock } from "../file-lock.mjs";
 import { baselinesDir } from "../paths.mjs";
@@ -113,9 +113,24 @@ export async function withBaselineStoreLock(path, callback) {
   // The canonical path stays stable across the first create and every later
   // replacement; inode-based keys would let old and new waiters split locks.
   const identity = createHash("sha256").update(resolve(writePath)).digest("hex");
-  const user = typeof process.getuid === "function" ? process.getuid() : "user";
-  const lockPath = join(tmpdir(), `kova-baseline-locks-${user}`, `${identity}.lock`);
+  const lockRoot = join(userInfo().homedir, ".kova", "locks", "baselines");
+  await ensurePrivateLockDirectory(lockRoot);
+  const lockPath = join(lockRoot, `${identity}.lock`);
   return withFileLock(lockPath, callback);
+}
+
+async function ensurePrivateLockDirectory(path) {
+  await mkdir(path, { recursive: true, mode: 0o700 });
+  const info = await lstat(path);
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error(`Kova baseline lock path must be a real directory: ${path}`);
+  }
+  if (typeof process.getuid === "function" && info.uid !== process.getuid()) {
+    throw new Error(`Kova baseline lock directory is not owned by the current user: ${path}`);
+  }
+  if (process.platform !== "win32" && (info.mode & 0o077) !== 0) {
+    await chmod(path, 0o700);
+  }
 }
 
 function baselineSaveReceipt(path, output) {

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -124,8 +124,10 @@ export async function withBaselineStoreLock(path, callback) {
     dirname(canonicalPath),
     `.kova-baseline-${identity}.lock`
   );
-  // The lock shares the baseline store's filesystem so every host and user
-  // participating in the same store observes one RMW serialization point.
+  // Colocation serializes shared-filesystem writers, but foreign-owner locks
+  // fail closed. After a remote crash, an operator must verify owner death
+  // before removing the lock; portable filesystem primitives cannot fence a
+  // resumed stale writer safely.
   return withFileLock(lockPath, callback, { fileMode: 0o644 });
 }
 

--- a/src/performance/baselines.mjs
+++ b/src/performance/baselines.mjs
@@ -1,6 +1,8 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { lstat, mkdir, open, readFile, readlink, rename, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join, posix, resolve, win32 } from "node:path";
+import { withFileLock } from "../file-lock.mjs";
 import { baselinesDir } from "../paths.mjs";
 import {
   DEFAULT_REGRESSION_THRESHOLDS,
@@ -104,6 +106,14 @@ export async function saveBaselineStore(path, store) {
     await rm(tempPath, { force: true });
   }
   return baselineSaveReceipt(path, output);
+}
+
+export async function withBaselineStoreLock(path, callback) {
+  const writePath = await resolveBaselineWritePath(path);
+  const identity = createHash("sha256").update(resolve(writePath)).digest("hex");
+  const user = typeof process.getuid === "function" ? process.getuid() : "user";
+  const lockPath = join(tmpdir(), `kova-baseline-locks-${user}`, `${identity}.lock`);
+  return withFileLock(lockPath, callback);
 }
 
 function baselineSaveReceipt(path, output) {

--- a/src/reporting/artifact-names.mjs
+++ b/src/reporting/artifact-names.mjs
@@ -1,0 +1,13 @@
+import { createHash } from "node:crypto";
+
+export function artifactRunIdSegment(value) {
+  const runId = String(value);
+  if (isCanonicalRunId(runId)) {
+    return runId;
+  }
+  return `external-${createHash("sha256").update(runId).digest("hex").slice(0, 24)}`;
+}
+
+export function isCanonicalRunId(value) {
+  return /^kova-\d{6}-\d{6}-[0-9a-f]{6}$/.test(value);
+}

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -191,7 +191,7 @@ async function listFiles(root, dir) {
   return entries;
 }
 
-async function publishBundlePair({ archive, outputPath, checksumPath, checksum }) {
+export async function publishBundlePair({ archive, outputPath, checksumPath, checksum }) {
   const entries = [
     { path: outputPath, content: archive },
     { path: checksumPath, content: checksum }
@@ -208,10 +208,16 @@ async function publishBundlePair({ archive, outputPath, checksumPath, checksum }
     const outputExists = await pathExists(outputPath);
     const checksumExists = await pathExists(checksumPath);
     if (outputExists || checksumExists) {
-      const existing = await readFile(outputPath).catch(() => null);
+      if (outputExists) {
+        await requireRegularFile(outputPath, "existing report bundle");
+      }
+      if (checksumExists) {
+        await requireRegularFile(checksumPath, "existing report bundle checksum");
+      }
+      const existing = outputExists ? await readFile(outputPath) : null;
       const existingHash = existing ? createHash("sha256").update(existing).digest("hex") : null;
       const expectedHash = createHash("sha256").update(archive).digest("hex");
-      const existingChecksum = await readFile(checksumPath, "utf8").catch(() => null);
+      const existingChecksum = checksumExists ? await readFile(checksumPath, "utf8") : null;
       if (existingHash !== expectedHash || (existingChecksum !== null && existingChecksum !== checksum)) {
         throw new Error(`bundle destination collision: ${outputPath}`);
       }

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -415,7 +415,7 @@ async function writeDurableFile(path, content) {
 async function requireRegularFile(path, label) {
   let info;
   try {
-    info = await stat(path);
+    info = await lstat(path);
   } catch (error) {
     if (error?.code === "ENOENT") {
       throw new Error(`${label} is missing: ${path}`);

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -251,7 +251,6 @@ async function replaceRetainedArtifactTree({
   const stage = join(parent, `.${basename(outputRoot)}.${transaction}.tmp`);
   const backup = join(parent, `.${basename(outputRoot)}.${transaction}.bak`);
   let oldTreeBackedUp = false;
-  let newTreePublished = false;
   let preserveBackup = false;
 
   try {
@@ -294,15 +293,14 @@ async function replaceRetainedArtifactTree({
       oldTreeBackedUp = true;
     }
     await rename(stage, outputRoot);
-    newTreePublished = true;
-    await rm(backup, { recursive: true, force: true });
+    // Publication commits at the directory rename. Cleanup cannot safely
+    // restore a backup once recursive deletion may have started.
     oldTreeBackedUp = false;
+    preserveBackup = true;
+    await rm(backup, { recursive: true, force: true }).catch(() => {});
     return receipt;
   } catch (error) {
     const rollbackErrors = [];
-    if (newTreePublished) {
-      await rm(outputRoot, { recursive: true, force: true }).catch((rollbackError) => rollbackErrors.push(rollbackError));
-    }
     if (oldTreeBackedUp) {
       await rename(backup, outputRoot).catch((rollbackError) => rollbackErrors.push(rollbackError));
     }

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { withFileLock } from "../file-lock.mjs";
 import { artifactsDir } from "../paths.mjs";
+import { artifactRunIdSegment, isCanonicalRunId } from "./artifact-names.mjs";
 import { renderPasteSummary } from "./report.mjs";
 
 const RESERVED_RETAINED_FILENAMES = new Set([
@@ -26,7 +27,7 @@ export async function bundleReport(reportPath, options = {}) {
   const outputRoot = options.outputDir ? resolve(options.outputDir) : join(artifactsDir, "bundles");
   await mkdir(outputRoot, { recursive: true });
 
-  const bundleName = `${safeRunIdSegment(runId)}-bundle`;
+  const bundleName = `${artifactRunIdSegment(runId)}-bundle`;
   const tmp = await mkdtemp(join(tmpdir(), "kova-artifact-bundle-"));
   const stage = join(tmp, bundleName);
   const stagedArchivePath = join(tmp, `${bundleName}.tar.gz`);
@@ -127,7 +128,7 @@ export async function retainGateArtifacts(reportPath, bundle, options = {}) {
 
   const outputRoot = options.outputDir
     ? resolve(options.outputDir)
-    : join(artifactsDir, "release-gates", safeRunIdSegment(report.runId));
+    : join(artifactsDir, "release-gates", artifactRunIdSegment(report.runId));
   await mkdir(dirname(outputRoot), { recursive: true });
 
   const hasBundle = Boolean(bundle?.outputPath);
@@ -171,14 +172,6 @@ function siblingMarkdownPath(path) {
   return join(dirname(path), `${base}.md`);
 }
 
-function safeRunIdSegment(value) {
-  const runId = String(value);
-  if (isCanonicalRunId(runId)) {
-    return runId;
-  }
-  return `external-${createHash("sha256").update(runId).digest("hex").slice(0, 24)}`;
-}
-
 function portableRetentionFilenameKey(value) {
   if (
     !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value) ||
@@ -188,10 +181,6 @@ function portableRetentionFilenameKey(value) {
     throw new Error("retained report bundle filenames must use portable filenames");
   }
   return value.toLowerCase();
-}
-
-function isCanonicalRunId(value) {
-  return /^kova-\d{6}-\d{6}-[0-9a-f]{6}$/.test(value);
 }
 
 async function buildArtifactIndex(stage, bundleName) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -348,10 +348,7 @@ async function replaceRetainedArtifactTree({
     // restore a backup once recursive deletion may have started.
     oldTreeBackedUp = false;
     newTreePublished = false;
-    await rm(backup, { recursive: true, force: true })
-      .then(() => rm(backupMarker, { force: true }))
-      .then(() => syncDirectory(parent))
-      .catch(() => {});
+    await removeRetainedBackup(backup, backupMarker, parent).catch(() => {});
     return receipt;
   } catch (error) {
     const rollbackErrors = [];
@@ -361,9 +358,7 @@ async function replaceRetainedArtifactTree({
         .catch((rollbackError) => rollbackErrors.push(rollbackError));
     }
     if (oldTreeBackedUp) {
-      await rename(backup, outputRoot)
-        .then(() => rm(backupMarker, { force: true }))
-        .then(() => syncDirectory(parent))
+      await restoreRetainedBackup(backup, outputRoot, backupMarker, parent)
         .catch((rollbackError) => rollbackErrors.push(rollbackError));
     }
     if (rollbackErrors.length > 0) {
@@ -386,27 +381,41 @@ async function recoverRetainedArtifactTree(outputRoot, backup, backupMarker) {
   await requireOwnedBackupMarker(backupMarker, outputRoot);
   if (!await pathExists(outputRoot)) {
     await assertManagedRetentionDirectory(backup, outputRoot);
-    await rename(backup, outputRoot);
-    await rm(backupMarker, { force: true });
-    await syncDirectory(dirname(outputRoot));
+    await restoreRetainedBackup(backup, outputRoot, backupMarker, dirname(outputRoot));
     return;
   }
   await assertManagedRetentionDirectory(outputRoot);
+  let currentComplete = true;
   try {
     await assertManagedRetentionDirectory(outputRoot, outputRoot, true);
-    await rm(backup, { recursive: true });
-    await rm(backupMarker, { force: true });
-    await syncDirectory(dirname(outputRoot));
-    return;
   } catch {
+    currentComplete = false;
     // The current tree is Kova-managed but incomplete; restore the prior
     // committed tree only after proving the backup is valid.
   }
+  if (currentComplete) {
+    await removeRetainedBackup(backup, backupMarker, dirname(outputRoot));
+    return;
+  }
   await assertManagedRetentionDirectory(backup, outputRoot);
   await rm(outputRoot, { recursive: true });
-  await rename(backup, outputRoot);
+  await restoreRetainedBackup(backup, outputRoot, backupMarker, dirname(outputRoot));
+}
+
+async function removeRetainedBackup(backup, backupMarker, parent) {
+  // The owner marker must outlive the backup directory on durable storage.
+  // Recovery rejects a backup whose marker disappeared first.
+  await rm(backup, { recursive: true, force: true });
+  await syncDirectory(parent);
   await rm(backupMarker, { force: true });
-  await syncDirectory(dirname(outputRoot));
+  await syncDirectory(parent);
+}
+
+async function restoreRetainedBackup(backup, outputRoot, backupMarker, parent) {
+  await rename(backup, outputRoot);
+  await syncDirectory(parent);
+  await rm(backupMarker, { force: true });
+  await syncDirectory(parent);
 }
 
 async function requireOwnedBackupMarker(path, outputRoot) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants, createReadStream, createWriteStream } from "node:fs";
 import { cp, lstat, mkdir, open, readFile, readdir, realpath, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { createGzip } from "node:zlib";
 import { pack as packTar } from "tar-stream";
@@ -1509,9 +1509,18 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function pathIsAtOrBelow(path, root) {
-  const child = relative(resolve(root), resolve(path));
-  return child === "" || (child !== ".." && !child.startsWith(`..${sep}`));
+export function pathIsAtOrBelow(path, root, pathApi = {
+  isAbsolute,
+  relative,
+  resolve,
+  sep
+}) {
+  const child = pathApi.relative(pathApi.resolve(root), pathApi.resolve(path));
+  return child === "" || (
+    !pathApi.isAbsolute(child) &&
+    child !== ".." &&
+    !child.startsWith(`..${pathApi.sep}`)
+  );
 }
 
 async function requireRegularFile(path, label) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -284,6 +284,7 @@ async function replaceRetainedArtifactTree({
   const stage = join(parent, `.${basename(outputRoot)}.${transaction}.tmp`);
   const backup = join(parent, `.${basename(outputRoot)}.bak`);
   let oldTreeBackedUp = false;
+  let newTreePublished = false;
 
   try {
     await recoverRetainedArtifactTree(outputRoot, backup);
@@ -336,16 +337,23 @@ async function replaceRetainedArtifactTree({
       await syncDirectory(parent);
     }
     await rename(stage, outputRoot);
+    newTreePublished = true;
     await syncDirectory(parent);
     // Publication commits at the directory rename. Cleanup cannot safely
     // restore a backup once recursive deletion may have started.
     oldTreeBackedUp = false;
+    newTreePublished = false;
     await rm(backup, { recursive: true, force: true })
       .then(() => syncDirectory(parent))
       .catch(() => {});
     return receipt;
   } catch (error) {
     const rollbackErrors = [];
+    if (newTreePublished) {
+      await rm(outputRoot, { recursive: true, force: true })
+        .then(() => syncDirectory(parent))
+        .catch((rollbackError) => rollbackErrors.push(rollbackError));
+    }
     if (oldTreeBackedUp) {
       await rename(backup, outputRoot)
         .then(() => syncDirectory(parent))
@@ -393,6 +401,9 @@ async function assertManagedRetentionDirectory(path, expectedOutputRoot = path, 
   }
   const entries = await readdir(path);
   if (entries.length === 0) {
+    if (requireComplete) {
+      throw new Error(`retained artifact destination is incomplete: ${path}`);
+    }
     return;
   }
   const receiptPath = join(path, "retained-artifacts.json");

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { chmod, cp, lstat, mkdir, mkdtemp, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, cp, lstat, mkdir, mkdtemp, open, readFile, readdir, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { withFileLock } from "../file-lock.mjs";
@@ -353,10 +353,13 @@ async function replaceRetainedArtifactTree({
 
     if (await pathExists(outputRoot)) {
       const treeSha256 = await retainedArtifactTreeDigest(outputRoot);
+      const claimId = randomUUID();
       await writeDurableMarker(backupMarker, `${JSON.stringify({
-        schemaVersion: "kova.retainedArtifactBackup.v2",
+        schemaVersion: "kova.retainedArtifactBackup.v3",
         outputRoot,
-        treeSha256
+        treeSha256,
+        claimId,
+        phase: "pending"
       })}\n`);
       await rename(outputRoot, backup);
       oldTreeBackedUp = true;
@@ -388,20 +391,39 @@ async function replaceRetainedArtifactTree({
     throw error;
   } finally {
     await rm(stage, { recursive: true, force: true });
-    if (!await pathExists(backup)) {
-      await removeOwnedBackupMarker(backupMarker, outputRoot);
-    }
+    await removeUnusedRetainedBackupMarker(backup, backupMarker, outputRoot);
   }
 }
 
 async function recoverRetainedArtifactTree(outputRoot, backup, backupMarker) {
-  if (!await pathExists(backup)) {
+  const marker = await readRetainedBackupMarker(backupMarker, outputRoot);
+  if (!marker) {
+    if (await retainedBackupStateExists(backup)) {
+      throw new Error(`retained artifact backup is not Kova-managed: ${backup}`);
+    }
+    return;
+  }
+  const claimedBackup = await claimRetainedBackup(backup, marker, outputRoot, dirname(outputRoot));
+  if (!claimedBackup) {
     await removeOwnedBackupMarker(backupMarker, outputRoot);
     return;
   }
-  await requireRetainedBackup(backup, backupMarker, outputRoot);
+  if (claimedBackup.empty) {
+    await assertCompletedRetainedClaim(outputRoot, claimedBackup);
+    await removeEmptyRetainedClaim(claimedBackup.container, backupMarker, dirname(outputRoot));
+    return;
+  }
+  if (claimedBackup.partial) {
+    await finishRetainedClaimCleanup(claimedBackup, backupMarker, dirname(outputRoot));
+    return;
+  }
   if (!await pathExists(outputRoot)) {
-    await restoreRetainedBackup(backup, outputRoot, backupMarker, dirname(outputRoot));
+    await restoreClaimedRetainedBackup(
+      claimedBackup,
+      outputRoot,
+      backupMarker,
+      dirname(outputRoot)
+    );
     return;
   }
   await assertManagedRetentionDirectory(outputRoot);
@@ -414,33 +436,96 @@ async function recoverRetainedArtifactTree(outputRoot, backup, backupMarker) {
     // committed tree only after proving the backup is valid.
   }
   if (currentComplete) {
-    await removeRetainedBackup(backup, backupMarker, outputRoot, dirname(outputRoot));
+    await removeClaimedRetainedBackup(
+      claimedBackup,
+      backupMarker,
+      dirname(outputRoot)
+    );
     return;
   }
   await rm(outputRoot, { recursive: true });
-  await restoreRetainedBackup(backup, outputRoot, backupMarker, dirname(outputRoot));
+  await restoreClaimedRetainedBackup(
+    claimedBackup,
+    outputRoot,
+    backupMarker,
+    dirname(outputRoot)
+  );
 }
 
 async function removeRetainedBackup(backup, backupMarker, outputRoot, parent) {
-  if (!await pathExists(backup)) {
+  const marker = await readRetainedBackupMarker(backupMarker, outputRoot);
+  if (!marker) {
+    if (await retainedBackupStateExists(backup)) {
+      throw new Error(`retained artifact backup is not Kova-managed: ${backup}`);
+    }
+    return;
+  }
+  const claimedBackup = await claimRetainedBackup(backup, marker, outputRoot, parent);
+  if (!claimedBackup) {
     await removeOwnedBackupMarker(backupMarker, outputRoot);
     return;
   }
-  await requireRetainedBackup(backup, backupMarker, outputRoot);
+  if (claimedBackup.empty) {
+    await assertCompletedRetainedClaim(outputRoot, claimedBackup);
+    await removeEmptyRetainedClaim(claimedBackup.container, backupMarker, parent);
+    return;
+  }
+  if (claimedBackup.partial) {
+    await finishRetainedClaimCleanup(claimedBackup, backupMarker, parent);
+    return;
+  }
+  await removeClaimedRetainedBackup(claimedBackup, backupMarker, parent);
+}
+
+async function removeClaimedRetainedBackup(claimedBackup, backupMarker, parent) {
   // The owner marker must outlive the backup directory on durable storage.
   // Recovery rejects a backup whose marker disappeared first.
-  await rm(backup, { recursive: true, force: true });
+  await validateClaimedRetainedBackup(claimedBackup);
+  await assertManagedRetentionDirectory(claimedBackup.outputRoot, claimedBackup.outputRoot, true);
+  await writeRetainedBackupPhase(backupMarker, claimedBackup.marker, "cleanup");
+  await finishRetainedClaimCleanup(claimedBackup, backupMarker, parent);
+}
+
+async function restoreRetainedBackup(backup, outputRoot, backupMarker, parent) {
+  const marker = await requireOwnedBackupMarker(backupMarker, outputRoot);
+  const claimedBackup = await claimRetainedBackup(backup, marker, outputRoot, parent);
+  if (!claimedBackup) {
+    throw new Error(`retained artifact backup is missing: ${backup}`);
+  }
+  if (claimedBackup.empty) {
+    await assertCompletedRetainedClaim(outputRoot, claimedBackup);
+    await removeEmptyRetainedClaim(claimedBackup.container, backupMarker, parent);
+    return;
+  }
+  if (claimedBackup.partial) {
+    await finishRetainedClaimCleanup(claimedBackup, backupMarker, parent);
+    return;
+  }
+  await restoreClaimedRetainedBackup(claimedBackup, outputRoot, backupMarker, parent);
+}
+
+async function restoreClaimedRetainedBackup(claimedBackup, outputRoot, backupMarker, parent) {
+  await validateClaimedRetainedBackup(claimedBackup);
+  await rename(claimedBackup.path, outputRoot);
+  await rmdir(claimedBackup.container);
   await syncDirectory(parent);
   await rm(backupMarker, { force: true });
   await syncDirectory(parent);
 }
 
-async function restoreRetainedBackup(backup, outputRoot, backupMarker, parent) {
-  await requireRetainedBackup(backup, backupMarker, outputRoot);
-  await rename(backup, outputRoot);
+async function removeEmptyRetainedClaim(claimContainer, backupMarker, parent) {
+  await assertEmptyRetainedClaimContainer(claimContainer);
+  await rmdir(claimContainer);
   await syncDirectory(parent);
   await rm(backupMarker, { force: true });
   await syncDirectory(parent);
+}
+
+async function readRetainedBackupMarker(path, outputRoot) {
+  if (!await pathExists(path)) {
+    return null;
+  }
+  return requireOwnedBackupMarker(path, outputRoot);
 }
 
 async function requireOwnedBackupMarker(path, outputRoot) {
@@ -455,25 +540,158 @@ async function requireOwnedBackupMarker(path, outputRoot) {
     throw new Error(`retained artifact backup is not Kova-managed: ${path}`);
   }
   if (
-    marker?.schemaVersion !== "kova.retainedArtifactBackup.v2" ||
+    marker?.schemaVersion !== "kova.retainedArtifactBackup.v3" ||
     resolve(marker.outputRoot ?? "") !== resolve(outputRoot) ||
-    !/^[a-f0-9]{64}$/.test(marker.treeSha256 ?? "")
+    !/^[a-f0-9]{64}$/.test(marker.treeSha256 ?? "") ||
+    !/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/.test(
+      marker.claimId ?? ""
+    ) ||
+    !["pending", "cleanup"].includes(marker.phase)
   ) {
     throw new Error(`retained artifact backup is not Kova-managed: ${path}`);
   }
   return marker;
 }
 
-async function requireRetainedBackup(backup, backupMarker, outputRoot) {
-  const marker = await requireOwnedBackupMarker(backupMarker, outputRoot);
+async function claimRetainedBackup(backup, marker, outputRoot, parent) {
+  const claimContainer = retainedBackupClaimContainer(backup, marker);
+  const claimPath = join(claimContainer, "tree");
+  const backupExists = await pathExists(backup);
+  const containerExists = await pathExists(claimContainer);
+  if (!backupExists && !containerExists) {
+    return null;
+  }
+  if (!containerExists) {
+    await mkdir(claimContainer, { recursive: false, mode: 0o700 });
+    await syncDirectory(parent);
+  }
+  await assertRetainedClaimContainer(claimContainer);
+  const claimExists = await pathExists(claimPath);
+  if (backupExists && claimExists) {
+    throw new Error(`retained artifact backup has a conflicting replacement: ${backup}`);
+  }
+  if (!backupExists && !claimExists) {
+    return {
+      container: claimContainer,
+      path: null,
+      empty: true,
+      outputRoot,
+      treeSha256: marker.treeSha256
+    };
+  }
+  if (backupExists) {
+    await rename(backup, claimPath);
+    await syncDirectory(claimContainer);
+    await syncDirectory(parent);
+  }
   try {
-    await assertManagedRetentionDirectory(backup, outputRoot);
-    if (await retainedArtifactTreeDigest(backup) !== marker.treeSha256) {
+    await assertManagedRetentionDirectory(claimPath, outputRoot);
+    if (await retainedArtifactTreeDigest(claimPath) !== marker.treeSha256) {
       throw new Error("tree digest mismatch");
     }
   } catch {
-    throw new Error(`retained artifact backup is not Kova-managed: ${backup}`);
+    if (marker.phase === "cleanup") {
+      return {
+        container: claimContainer,
+        path: claimPath,
+        empty: false,
+        partial: true,
+        outputRoot,
+        treeSha256: marker.treeSha256,
+        marker
+      };
+    }
+    throw new Error(`retained artifact backup is not Kova-managed: ${claimPath}`);
   }
+  return {
+    container: claimContainer,
+    path: claimPath,
+    empty: false,
+    partial: false,
+    outputRoot,
+    treeSha256: marker.treeSha256,
+    marker
+  };
+}
+
+function retainedBackupClaimContainer(backup, marker) {
+  return `${backup}.claim-${marker.claimId}`;
+}
+
+async function assertRetainedClaimContainer(path) {
+  const info = await lstat(path);
+  if (!info.isDirectory()) {
+    throw new Error(`retained artifact backup claim is invalid: ${path}`);
+  }
+  const names = await readdir(path);
+  if (names.some((name) => name !== "tree")) {
+    throw new Error(`retained artifact backup claim is invalid: ${path}`);
+  }
+}
+
+async function assertEmptyRetainedClaimContainer(path) {
+  await assertRetainedClaimContainer(path);
+  if ((await readdir(path)).length !== 0) {
+    throw new Error(`retained artifact backup claim is not empty: ${path}`);
+  }
+}
+
+async function validateClaimedRetainedBackup(claimedBackup) {
+  // The 0700 claim container and retention lock exclude peer Kova writers.
+  // Revalidate immediately before mutation; same-user hostile writers are outside the trust boundary.
+  await assertRetainedClaimContainer(claimedBackup.container);
+  try {
+    await assertManagedRetentionDirectory(claimedBackup.path, claimedBackup.outputRoot);
+    if (await retainedArtifactTreeDigest(claimedBackup.path) !== claimedBackup.treeSha256) {
+      throw new Error("tree digest mismatch");
+    }
+  } catch {
+    throw new Error(`retained artifact backup is not Kova-managed: ${claimedBackup.path}`);
+  }
+}
+
+async function assertCompletedRetainedClaim(outputRoot, claimedBackup) {
+  if (!await pathExists(outputRoot)) {
+    throw new Error(`retained artifact backup claim is incomplete: ${claimedBackup.container}`);
+  }
+  try {
+    if (await retainedArtifactTreeDigest(outputRoot) === claimedBackup.treeSha256) {
+      return;
+    }
+  } catch {
+    // A different current tree still qualifies if it is a complete committed generation.
+  }
+  await assertManagedRetentionDirectory(outputRoot, outputRoot, true);
+}
+
+async function writeRetainedBackupPhase(path, marker, phase) {
+  await writeDurableMarker(path, `${JSON.stringify({ ...marker, phase })}\n`);
+}
+
+async function finishRetainedClaimCleanup(claimedBackup, backupMarker, parent) {
+  if (!await pathExists(claimedBackup.outputRoot)) {
+    throw new Error(`retained artifact cleanup is missing current tree: ${claimedBackup.outputRoot}`);
+  }
+  await assertManagedRetentionDirectory(
+    claimedBackup.outputRoot,
+    claimedBackup.outputRoot,
+    true
+  );
+  await assertRetainedClaimContainer(claimedBackup.container);
+  await rm(claimedBackup.path, { recursive: true, force: true });
+  await rmdir(claimedBackup.container);
+  await syncDirectory(parent);
+  await rm(backupMarker, { force: true });
+  await syncDirectory(parent);
+}
+
+async function retainedBackupStateExists(backup) {
+  if (await pathExists(backup)) {
+    return true;
+  }
+  const names = await readdir(dirname(backup));
+  const prefix = `${basename(backup)}.claim-`;
+  return names.some((name) => name.startsWith(prefix));
 }
 
 async function removeOwnedBackupMarker(path, outputRoot) {
@@ -483,6 +701,20 @@ async function removeOwnedBackupMarker(path, outputRoot) {
   await requireOwnedBackupMarker(path, outputRoot);
   await rm(path, { force: true });
   await syncDirectory(dirname(path));
+}
+
+async function removeUnusedRetainedBackupMarker(backup, backupMarker, outputRoot) {
+  const marker = await readRetainedBackupMarker(backupMarker, outputRoot);
+  if (!marker) {
+    return;
+  }
+  if (
+    await pathExists(backup) ||
+    await pathExists(retainedBackupClaimContainer(backup, marker))
+  ) {
+    return;
+  }
+  await removeOwnedBackupMarker(backupMarker, outputRoot);
 }
 
 async function assertManagedRetentionDirectory(path, expectedOutputRoot = path, requireComplete = false) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -285,11 +285,12 @@ async function replaceRetainedArtifactTree({
   const transaction = randomUUID();
   const stage = join(parent, `.${basename(outputRoot)}.${transaction}.tmp`);
   const backup = join(parent, `.${basename(outputRoot)}.bak`);
+  const backupMarker = `${backup}.owner`;
   let oldTreeBackedUp = false;
   let newTreePublished = false;
 
   try {
-    await recoverRetainedArtifactTree(outputRoot, backup);
+    await recoverRetainedArtifactTree(outputRoot, backup, backupMarker);
     await assertManagedRetentionDirectory(outputRoot);
     await mkdir(stage, { recursive: false, mode: 0o700 });
     await writeDurableFile(join(stage, "report.json"), sourceJson);
@@ -332,6 +333,11 @@ async function replaceRetainedArtifactTree({
     await syncDirectory(stage);
 
     if (await pathExists(outputRoot)) {
+      await writeDurableFile(backupMarker, `${JSON.stringify({
+        schemaVersion: "kova.retainedArtifactBackup.v1",
+        outputRoot
+      })}\n`);
+      await syncDirectory(parent);
       await rename(outputRoot, backup);
       oldTreeBackedUp = true;
       await syncDirectory(parent);
@@ -344,6 +350,7 @@ async function replaceRetainedArtifactTree({
     oldTreeBackedUp = false;
     newTreePublished = false;
     await rm(backup, { recursive: true, force: true })
+      .then(() => rm(backupMarker, { force: true }))
       .then(() => syncDirectory(parent))
       .catch(() => {});
     return receipt;
@@ -356,6 +363,7 @@ async function replaceRetainedArtifactTree({
     }
     if (oldTreeBackedUp) {
       await rename(backup, outputRoot)
+        .then(() => rm(backupMarker, { force: true }))
         .then(() => syncDirectory(parent))
         .catch((rollbackError) => rollbackErrors.push(rollbackError));
     }
@@ -365,16 +373,22 @@ async function replaceRetainedArtifactTree({
     throw error;
   } finally {
     await rm(stage, { recursive: true, force: true });
+    if (!await pathExists(backup)) {
+      await removeOwnedBackupMarker(backupMarker, outputRoot);
+    }
   }
 }
 
-async function recoverRetainedArtifactTree(outputRoot, backup) {
+async function recoverRetainedArtifactTree(outputRoot, backup, backupMarker) {
   if (!await pathExists(backup)) {
+    await removeOwnedBackupMarker(backupMarker, outputRoot);
     return;
   }
+  await requireOwnedBackupMarker(backupMarker, outputRoot);
   if (!await pathExists(outputRoot)) {
     await assertManagedRetentionDirectory(backup, outputRoot);
     await rename(backup, outputRoot);
+    await rm(backupMarker, { force: true });
     await syncDirectory(dirname(outputRoot));
     return;
   }
@@ -382,6 +396,7 @@ async function recoverRetainedArtifactTree(outputRoot, backup) {
   try {
     await assertManagedRetentionDirectory(outputRoot, outputRoot, true);
     await rm(backup, { recursive: true });
+    await rm(backupMarker, { force: true });
     await syncDirectory(dirname(outputRoot));
     return;
   } catch {
@@ -391,7 +406,36 @@ async function recoverRetainedArtifactTree(outputRoot, backup) {
   await assertManagedRetentionDirectory(backup, outputRoot);
   await rm(outputRoot, { recursive: true });
   await rename(backup, outputRoot);
+  await rm(backupMarker, { force: true });
   await syncDirectory(dirname(outputRoot));
+}
+
+async function requireOwnedBackupMarker(path, outputRoot) {
+  let marker;
+  try {
+    const info = await lstat(path);
+    if (!info.isFile()) {
+      throw new Error("not a regular file");
+    }
+    marker = JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    throw new Error(`retained artifact backup is not Kova-managed: ${path}`);
+  }
+  if (
+    marker?.schemaVersion !== "kova.retainedArtifactBackup.v1" ||
+    resolve(marker.outputRoot ?? "") !== resolve(outputRoot)
+  ) {
+    throw new Error(`retained artifact backup is not Kova-managed: ${path}`);
+  }
+}
+
+async function removeOwnedBackupMarker(path, outputRoot) {
+  if (!await pathExists(path)) {
+    return;
+  }
+  await requireOwnedBackupMarker(path, outputRoot);
+  await rm(path, { force: true });
+  await syncDirectory(dirname(path));
 }
 
 async function assertManagedRetentionDirectory(path, expectedOutputRoot = path, requireComplete = false) {
@@ -481,6 +525,15 @@ async function syncDirectory(path) {
   if (process.platform === "win32") {
     return;
   }
+  const handle = await open(path, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function syncFile(path) {
   const handle = await open(path, "r");
   try {
     await handle.sync();

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants, createReadStream, createWriteStream } from "node:fs";
-import { cp, lstat, mkdir, open, readFile, readdir, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
+import { cp, lstat, mkdir, open, readFile, readdir, realpath, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
@@ -10,6 +10,16 @@ import { withFileLock } from "../file-lock.mjs";
 import { artifactsDir } from "../paths.mjs";
 import { reportTransactionLockPath } from "../run/report-output.mjs";
 import { artifactRunIdSegment, isCanonicalRunId } from "./artifact-names.mjs";
+import {
+  MAX_BUNDLE_ANCESTORS,
+  MAX_BUNDLE_CHECKSUM_BYTES,
+  MAX_BUNDLE_COMPRESSED_BYTES,
+  MAX_BUNDLE_DECLARED_BYTES,
+  MAX_BUNDLE_ENTRIES,
+  MAX_BUNDLE_NAME_BYTES,
+  MAX_BUNDLE_UNPACKED_BYTES,
+  normalizeArchiveMember
+} from "./bundle-contract.mjs";
 import { renderPasteSummary } from "./report.mjs";
 
 const RESERVED_RETAINED_FILENAMES = new Set([
@@ -18,9 +28,6 @@ const RESERVED_RETAINED_FILENAMES = new Set([
   "report.md",
   "retained-artifacts.json"
 ]);
-const MAX_BUNDLE_ARCHIVE_BYTES = 256 * 1024 * 1024;
-const MAX_BUNDLE_CHECKSUM_BYTES = 8 * 1024;
-const MAX_USTAR_FILE_BYTES = 0o77777777777;
 const FILE_READ_CHUNK_BYTES = 1024 * 1024;
 const READ_ONLY_NONBLOCK =
   fsConstants.O_RDONLY |
@@ -84,7 +91,26 @@ export async function bundleReport(reportPath, options = {}) {
         ? join(sourceArtifactsRoot, runId)
         : null;
       if (runArtifactsPath && await directoryExists(runArtifactsPath)) {
-        await cp(runArtifactsPath, join(stage, "artifacts"), { recursive: true });
+        const [canonicalOutputRoot, canonicalRunArtifactsPath] = await Promise.all([
+          realpath(outputRoot),
+          realpath(runArtifactsPath)
+        ]);
+        if (canonicalOutputRoot === canonicalRunArtifactsPath) {
+          throw new Error("report bundle output directory cannot replace the run artifact root");
+        }
+        const excludesOutputRoot = pathIsAtOrBelow(
+          canonicalOutputRoot,
+          canonicalRunArtifactsPath
+        );
+        await cp(runArtifactsPath, join(stage, "artifacts"), {
+          recursive: true,
+          filter: excludesOutputRoot
+            ? async (source) => !pathIsAtOrBelow(
+              await realpath(source),
+              canonicalOutputRoot
+            )
+            : undefined
+        });
         included.runArtifacts = true;
       }
 
@@ -121,7 +147,7 @@ export async function bundleReport(reportPath, options = {}) {
       const archive = await readStableRegularFile(
         stagedArchivePath,
         "generated report bundle",
-        MAX_BUNDLE_ARCHIVE_BYTES
+        MAX_BUNDLE_COMPRESSED_BYTES
       );
       const sha256 = createHash("sha256").update(archive).digest("hex");
       const outputPath = join(outputRoot, `${bundleName}-${sha256}.tar.gz`);
@@ -228,7 +254,7 @@ function portableRetentionFilenameKey(value) {
 }
 
 async function buildArtifactIndex(stage, bundleName) {
-  const entries = await listFiles(stage, stage, bundleName);
+  const entries = await listBundleFiles(stage, bundleName);
   const totalBytes = entries.reduce((sum, entry) => sum + entry.bytes, 0);
   return {
     schemaVersion: "kova.artifact.index.v1",
@@ -240,27 +266,43 @@ async function buildArtifactIndex(stage, bundleName) {
   };
 }
 
-async function listFiles(root, dir, bundleName) {
+async function listBundleFiles(root, bundleName) {
+  const budget = {
+    entries: 0,
+    declaredBytes: 0,
+    unpackedBytes: 1024
+  };
+  const entries = await listFiles(root, root, budget);
+  return assignArchivePaths(entries, bundleName);
+}
+
+async function listFiles(root, dir, budget) {
   const names = await readdir(dir, { withFileTypes: true });
   const entries = [];
   for (const name of names.toSorted((left, right) => left.name.localeCompare(right.name))) {
     const path = join(dir, name.name);
     if (name.isDirectory()) {
-      entries.push(...await listFiles(root, path, bundleName));
+      entries.push(...await listFiles(root, path, budget));
       continue;
     }
     if (!name.isFile()) {
       throw new Error(`report bundle contains an unsupported filesystem entry: ${path}`);
     }
     const info = await lstat(path);
-    if (info.size > MAX_USTAR_FILE_BYTES) {
-      throw new Error(`report bundle file exceeds the portable USTAR size limit: ${path}`);
+    budget.entries += 1;
+    budget.declaredBytes += info.size;
+    budget.unpackedBytes += 512 + Math.ceil(info.size / 512) * 512;
+    if (
+      budget.entries > MAX_BUNDLE_ENTRIES ||
+      budget.declaredBytes > MAX_BUNDLE_DECLARED_BYTES ||
+      budget.unpackedBytes > MAX_BUNDLE_UNPACKED_BYTES
+    ) {
+      throw new Error(`report bundle content exceeds the publication size limit: ${path}`);
     }
     const metadata = await hashFile(path);
     const bundlePath = relative(root, path).split(sep).join("/");
     entries.push({
       path: bundlePath,
-      archivePath: archivePathFor(bundleName, bundlePath),
       bytes: metadata.bytes,
       sha256: metadata.sha256
     });
@@ -269,8 +311,7 @@ async function listFiles(root, dir, bundleName) {
 }
 
 async function writeUstarArchive(stage, bundleName, destination) {
-  const files = await listFiles(stage, stage, bundleName);
-  const archivePaths = new Set();
+  const files = await listBundleFiles(stage, bundleName);
   const pack = packTar();
   const output = pipeline(
     pack,
@@ -279,10 +320,6 @@ async function writeUstarArchive(stage, bundleName, destination) {
   );
   try {
     for (const file of files) {
-      if (archivePaths.has(file.archivePath)) {
-        throw new Error(`report bundle archive path collision: ${file.archivePath}`);
-      }
-      archivePaths.add(file.archivePath);
       const source = join(stage, ...file.path.split("/"));
       const entry = pack.entry({
         name: `${bundleName}/${file.archivePath}`,
@@ -314,13 +351,114 @@ async function hashFile(path) {
   return { bytes, sha256: hash.digest("hex") };
 }
 
-function archivePathFor(bundleName, bundlePath) {
-  // `mapped/` is owned by the archiver. Remap any future source path that
-  // enters that namespace so original and generated paths cannot collide.
-  if (!bundlePath.startsWith("mapped/") && isUstarPath(`${bundleName}/${bundlePath}`)) {
-    return bundlePath;
+function assignArchivePaths(entries, bundleName) {
+  const destinations = new Map();
+  const requiredDirectories = new Set();
+  const mappedProbe = normalizeArchiveMember(
+    `${bundleName}/mapped/reserved`,
+    "file"
+  );
+  for (const ancestor of archiveAncestors(mappedProbe.portableSegments)) {
+    requiredDirectories.add(ancestor);
   }
-  return `mapped/${createHash("sha256").update(bundlePath).digest("hex")}`;
+  return entries.map((entry) => {
+    const preferred = entry.path.startsWith("mapped/") ? null : entry.path;
+    const archivePath = claimArchivePath(
+      preferred,
+      entry.path,
+      bundleName,
+      destinations,
+      requiredDirectories
+    );
+    return { ...entry, archivePath };
+  });
+}
+
+function claimArchivePath(
+  preferred,
+  originalPath,
+  bundleName,
+  destinations,
+  requiredDirectories
+) {
+  if (
+    preferred &&
+    claimPortableArchivePath(
+      preferred,
+      bundleName,
+      destinations,
+      requiredDirectories
+    )
+  ) {
+    return preferred;
+  }
+  const digest = createHash("sha256").update(originalPath).digest("hex");
+  for (let suffix = 0; ; suffix += 1) {
+    const candidate = `mapped/${digest}${suffix === 0 ? "" : `-${suffix}`}`;
+    if (
+      claimPortableArchivePath(
+        candidate,
+        bundleName,
+        destinations,
+        requiredDirectories
+      )
+    ) {
+      return candidate;
+    }
+  }
+}
+
+function claimPortableArchivePath(
+  archivePath,
+  bundleName,
+  destinations,
+  requiredDirectories
+) {
+  const name = `${bundleName}/${archivePath}`;
+  const normalized = normalizeArchiveMember(name, "file");
+  if (
+    !normalized ||
+    Buffer.byteLength(name) > MAX_BUNDLE_NAME_BYTES ||
+    !isUstarPath(name) ||
+    archiveDestinationConflicts(destinations, requiredDirectories, normalized)
+  ) {
+    return false;
+  }
+  const newAncestors = archiveAncestors(normalized.portableSegments)
+    .filter((ancestor) => !requiredDirectories.has(ancestor));
+  if (
+    requiredDirectories.size + newAncestors.length >
+    MAX_BUNDLE_ANCESTORS
+  ) {
+    return false;
+  }
+  destinations.set(normalized.portablePath, "file");
+  for (const ancestor of newAncestors) {
+    requiredDirectories.add(ancestor);
+  }
+  return true;
+}
+
+function archiveDestinationConflicts(destinations, requiredDirectories, member) {
+  if (destinations.has(member.portablePath)) {
+    return true;
+  }
+  for (const ancestor of archiveAncestors(member.portableSegments)) {
+    if (destinations.get(ancestor) === "file") {
+      return true;
+    }
+  }
+  return requiredDirectories.has(member.portablePath);
+}
+
+function archiveAncestors(segments) {
+  const ancestors = [];
+  let ancestor = segments[0];
+  for (let index = 1; index < segments.length; index += 1) {
+    ancestors.push(ancestor);
+    ancestor += `/${segments[index]}`;
+  }
+  return ancestors;
 }
 
 function isUstarPath(path) {
@@ -392,7 +530,7 @@ async function publishBundlePairLocked({ archive, outputPath, checksumPath, chec
         ? await readStableRegularFile(
           outputPath,
           "existing report bundle",
-          MAX_BUNDLE_ARCHIVE_BYTES
+          MAX_BUNDLE_COMPRESSED_BYTES
         )
         : null;
       const existingHash = existing ? createHash("sha256").update(existing).digest("hex") : null;
@@ -1089,7 +1227,7 @@ async function readVerifiedBundlePair(archivePath, checksumPath) {
     readStableRegularFile(
       archivePath,
       "report bundle",
-      MAX_BUNDLE_ARCHIVE_BYTES
+      MAX_BUNDLE_COMPRESSED_BYTES
     ),
     readStableRegularFile(
       checksumPath,
@@ -1363,6 +1501,11 @@ function isOwnedByCurrentUser(info) {
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function pathIsAtOrBelow(path, root) {
+  const child = relative(resolve(root), resolve(path));
+  return child === "" || (child !== ".." && !child.startsWith(`..${sep}`));
 }
 
 async function requireRegularFile(path, label) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -77,8 +77,9 @@ export async function bundleReport(reportPath, options = {}) {
     const artifactIndex = await buildArtifactIndex(stage, bundleName);
     await writeFile(join(stage, "artifact-index.json"), `${JSON.stringify(artifactIndex, null, 2)}\n`, "utf8");
 
-    const tar = spawnSync("tar", ["-czf", stagedArchivePath, "-C", tmp, bundleName], {
+    const tar = spawnSync("tar", ["--format=ustar", "-czf", stagedArchivePath, "-C", tmp, bundleName], {
       encoding: "utf8",
+      env: { ...process.env, COPYFILE_DISABLE: "1" },
       stdio: ["ignore", "pipe", "pipe"]
     });
     if (tar.status !== 0) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -1,9 +1,9 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { cp, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { cp, lstat, mkdir, mkdtemp, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { withFileLock } from "../file-lock.mjs";
 import { artifactsDir } from "../paths.mjs";
 import { renderPasteSummary } from "./report.mjs";
 
@@ -18,34 +18,31 @@ export async function bundleReport(reportPath, options = {}) {
   const outputRoot = options.outputDir ? resolve(options.outputDir) : join(artifactsDir, "bundles");
   await mkdir(outputRoot, { recursive: true });
 
-  const bundleName = `${sanitize(runId)}-bundle`;
-  const outputPath = join(outputRoot, `${bundleName}.tar.gz`);
-  const checksumPath = `${outputPath}.sha256`;
+  const bundleName = `${safeRunIdSegment(runId)}-bundle`;
   const tmp = await mkdtemp(join(tmpdir(), "kova-artifact-bundle-"));
   const stage = join(tmp, bundleName);
+  const stagedArchivePath = join(tmp, `${bundleName}.tar.gz`);
 
   try {
     await mkdir(stage, { recursive: true });
     await cp(sourceJsonPath, join(stage, "report.json"));
 
     const markdownPath = siblingMarkdownPath(sourceJsonPath);
+    await requireRegularFile(markdownPath, "report Markdown");
     const included = {
       reportJson: true,
-      reportMarkdown: false,
+      reportMarkdown: true,
       pasteSummary: true,
       runArtifacts: false,
       artifactIndex: true
     };
 
-    if (existsSync(markdownPath)) {
-      await cp(markdownPath, join(stage, "report.md"));
-      included.reportMarkdown = true;
-    }
+    await cp(markdownPath, join(stage, "report.md"));
 
     await writeFile(join(stage, "paste-summary.txt"), renderPasteSummary(report), "utf8");
 
-    const runArtifactsPath = join(artifactsDir, runId);
-    if (existsSync(runArtifactsPath) && (await stat(runArtifactsPath)).isDirectory()) {
+    const runArtifactsPath = isCanonicalRunId(runId) ? join(artifactsDir, runId) : null;
+    if (runArtifactsPath && await directoryExists(runArtifactsPath)) {
       await cp(runArtifactsPath, join(stage, "artifacts"), { recursive: true });
       included.runArtifacts = true;
     }
@@ -60,8 +57,10 @@ export async function bundleReport(reportPath, options = {}) {
       platform: report.platform ?? null,
       source: {
         reportJsonPath: sourceJsonPath,
-        reportMarkdownPath: existsSync(markdownPath) ? markdownPath : null,
-        runArtifactsPath: existsSync(runArtifactsPath) ? runArtifactsPath : null
+        reportMarkdownPath: markdownPath,
+        runArtifactsPath: runArtifactsPath && await directoryExists(runArtifactsPath)
+          ? runArtifactsPath
+          : null
       },
       included
     };
@@ -69,7 +68,7 @@ export async function bundleReport(reportPath, options = {}) {
     const artifactIndex = await buildArtifactIndex(stage, bundleName);
     await writeFile(join(stage, "artifact-index.json"), `${JSON.stringify(artifactIndex, null, 2)}\n`, "utf8");
 
-    const tar = spawnSync("tar", ["-czf", outputPath, "-C", tmp, bundleName], {
+    const tar = spawnSync("tar", ["-czf", stagedArchivePath, "-C", tmp, bundleName], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"]
     });
@@ -77,9 +76,16 @@ export async function bundleReport(reportPath, options = {}) {
       throw new Error(tar.stderr || tar.stdout || "tar failed");
     }
 
-    const archive = await readFile(outputPath);
+    const archive = await readFile(stagedArchivePath);
     const sha256 = createHash("sha256").update(archive).digest("hex");
-    await writeFile(checksumPath, `${sha256}  ${basename(outputPath)}\n`, "utf8");
+    const outputPath = join(outputRoot, `${bundleName}-${sha256}.tar.gz`);
+    const checksumPath = `${outputPath}.sha256`;
+    await publishBundlePair({
+      archive,
+      outputPath,
+      checksumPath,
+      checksum: `${sha256}  ${basename(outputPath)}\n`
+    });
 
     return {
       schemaVersion: "kova.artifact.bundle.v1",
@@ -110,44 +116,26 @@ export async function retainGateArtifacts(reportPath, bundle, options = {}) {
 
   const outputRoot = options.outputDir
     ? resolve(options.outputDir)
-    : join(artifactsDir, "release-gates", sanitize(report.runId));
-  await mkdir(outputRoot, { recursive: true });
+    : join(artifactsDir, "release-gates", safeRunIdSegment(report.runId));
+  await mkdir(dirname(outputRoot), { recursive: true });
 
   const markdownPath = siblingMarkdownPath(sourceJsonPath);
-  const retainedJsonPath = join(outputRoot, "report.json");
-  const retainedMarkdownPath = join(outputRoot, "report.md");
-  const retainedPastePath = join(outputRoot, "paste-summary.txt");
-  await cp(sourceJsonPath, retainedJsonPath);
-  if (existsSync(markdownPath)) {
-    await cp(markdownPath, retainedMarkdownPath);
+  await requireRegularFile(markdownPath, "report Markdown");
+  if (bundle?.outputPath) {
+    await requireRegularFile(bundle.outputPath, "report bundle");
   }
-  await writeFile(retainedPastePath, renderPasteSummary(report), "utf8");
-
-  let retainedBundlePath = null;
-  let retainedChecksumPath = null;
-  if (bundle?.outputPath && existsSync(bundle.outputPath)) {
-    retainedBundlePath = join(outputRoot, basename(bundle.outputPath));
-    await cp(bundle.outputPath, retainedBundlePath);
-  }
-  if (bundle?.checksumPath && existsSync(bundle.checksumPath)) {
-    retainedChecksumPath = join(outputRoot, basename(bundle.checksumPath));
-    await cp(bundle.checksumPath, retainedChecksumPath);
+  if (bundle?.checksumPath) {
+    await requireRegularFile(bundle.checksumPath, "report bundle checksum");
   }
 
-  const receipt = {
-    schemaVersion: "kova.releaseGate.retainedArtifacts.v1",
-    generatedAt: new Date().toISOString(),
-    runId: report.runId,
-    verdict: report.gate?.verdict ?? null,
-    outputDir: outputRoot,
-    reportPath: retainedMarkdownPath,
-    jsonPath: retainedJsonPath,
-    pasteSummaryPath: retainedPastePath,
-    bundlePath: retainedBundlePath,
-    checksumPath: retainedChecksumPath
-  };
-  await writeFile(join(outputRoot, "retained-artifacts.json"), `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
-  return receipt;
+  const lockPath = `${outputRoot}.lock`;
+  return withFileLock(lockPath, () => replaceRetainedArtifactTree({
+    outputRoot,
+    sourceJsonPath,
+    markdownPath,
+    report,
+    bundle
+  }));
 }
 
 function siblingMarkdownPath(path) {
@@ -156,8 +144,16 @@ function siblingMarkdownPath(path) {
   return join(dirname(path), `${base}.md`);
 }
 
-function sanitize(value) {
-  return String(value).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+function safeRunIdSegment(value) {
+  const runId = String(value);
+  if (isCanonicalRunId(runId)) {
+    return runId;
+  }
+  return `external-${createHash("sha256").update(runId).digest("hex").slice(0, 24)}`;
+}
+
+function isCanonicalRunId(value) {
+  return /^kova-\d{6}-\d{6}-[0-9a-f]{6}$/.test(value);
 }
 
 async function buildArtifactIndex(stage, bundleName) {
@@ -193,4 +189,174 @@ async function listFiles(root, dir) {
     });
   }
   return entries;
+}
+
+async function publishBundlePair({ archive, outputPath, checksumPath, checksum }) {
+  const entries = [
+    { path: outputPath, content: archive },
+    { path: checksumPath, content: checksum }
+  ];
+  const staged = entries.map((entry) => ({
+    ...entry,
+    stagedPath: `${entry.path}.${randomUUID()}.tmp`
+  }));
+  let archivePublished = false;
+  try {
+    for (const entry of staged) {
+      await writeDurableFile(entry.stagedPath, entry.content);
+    }
+    const outputExists = await pathExists(outputPath);
+    const checksumExists = await pathExists(checksumPath);
+    if (outputExists || checksumExists) {
+      const existing = await readFile(outputPath).catch(() => null);
+      const existingHash = existing ? createHash("sha256").update(existing).digest("hex") : null;
+      const expectedHash = createHash("sha256").update(archive).digest("hex");
+      const existingChecksum = await readFile(checksumPath, "utf8").catch(() => null);
+      if (existingHash !== expectedHash || (existingChecksum !== null && existingChecksum !== checksum)) {
+        throw new Error(`bundle destination collision: ${outputPath}`);
+      }
+      if (!checksumExists) {
+        await rename(staged[1].stagedPath, checksumPath);
+      }
+      return;
+    }
+    await rename(staged[0].stagedPath, outputPath);
+    archivePublished = true;
+    await rename(staged[1].stagedPath, checksumPath);
+  } catch (error) {
+    if (archivePublished) {
+      await rm(outputPath, { force: true });
+    }
+    throw error;
+  } finally {
+    await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true })));
+  }
+}
+
+async function replaceRetainedArtifactTree({
+  outputRoot,
+  sourceJsonPath,
+  markdownPath,
+  report,
+  bundle
+}) {
+  const parent = dirname(outputRoot);
+  const transaction = randomUUID();
+  const stage = join(parent, `.${basename(outputRoot)}.${transaction}.tmp`);
+  const backup = join(parent, `.${basename(outputRoot)}.${transaction}.bak`);
+  let oldTreeBackedUp = false;
+  let newTreePublished = false;
+  let preserveBackup = false;
+
+  try {
+    await mkdir(stage, { recursive: false, mode: 0o700 });
+    await cp(sourceJsonPath, join(stage, "report.json"));
+    await cp(markdownPath, join(stage, "report.md"));
+    await writeFile(join(stage, "paste-summary.txt"), renderPasteSummary(report), "utf8");
+
+    const retainedBundlePath = bundle?.outputPath
+      ? join(outputRoot, basename(bundle.outputPath))
+      : null;
+    const retainedChecksumPath = bundle?.checksumPath
+      ? join(outputRoot, basename(bundle.checksumPath))
+      : null;
+    if (bundle?.outputPath) {
+      await cp(bundle.outputPath, join(stage, basename(bundle.outputPath)));
+    }
+    if (bundle?.checksumPath) {
+      await cp(bundle.checksumPath, join(stage, basename(bundle.checksumPath)));
+    }
+
+    const receipt = {
+      schemaVersion: "kova.releaseGate.retainedArtifacts.v1",
+      generatedAt: new Date().toISOString(),
+      runId: report.runId,
+      verdict: report.gate?.verdict ?? null,
+      outputDir: outputRoot,
+      reportPath: join(outputRoot, "report.md"),
+      jsonPath: join(outputRoot, "report.json"),
+      pasteSummaryPath: join(outputRoot, "paste-summary.txt"),
+      bundlePath: retainedBundlePath,
+      checksumPath: retainedChecksumPath
+    };
+    // The receipt is the retained tree's commit marker and is written only
+    // after every referenced artifact is present in the staging directory.
+    await writeFile(join(stage, "retained-artifacts.json"), `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+
+    if (await pathExists(outputRoot)) {
+      await rename(outputRoot, backup);
+      oldTreeBackedUp = true;
+    }
+    await rename(stage, outputRoot);
+    newTreePublished = true;
+    await rm(backup, { recursive: true, force: true });
+    oldTreeBackedUp = false;
+    return receipt;
+  } catch (error) {
+    const rollbackErrors = [];
+    if (newTreePublished) {
+      await rm(outputRoot, { recursive: true, force: true }).catch((rollbackError) => rollbackErrors.push(rollbackError));
+    }
+    if (oldTreeBackedUp) {
+      await rename(backup, outputRoot).catch((rollbackError) => rollbackErrors.push(rollbackError));
+    }
+    if (rollbackErrors.length > 0) {
+      preserveBackup = true;
+      throw new AggregateError([error, ...rollbackErrors], "retained artifact publication failed and rollback was incomplete");
+    }
+    throw error;
+  } finally {
+    await rm(stage, { recursive: true, force: true });
+    if (!preserveBackup) {
+      await rm(backup, { recursive: true, force: true });
+    }
+  }
+}
+
+async function writeDurableFile(path, content) {
+  const handle = await open(path, "wx", 0o600);
+  try {
+    await handle.writeFile(content);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function requireRegularFile(path, label) {
+  let info;
+  try {
+    info = await stat(path);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Error(`${label} is missing: ${path}`);
+    }
+    throw error;
+  }
+  if (!info.isFile()) {
+    throw new Error(`${label} is not a regular file: ${path}`);
+  }
+}
+
+async function directoryExists(path) {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function pathExists(path) {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
 }

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -338,7 +338,7 @@ async function recoverRetainedArtifactTree(outputRoot, backup) {
   if (!await pathExists(backup)) {
     return;
   }
-  await assertManagedRetentionDirectory(backup, outputRoot, false);
+  await assertManagedRetentionDirectory(backup, outputRoot);
   if (!await pathExists(outputRoot)) {
     await rename(backup, outputRoot);
     return;
@@ -347,7 +347,7 @@ async function recoverRetainedArtifactTree(outputRoot, backup) {
   await rm(backup, { recursive: true });
 }
 
-async function assertManagedRetentionDirectory(path, expectedOutputRoot = path, allowEmpty = true) {
+async function assertManagedRetentionDirectory(path, expectedOutputRoot = path) {
   if (!await pathExists(path)) {
     return;
   }
@@ -357,10 +357,7 @@ async function assertManagedRetentionDirectory(path, expectedOutputRoot = path, 
   }
   const entries = await readdir(path);
   if (entries.length === 0) {
-    if (allowEmpty) {
-      return;
-    }
-    throw new Error(`retained artifact backup is incomplete: ${path}`);
+    return;
   }
   const receiptPath = join(path, "retained-artifacts.json");
   let receipt;

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -1200,19 +1200,25 @@ async function cleanupOrphanBundlePublications(outputRoot, bundleName) {
     if (checksumMatch) {
       const checksumPath = join(outputRoot, name);
       const archivePath = checksumPath.slice(0, -".sha256".length);
-      if (!await pathExists(archivePath)) {
-        await rm(checksumPath, { force: true });
-      }
+      await withFileLock(`${archivePath}.lock`, async () => {
+        if (!await pathExists(archivePath)) {
+          await rm(checksumPath, { force: true });
+        }
+      });
       continue;
     }
-    if (new RegExp(
-      `^${escapeRegExp(prefix)}[a-f0-9]{64}[.]tar[.]gz[.]` +
-      "[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}[.]tmp[.]owner$"
-    ).test(name)) {
-      await cleanupOwnedBundlePairStage(join(outputRoot, name), {
-        outputRoot,
-        bundleName
-      });
+    const stageMatch = name.match(new RegExp(
+      `^(${escapeRegExp(prefix)}[a-f0-9]{64}[.]tar[.]gz)[.]` +
+      "([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})[.]tmp[.]owner$"
+    ));
+    if (stageMatch) {
+      const outputPath = join(outputRoot, stageMatch[1]);
+      await withFileLock(`${outputPath}.lock`, () => (
+        cleanupOwnedBundlePairStage(join(outputRoot, name), {
+          outputRoot,
+          bundleName
+        })
+      ));
     }
   }
   await syncDirectory(outputRoot);

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -9,7 +9,8 @@ import { renderPasteSummary } from "./report.mjs";
 
 export async function bundleReport(reportPath, options = {}) {
   const sourceJsonPath = resolve(reportPath);
-  const report = JSON.parse(await readFile(sourceJsonPath, "utf8"));
+  const snapshot = await snapshotReportSet(sourceJsonPath);
+  const report = JSON.parse(snapshot.json.toString("utf8"));
   const runId = report.runId;
   if (!runId) {
     throw new Error("report is missing runId");
@@ -25,10 +26,9 @@ export async function bundleReport(reportPath, options = {}) {
 
   try {
     await mkdir(stage, { recursive: true });
-    await cp(sourceJsonPath, join(stage, "report.json"));
+    await writeDurableFile(join(stage, "report.json"), snapshot.json);
 
-    const markdownPath = siblingMarkdownPath(sourceJsonPath);
-    await requireRegularFile(markdownPath, "report Markdown");
+    const markdownPath = snapshot.markdownPath;
     const included = {
       reportJson: true,
       reportMarkdown: true,
@@ -37,7 +37,7 @@ export async function bundleReport(reportPath, options = {}) {
       artifactIndex: true
     };
 
-    await cp(markdownPath, join(stage, "report.md"));
+    await writeDurableFile(join(stage, "report.md"), snapshot.markdown);
 
     await writeFile(join(stage, "paste-summary.txt"), renderPasteSummary(report), "utf8");
 
@@ -80,11 +80,14 @@ export async function bundleReport(reportPath, options = {}) {
     const sha256 = createHash("sha256").update(archive).digest("hex");
     const outputPath = join(outputRoot, `${bundleName}-${sha256}.tar.gz`);
     const checksumPath = `${outputPath}.sha256`;
-    await publishBundlePair({
-      archive,
-      outputPath,
-      checksumPath,
-      checksum: `${sha256}  ${basename(outputPath)}\n`
+    await withFileLock(join(outputRoot, `${bundleName}.publication.lock`), async () => {
+      await cleanupOrphanBundleChecksums(outputRoot, bundleName);
+      await publishBundlePair({
+        archive,
+        outputPath,
+        checksumPath,
+        checksum: `${sha256}  ${basename(outputPath)}\n`
+      });
     });
 
     return {
@@ -109,7 +112,8 @@ export async function bundleReport(reportPath, options = {}) {
 
 export async function retainGateArtifacts(reportPath, bundle, options = {}) {
   const sourceJsonPath = resolve(reportPath);
-  const report = JSON.parse(await readFile(sourceJsonPath, "utf8"));
+  const snapshot = await snapshotReportSet(sourceJsonPath);
+  const report = JSON.parse(snapshot.json.toString("utf8"));
   if (!report.runId) {
     throw new Error("report is missing runId");
   }
@@ -119,8 +123,6 @@ export async function retainGateArtifacts(reportPath, bundle, options = {}) {
     : join(artifactsDir, "release-gates", safeRunIdSegment(report.runId));
   await mkdir(dirname(outputRoot), { recursive: true });
 
-  const markdownPath = siblingMarkdownPath(sourceJsonPath);
-  await requireRegularFile(markdownPath, "report Markdown");
   const hasBundle = Boolean(bundle?.outputPath);
   const hasChecksum = Boolean(bundle?.checksumPath);
   if (hasBundle !== hasChecksum) {
@@ -135,8 +137,8 @@ export async function retainGateArtifacts(reportPath, bundle, options = {}) {
   const lockPath = `${outputRoot}.lock`;
   return withFileLock(lockPath, () => replaceRetainedArtifactTree({
     outputRoot,
-    sourceJsonPath,
-    markdownPath,
+    sourceJson: snapshot.json,
+    markdown: snapshot.markdown,
     report,
     bundle
   }));
@@ -274,8 +276,8 @@ async function publishBundlePairLocked({ archive, outputPath, checksumPath, chec
 
 async function replaceRetainedArtifactTree({
   outputRoot,
-  sourceJsonPath,
-  markdownPath,
+  sourceJson,
+  markdown,
   report,
   bundle
 }) {
@@ -290,10 +292,8 @@ async function replaceRetainedArtifactTree({
     await recoverRetainedArtifactTree(outputRoot, backup);
     await assertManagedRetentionDirectory(outputRoot);
     await mkdir(stage, { recursive: false, mode: 0o700 });
-    await cp(sourceJsonPath, join(stage, "report.json"));
-    await syncFile(join(stage, "report.json"));
-    await cp(markdownPath, join(stage, "report.md"));
-    await syncFile(join(stage, "report.md"));
+    await writeDurableFile(join(stage, "report.json"), sourceJson);
+    await writeDurableFile(join(stage, "report.md"), markdown);
     await writeDurableFile(join(stage, "paste-summary.txt"), renderPasteSummary(report));
 
     const retainedBundlePath = bundle?.outputPath
@@ -372,8 +372,8 @@ async function recoverRetainedArtifactTree(outputRoot, backup) {
   if (!await pathExists(backup)) {
     return;
   }
-  await assertManagedRetentionDirectory(backup, outputRoot);
   if (!await pathExists(outputRoot)) {
+    await assertManagedRetentionDirectory(backup, outputRoot);
     await rename(backup, outputRoot);
     await syncDirectory(dirname(outputRoot));
     return;
@@ -381,13 +381,16 @@ async function recoverRetainedArtifactTree(outputRoot, backup) {
   await assertManagedRetentionDirectory(outputRoot);
   try {
     await assertManagedRetentionDirectory(outputRoot, outputRoot, true);
-  } catch {
-    await rm(outputRoot, { recursive: true });
-    await rename(backup, outputRoot);
+    await rm(backup, { recursive: true });
     await syncDirectory(dirname(outputRoot));
     return;
+  } catch {
+    // The current tree is Kova-managed but incomplete; restore the prior
+    // committed tree only after proving the backup is valid.
   }
-  await rm(backup, { recursive: true });
+  await assertManagedRetentionDirectory(backup, outputRoot);
+  await rm(outputRoot, { recursive: true });
+  await rename(backup, outputRoot);
   await syncDirectory(dirname(outputRoot));
 }
 
@@ -474,15 +477,6 @@ async function writeDurableFile(path, content) {
   }
 }
 
-async function syncFile(path) {
-  const handle = await open(path, "r");
-  try {
-    await handle.sync();
-  } finally {
-    await handle.close();
-  }
-}
-
 async function syncDirectory(path) {
   if (process.platform === "win32") {
     return;
@@ -493,6 +487,45 @@ async function syncDirectory(path) {
   } finally {
     await handle.close();
   }
+}
+
+async function snapshotReportSet(sourceJsonPath) {
+  const markdownPath = siblingMarkdownPath(sourceJsonPath);
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await requireRegularFile(sourceJsonPath, "report JSON");
+    await requireRegularFile(markdownPath, "report Markdown");
+    const before = await lstat(sourceJsonPath);
+    const json = await readFile(sourceJsonPath);
+    const markdown = await readFile(markdownPath);
+    const committedJson = await readFile(sourceJsonPath);
+    const after = await lstat(sourceJsonPath);
+    if (
+      before.dev === after.dev &&
+      before.ino === after.ino &&
+      before.size === after.size &&
+      before.mtimeMs === after.mtimeMs &&
+      json.equals(committedJson)
+    ) {
+      return { json, markdown, markdownPath };
+    }
+  }
+  throw new Error(`report changed while publication snapshot was being captured: ${sourceJsonPath}`);
+}
+
+async function cleanupOrphanBundleChecksums(outputRoot, bundleName) {
+  const prefix = `${bundleName}-`;
+  const suffix = ".tar.gz.sha256";
+  for (const name of await readdir(outputRoot)) {
+    if (!name.startsWith(prefix) || !name.endsWith(suffix)) {
+      continue;
+    }
+    const checksumPath = join(outputRoot, name);
+    const archivePath = checksumPath.slice(0, -".sha256".length);
+    if (!await pathExists(archivePath)) {
+      await rm(checksumPath, { force: true });
+    }
+  }
+  await syncDirectory(outputRoot);
 }
 
 async function validateBundlePair(archivePath, checksumPath) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -333,11 +333,10 @@ async function replaceRetainedArtifactTree({
     await syncDirectory(stage);
 
     if (await pathExists(outputRoot)) {
-      await writeDurableFile(backupMarker, `${JSON.stringify({
+      await writeDurableMarker(backupMarker, `${JSON.stringify({
         schemaVersion: "kova.retainedArtifactBackup.v1",
         outputRoot
       })}\n`);
-      await syncDirectory(parent);
       await rename(outputRoot, backup);
       oldTreeBackedUp = true;
       await syncDirectory(parent);
@@ -518,6 +517,17 @@ async function writeDurableFile(path, content) {
     await handle.sync();
   } finally {
     await handle.close();
+  }
+}
+
+async function writeDurableMarker(path, content) {
+  const stagedPath = `${path}.${randomUUID()}.tmp`;
+  try {
+    await writeDurableFile(stagedPath, content);
+    await rename(stagedPath, path);
+    await syncDirectory(dirname(path));
+  } finally {
+    await rm(stagedPath, { force: true });
   }
 }
 

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -192,6 +192,15 @@ async function listFiles(root, dir) {
 }
 
 export async function publishBundlePair({ archive, outputPath, checksumPath, checksum }) {
+  return withFileLock(`${outputPath}.lock`, () => publishBundlePairLocked({
+    archive,
+    outputPath,
+    checksumPath,
+    checksum
+  }));
+}
+
+async function publishBundlePairLocked({ archive, outputPath, checksumPath, checksum }) {
   const entries = [
     { path: outputPath, content: archive },
     { path: checksumPath, content: checksum }
@@ -254,6 +263,7 @@ async function replaceRetainedArtifactTree({
   let preserveBackup = false;
 
   try {
+    await assertManagedRetentionDirectory(outputRoot);
     await mkdir(stage, { recursive: false, mode: 0o700 });
     await cp(sourceJsonPath, join(stage, "report.json"));
     await cp(markdownPath, join(stage, "report.md"));
@@ -314,6 +324,55 @@ async function replaceRetainedArtifactTree({
     if (!preserveBackup) {
       await rm(backup, { recursive: true, force: true });
     }
+  }
+}
+
+async function assertManagedRetentionDirectory(path) {
+  if (!await pathExists(path)) {
+    return;
+  }
+  const info = await lstat(path);
+  if (!info.isDirectory()) {
+    throw new Error(`retained artifact destination is not a directory: ${path}`);
+  }
+  const entries = await readdir(path);
+  if (entries.length === 0) {
+    return;
+  }
+  const receiptPath = join(path, "retained-artifacts.json");
+  let receipt;
+  try {
+    receipt = JSON.parse(await readFile(receiptPath, "utf8"));
+  } catch {
+    throw new Error(`retained artifact destination must be empty or Kova-managed: ${path}`);
+  }
+  if (
+    receipt?.schemaVersion !== "kova.releaseGate.retainedArtifacts.v1" ||
+    resolve(receipt.outputDir ?? "") !== resolve(path) ||
+    resolve(receipt.reportPath ?? "") !== resolve(path, "report.md") ||
+    resolve(receipt.jsonPath ?? "") !== resolve(path, "report.json") ||
+    resolve(receipt.pasteSummaryPath ?? "") !== resolve(path, "paste-summary.txt")
+  ) {
+    throw new Error(`retained artifact destination must be empty or Kova-managed: ${path}`);
+  }
+  const managedEntries = new Set([
+    "retained-artifacts.json",
+    "report.json",
+    "report.md",
+    "paste-summary.txt"
+  ]);
+  for (const artifactPath of [receipt.bundlePath, receipt.checksumPath]) {
+    if (!artifactPath) {
+      continue;
+    }
+    const resolvedArtifactPath = resolve(artifactPath);
+    if (dirname(resolvedArtifactPath) !== resolve(path)) {
+      throw new Error(`retained artifact destination must be empty or Kova-managed: ${path}`);
+    }
+    managedEntries.add(basename(resolvedArtifactPath));
+  }
+  if (entries.some((entry) => !managedEntries.has(entry))) {
+    throw new Error(`retained artifact destination contains unmanaged files: ${path}`);
   }
 }
 

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -544,7 +544,9 @@ async function syncDirectory(path) {
 }
 
 async function syncFile(path) {
-  const handle = await open(path, "r");
+  // Windows FlushFileBuffers requires a writable handle. These are staged
+  // copies owned by this transaction, so opening them read/write is safe.
+  const handle = await open(path, "r+");
   try {
     await handle.sync();
   } finally {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -1,8 +1,11 @@
 import { createHash, randomUUID } from "node:crypto";
-import { spawnSync } from "node:child_process";
-import { chmod, cp, lstat, mkdir, mkdtemp, open, readFile, readdir, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
+import { constants as fsConstants, createReadStream, createWriteStream } from "node:fs";
+import { cp, lstat, mkdir, open, readFile, readdir, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { createGzip } from "node:zlib";
+import { pack as packTar } from "tar-stream";
 import { withFileLock } from "../file-lock.mjs";
 import { artifactsDir } from "../paths.mjs";
 import { reportTransactionLockPath } from "../run/report-output.mjs";
@@ -15,6 +18,14 @@ const RESERVED_RETAINED_FILENAMES = new Set([
   "report.md",
   "retained-artifacts.json"
 ]);
+const MAX_BUNDLE_ARCHIVE_BYTES = 256 * 1024 * 1024;
+const MAX_BUNDLE_CHECKSUM_BYTES = 8 * 1024;
+const MAX_USTAR_FILE_BYTES = 0o77777777777;
+const FILE_READ_CHUNK_BYTES = 1024 * 1024;
+const READ_ONLY_NONBLOCK =
+  fsConstants.O_RDONLY |
+  (fsConstants.O_NONBLOCK ?? 0) |
+  (fsConstants.O_NOFOLLOW ?? 0);
 
 export async function bundleReport(reportPath, options = {}) {
   const sourceJsonPath = resolve(reportPath);
@@ -26,98 +37,126 @@ export async function bundleReport(reportPath, options = {}) {
   }
 
   const outputRoot = options.outputDir ? resolve(options.outputDir) : join(artifactsDir, "bundles");
+  const sourceArtifactsRoot = options.artifactsDir
+    ? resolve(options.artifactsDir)
+    : artifactsDir;
   await mkdir(outputRoot, { recursive: true });
 
   const bundleName = `${artifactRunIdSegment(runId)}-bundle`;
-  const tmp = await mkdtemp(join(tmpdir(), "kova-artifact-bundle-"));
-  const stage = join(tmp, bundleName);
-  const stagedArchivePath = join(tmp, `${bundleName}.tar.gz`);
+  const publicationLock = join(outputRoot, `${bundleName}.publication.lock`);
+  return withFileLock(publicationLock, async () => {
+    await cleanupBundleBuildStages(outputRoot, bundleName);
+    const transaction = randomUUID();
+    const tmp = join(tmpdir(), `kova-artifact-bundle-${transaction}.tmp`);
+    const stageOwner = `${tmp}.owner`;
+    const stage = join(tmp, bundleName);
+    const stagedArchivePath = join(tmp, `${bundleName}.tar.gz`);
+    let tmpCreated = false;
+    try {
+      await writeDurableMarker(stageOwner, `${JSON.stringify({
+        schemaVersion: "kova.bundleBuildStage.v1",
+        transaction,
+        outputRoot,
+        bundleName
+      })}\n`);
+      await mkdir(tmp, { mode: 0o700 });
+      tmpCreated = true;
+      await mkdir(stage, { recursive: true });
+      await writeDurableFile(join(stage, "report.json"), snapshot.json);
 
-  try {
-    await mkdir(stage, { recursive: true });
-    await writeDurableFile(join(stage, "report.json"), snapshot.json);
+      const markdownPath = snapshot.markdownPath;
+      const included = {
+        reportJson: true,
+        reportMarkdown: true,
+        pasteSummary: true,
+        runArtifacts: false,
+        artifactIndex: true
+      };
 
-    const markdownPath = snapshot.markdownPath;
-    const included = {
-      reportJson: true,
-      reportMarkdown: true,
-      pasteSummary: true,
-      runArtifacts: false,
-      artifactIndex: true
-    };
+      await writeDurableFile(join(stage, "report.md"), snapshot.markdown);
+      await writeFile(
+        join(stage, "paste-summary.txt"),
+        renderPasteSummary(report),
+        "utf8"
+      );
 
-    await writeDurableFile(join(stage, "report.md"), snapshot.markdown);
+      const runArtifactsPath = isCanonicalRunId(runId)
+        ? join(sourceArtifactsRoot, runId)
+        : null;
+      if (runArtifactsPath && await directoryExists(runArtifactsPath)) {
+        await cp(runArtifactsPath, join(stage, "artifacts"), { recursive: true });
+        included.runArtifacts = true;
+      }
 
-    await writeFile(join(stage, "paste-summary.txt"), renderPasteSummary(report), "utf8");
+      const manifest = {
+        schemaVersion: "kova.artifact.manifest.v1",
+        generatedAt: new Date().toISOString(),
+        runId,
+        mode: report.mode ?? null,
+        target: report.target ?? null,
+        profile: report.profile ?? null,
+        platform: report.platform ?? null,
+        source: {
+          reportJsonPath: sourceJsonPath,
+          reportMarkdownPath: markdownPath,
+          runArtifactsPath: runArtifactsPath && await directoryExists(runArtifactsPath)
+            ? runArtifactsPath
+            : null
+        },
+        included
+      };
+      await writeFile(
+        join(stage, "manifest.json"),
+        `${JSON.stringify(manifest, null, 2)}\n`,
+        "utf8"
+      );
+      const artifactIndex = await buildArtifactIndex(stage, bundleName);
+      await writeFile(
+        join(stage, "artifact-index.json"),
+        `${JSON.stringify(artifactIndex, null, 2)}\n`,
+        "utf8"
+      );
+      await writeUstarArchive(stage, bundleName, stagedArchivePath);
 
-    const runArtifactsPath = isCanonicalRunId(runId) ? join(artifactsDir, runId) : null;
-    if (runArtifactsPath && await directoryExists(runArtifactsPath)) {
-      await cp(runArtifactsPath, join(stage, "artifacts"), { recursive: true });
-      included.runArtifacts = true;
-    }
-
-    const manifest = {
-      schemaVersion: "kova.artifact.manifest.v1",
-      generatedAt: new Date().toISOString(),
-      runId,
-      mode: report.mode ?? null,
-      target: report.target ?? null,
-      profile: report.profile ?? null,
-      platform: report.platform ?? null,
-      source: {
-        reportJsonPath: sourceJsonPath,
-        reportMarkdownPath: markdownPath,
-        runArtifactsPath: runArtifactsPath && await directoryExists(runArtifactsPath)
-          ? runArtifactsPath
-          : null
-      },
-      included
-    };
-    await writeFile(join(stage, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
-    const artifactIndex = await buildArtifactIndex(stage, bundleName);
-    await writeFile(join(stage, "artifact-index.json"), `${JSON.stringify(artifactIndex, null, 2)}\n`, "utf8");
-
-    const tar = spawnSync("tar", ["--format=ustar", "-czf", stagedArchivePath, "-C", tmp, bundleName], {
-      encoding: "utf8",
-      env: { ...process.env, COPYFILE_DISABLE: "1" },
-      stdio: ["ignore", "pipe", "pipe"]
-    });
-    if (tar.status !== 0) {
-      throw new Error(tar.stderr || tar.stdout || "tar failed");
-    }
-
-    const archive = await readFile(stagedArchivePath);
-    const sha256 = createHash("sha256").update(archive).digest("hex");
-    const outputPath = join(outputRoot, `${bundleName}-${sha256}.tar.gz`);
-    const checksumPath = `${outputPath}.sha256`;
-    await withFileLock(join(outputRoot, `${bundleName}.publication.lock`), async () => {
-      await cleanupOrphanBundleChecksums(outputRoot, bundleName);
+      const archive = await readStableRegularFile(
+        stagedArchivePath,
+        "generated report bundle",
+        MAX_BUNDLE_ARCHIVE_BYTES
+      );
+      const sha256 = createHash("sha256").update(archive).digest("hex");
+      const outputPath = join(outputRoot, `${bundleName}-${sha256}.tar.gz`);
+      const checksumPath = `${outputPath}.sha256`;
+      await cleanupOrphanBundlePublications(outputRoot, bundleName);
       await publishBundlePair({
         archive,
         outputPath,
         checksumPath,
         checksum: `${sha256}  ${basename(outputPath)}\n`
       });
-    });
 
-    return {
-      schemaVersion: "kova.artifact.bundle.v1",
-      generatedAt: new Date().toISOString(),
-      runId,
-      outputPath,
-      checksumPath,
-      sha256,
-      bytes: archive.length,
-      artifactIndex: {
-        path: "artifact-index.json",
-        fileCount: artifactIndex.fileCount,
-        totalBytes: artifactIndex.totalBytes
-      },
-      included
-    };
-  } finally {
-    await rm(tmp, { recursive: true, force: true });
-  }
+      return {
+        schemaVersion: "kova.artifact.bundle.v1",
+        generatedAt: new Date().toISOString(),
+        runId,
+        outputPath,
+        checksumPath,
+        sha256,
+        bytes: archive.length,
+        artifactIndex: {
+          path: "artifact-index.json",
+          fileCount: artifactIndex.fileCount,
+          totalBytes: artifactIndex.totalBytes
+        },
+        included
+      };
+    } finally {
+      if (tmpCreated) {
+        await rm(tmp, { recursive: true, force: true });
+      }
+      await rm(stageOwner, { force: true });
+      await syncDirectory(tmpdir()).catch(() => {});
+    }
+  });
 }
 
 export async function retainGateArtifacts(reportPath, bundle, options = {}) {
@@ -153,19 +192,22 @@ export async function retainGateArtifacts(reportPath, bundle, options = {}) {
     if (retainedFilenameKeys.some((name) => RESERVED_RETAINED_FILENAMES.has(name))) {
       throw new Error("retained report bundle filenames conflict with reserved retained artifacts");
     }
-    await requireRegularFile(bundle.outputPath, "report bundle");
-    await requireRegularFile(bundle.checksumPath, "report bundle checksum");
-    await validateBundlePair(bundle.outputPath, bundle.checksumPath);
   }
 
   const lockPath = `${outputRoot}.lock`;
-  return withFileLock(lockPath, () => replaceRetainedArtifactTree({
-    outputRoot,
-    sourceJson: snapshot.json,
-    markdown: snapshot.markdown,
-    report,
-    bundle
-  }));
+  return withFileLock(lockPath, async () => {
+    const bundleSnapshot = hasBundle
+      ? await readVerifiedBundlePair(bundle.outputPath, bundle.checksumPath)
+      : null;
+    return replaceRetainedArtifactTree({
+      outputRoot,
+      sourceJson: snapshot.json,
+      markdown: snapshot.markdown,
+      report,
+      bundle,
+      bundleSnapshot
+    });
+  });
 }
 
 function siblingMarkdownPath(path) {
@@ -186,7 +228,7 @@ function portableRetentionFilenameKey(value) {
 }
 
 async function buildArtifactIndex(stage, bundleName) {
-  const entries = await listFiles(stage, stage);
+  const entries = await listFiles(stage, stage, bundleName);
   const totalBytes = entries.reduce((sum, entry) => sum + entry.bytes, 0);
   return {
     schemaVersion: "kova.artifact.index.v1",
@@ -198,52 +240,142 @@ async function buildArtifactIndex(stage, bundleName) {
   };
 }
 
-async function listFiles(root, dir) {
+async function listFiles(root, dir, bundleName) {
   const names = await readdir(dir, { withFileTypes: true });
   const entries = [];
   for (const name of names.toSorted((left, right) => left.name.localeCompare(right.name))) {
     const path = join(dir, name.name);
     if (name.isDirectory()) {
-      entries.push(...await listFiles(root, path));
+      entries.push(...await listFiles(root, path, bundleName));
       continue;
     }
     if (!name.isFile()) {
-      continue;
+      throw new Error(`report bundle contains an unsupported filesystem entry: ${path}`);
     }
-    const bytes = await readFile(path);
+    const info = await lstat(path);
+    if (info.size > MAX_USTAR_FILE_BYTES) {
+      throw new Error(`report bundle file exceeds the portable USTAR size limit: ${path}`);
+    }
+    const metadata = await hashFile(path);
+    const bundlePath = relative(root, path).split(sep).join("/");
     entries.push({
-      path: relative(root, path),
-      bytes: bytes.length,
-      sha256: createHash("sha256").update(bytes).digest("hex")
+      path: bundlePath,
+      archivePath: archivePathFor(bundleName, bundlePath),
+      bytes: metadata.bytes,
+      sha256: metadata.sha256
     });
   }
   return entries;
 }
 
+async function writeUstarArchive(stage, bundleName, destination) {
+  const files = await listFiles(stage, stage, bundleName);
+  const archivePaths = new Set();
+  const pack = packTar();
+  const output = pipeline(
+    pack,
+    createGzip({ level: 9 }),
+    createWriteStream(destination, { flags: "wx", mode: 0o600 })
+  );
+  try {
+    for (const file of files) {
+      if (archivePaths.has(file.archivePath)) {
+        throw new Error(`report bundle archive path collision: ${file.archivePath}`);
+      }
+      archivePaths.add(file.archivePath);
+      const source = join(stage, ...file.path.split("/"));
+      const entry = pack.entry({
+        name: `${bundleName}/${file.archivePath}`,
+        type: "file",
+        mode: 0o600,
+        uid: 0,
+        gid: 0,
+        size: file.bytes,
+        mtime: new Date(0)
+      });
+      await pipeline(createReadStream(source), entry);
+    }
+    pack.finalize();
+    await output;
+  } catch (error) {
+    pack.destroy(error);
+    await output.catch(() => {});
+    throw error;
+  }
+}
+
+async function hashFile(path) {
+  const hash = createHash("sha256");
+  let bytes = 0;
+  for await (const chunk of createReadStream(path)) {
+    bytes += chunk.length;
+    hash.update(chunk);
+  }
+  return { bytes, sha256: hash.digest("hex") };
+}
+
+function archivePathFor(bundleName, bundlePath) {
+  // `mapped/` is owned by the archiver. Remap any future source path that
+  // enters that namespace so original and generated paths cannot collide.
+  if (!bundlePath.startsWith("mapped/") && isUstarPath(`${bundleName}/${bundlePath}`)) {
+    return bundlePath;
+  }
+  return `mapped/${createHash("sha256").update(bundlePath).digest("hex")}`;
+}
+
+function isUstarPath(path) {
+  if (Buffer.byteLength(path) !== path.length) {
+    return false;
+  }
+  let name = path;
+  let prefix = "";
+  while (Buffer.byteLength(name) > 100) {
+    const separator = name.indexOf("/");
+    if (separator === -1) {
+      return false;
+    }
+    prefix += prefix ? `/${name.slice(0, separator)}` : name.slice(0, separator);
+    name = name.slice(separator + 1);
+  }
+  return Buffer.byteLength(name) <= 100 && Buffer.byteLength(prefix) <= 155;
+}
+
 export async function publishBundlePair({ archive, outputPath, checksumPath, checksum }) {
-  if (dirname(outputPath) !== dirname(checksumPath)) {
+  const resolvedOutputPath = resolve(outputPath);
+  const resolvedChecksumPath = resolve(checksumPath);
+  if (dirname(resolvedOutputPath) !== dirname(resolvedChecksumPath)) {
     throw new Error("report bundle and checksum must share one publication directory");
   }
-  return withFileLock(`${outputPath}.lock`, () => publishBundlePairLocked({
+  return withFileLock(`${resolvedOutputPath}.lock`, () => publishBundlePairLocked({
     archive,
-    outputPath,
-    checksumPath,
+    outputPath: resolvedOutputPath,
+    checksumPath: resolvedChecksumPath,
     checksum
   }));
 }
 
 async function publishBundlePairLocked({ archive, outputPath, checksumPath, checksum }) {
+  await cleanupBundlePairStages(outputPath, checksumPath);
+  const transaction = randomUUID();
   const entries = [
     { path: outputPath, content: archive },
     { path: checksumPath, content: checksum }
   ];
   const staged = entries.map((entry) => ({
     ...entry,
-    stagedPath: `${entry.path}.${randomUUID()}.tmp`
+    stagedPath: `${entry.path}.${transaction}.tmp`
   }));
+  const stageOwner = `${staged[0].stagedPath}.owner`;
   let archivePublished = false;
   let checksumPublished = false;
+  let publicationFailed = false;
   try {
+    await writeDurableMarker(stageOwner, `${JSON.stringify({
+      schemaVersion: "kova.bundlePairStage.v1",
+      transaction,
+      outputPath: resolve(outputPath),
+      checksumPath: resolve(checksumPath)
+    })}\n`);
     for (const entry of staged) {
       await writeDurableFile(entry.stagedPath, entry.content);
     }
@@ -256,10 +388,23 @@ async function publishBundlePairLocked({ archive, outputPath, checksumPath, chec
       if (checksumExists) {
         await requireRegularFile(checksumPath, "existing report bundle checksum");
       }
-      const existing = outputExists ? await readFile(outputPath) : null;
+      const existing = outputExists
+        ? await readStableRegularFile(
+          outputPath,
+          "existing report bundle",
+          MAX_BUNDLE_ARCHIVE_BYTES
+        )
+        : null;
       const existingHash = existing ? createHash("sha256").update(existing).digest("hex") : null;
       const expectedHash = createHash("sha256").update(archive).digest("hex");
-      const existingChecksum = checksumExists ? await readFile(checksumPath, "utf8") : null;
+      const existingChecksum = checksumExists
+        ? await readStableRegularFile(
+          checksumPath,
+          "existing report bundle checksum",
+          MAX_BUNDLE_CHECKSUM_BYTES,
+          "utf8"
+        )
+        : null;
       if (
         (existingHash !== null && existingHash !== expectedHash) ||
         (existingChecksum !== null && existingChecksum !== checksum)
@@ -284,6 +429,7 @@ async function publishBundlePairLocked({ archive, outputPath, checksumPath, chec
     archivePublished = true;
     await syncDirectory(dirname(outputPath));
   } catch (error) {
+    publicationFailed = true;
     if (archivePublished) {
       await rm(outputPath, { force: true });
     }
@@ -293,7 +439,20 @@ async function publishBundlePairLocked({ archive, outputPath, checksumPath, chec
     await syncDirectory(dirname(outputPath)).catch(() => {});
     throw error;
   } finally {
-    await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true }).catch(() => {})));
+    const cleanupErrors = [];
+    for (const entry of staged) {
+      await rm(entry.stagedPath, { force: true })
+        .catch((error) => cleanupErrors.push(error));
+    }
+    if (cleanupErrors.length === 0) {
+      await rm(stageOwner, { force: true });
+      await syncDirectory(dirname(outputPath)).catch(() => {});
+    } else if (!publicationFailed) {
+      throw new AggregateError(
+        cleanupErrors,
+        "report bundle publication committed but staging cleanup was incomplete"
+      );
+    }
   }
 }
 
@@ -302,20 +461,30 @@ async function replaceRetainedArtifactTree({
   sourceJson,
   markdown,
   report,
-  bundle
+  bundle,
+  bundleSnapshot
 }) {
   const parent = dirname(outputRoot);
   const transaction = randomUUID();
   const stage = join(parent, `.${basename(outputRoot)}.${transaction}.tmp`);
+  const stageOwner = `${stage}.owner`;
   const backup = join(parent, `.${basename(outputRoot)}.bak`);
   const backupMarker = `${backup}.owner`;
   let oldTreeBackedUp = false;
   let newTreePublished = false;
+  let stageCreated = false;
 
   try {
+    await cleanupRetainedArtifactStages(outputRoot);
     await recoverRetainedArtifactTree(outputRoot, backup, backupMarker);
     await assertManagedRetentionDirectory(outputRoot);
+    await writeDurableMarker(stageOwner, `${JSON.stringify({
+      schemaVersion: "kova.retainedArtifactStage.v1",
+      transaction,
+      outputRoot
+    })}\n`);
     await mkdir(stage, { recursive: false, mode: 0o700 });
+    stageCreated = true;
     await writeDurableFile(join(stage, "report.json"), sourceJson);
     await writeDurableFile(join(stage, "report.md"), markdown);
     await writeDurableFile(join(stage, "paste-summary.txt"), renderPasteSummary(report));
@@ -326,11 +495,15 @@ async function replaceRetainedArtifactTree({
     const retainedChecksumPath = bundle?.checksumPath
       ? join(outputRoot, basename(bundle.checksumPath))
       : null;
-    if (bundle?.outputPath) {
-      await copyDurableFile(bundle.outputPath, join(stage, basename(bundle.outputPath)));
-    }
-    if (bundle?.checksumPath) {
-      await copyDurableFile(bundle.checksumPath, join(stage, basename(bundle.checksumPath)));
+    if (bundleSnapshot) {
+      await writeDurableFile(
+        join(stage, basename(bundle.outputPath)),
+        bundleSnapshot.archive
+      );
+      await writeDurableFile(
+        join(stage, basename(bundle.checksumPath)),
+        bundleSnapshot.checksum
+      );
     }
 
     const receipt = {
@@ -392,7 +565,10 @@ async function replaceRetainedArtifactTree({
     }
     throw error;
   } finally {
-    await rm(stage, { recursive: true, force: true });
+    if (stageCreated) {
+      await rm(stage, { recursive: true, force: true });
+    }
+    await rm(stageOwner, { force: true });
     await removeUnusedRetainedBackupMarker(backup, backupMarker, outputRoot);
   }
 }
@@ -841,25 +1017,6 @@ async function syncDirectory(path) {
   }
 }
 
-async function syncFile(path) {
-  // Windows FlushFileBuffers requires a writable handle. These are staged
-  // copies owned by this transaction, so opening them read/write is safe.
-  const handle = await open(path, "r+");
-  try {
-    await handle.sync();
-  } finally {
-    await handle.close();
-  }
-}
-
-async function copyDurableFile(source, destination) {
-  await cp(source, destination);
-  // The staged copy belongs to this transaction. Normalize its mode so a
-  // read-only source cannot prevent the durability sync.
-  await chmod(destination, 0o600);
-  await syncFile(destination);
-}
-
 async function snapshotReportSet(sourceJsonPath) {
   return withFileLock(
     reportTransactionLockPath(sourceJsonPath),
@@ -896,36 +1053,316 @@ async function snapshotReportSetLocked(sourceJsonPath) {
   throw new Error(`report changed while publication snapshot was being captured: ${sourceJsonPath}`);
 }
 
-async function cleanupOrphanBundleChecksums(outputRoot, bundleName) {
+async function cleanupOrphanBundlePublications(outputRoot, bundleName) {
   const prefix = `${bundleName}-`;
-  const suffix = ".tar.gz.sha256";
   for (const name of await readdir(outputRoot)) {
-    if (!name.startsWith(prefix) || !name.endsWith(suffix)) {
+    const checksumMatch = name.match(
+      new RegExp(`^${escapeRegExp(prefix)}([a-f0-9]{64})[.]tar[.]gz[.]sha256$`)
+    );
+    if (checksumMatch) {
+      const checksumPath = join(outputRoot, name);
+      const archivePath = checksumPath.slice(0, -".sha256".length);
+      if (!await pathExists(archivePath)) {
+        await rm(checksumPath, { force: true });
+      }
       continue;
     }
-    const digest = name.slice(prefix.length, -suffix.length);
-    if (!/^[a-f0-9]{64}$/.test(digest)) {
-      continue;
-    }
-    const checksumPath = join(outputRoot, name);
-    const archivePath = checksumPath.slice(0, -".sha256".length);
-    if (!await pathExists(archivePath)) {
-      await rm(checksumPath, { force: true });
+    if (new RegExp(
+      `^${escapeRegExp(prefix)}[a-f0-9]{64}[.]tar[.]gz[.]` +
+      "[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}[.]tmp[.]owner$"
+    ).test(name)) {
+      await cleanupOwnedBundlePairStage(join(outputRoot, name), {
+        outputRoot,
+        bundleName
+      });
     }
   }
   await syncDirectory(outputRoot);
 }
 
 async function validateBundlePair(archivePath, checksumPath) {
+  await readVerifiedBundlePair(archivePath, checksumPath);
+}
+
+async function readVerifiedBundlePair(archivePath, checksumPath) {
   const [archive, checksum] = await Promise.all([
-    readFile(archivePath),
-    readFile(checksumPath, "utf8")
+    readStableRegularFile(
+      archivePath,
+      "report bundle",
+      MAX_BUNDLE_ARCHIVE_BYTES
+    ),
+    readStableRegularFile(
+      checksumPath,
+      "report bundle checksum",
+      MAX_BUNDLE_CHECKSUM_BYTES,
+      "utf8"
+    )
   ]);
   const sha256 = createHash("sha256").update(archive).digest("hex");
   const expected = `${sha256}  ${basename(archivePath)}\n`;
   if (checksum !== expected) {
     throw new Error(`report bundle checksum does not match archive: ${archivePath}`);
   }
+  return { archive, checksum };
+}
+
+async function readStableRegularFile(path, label, maxBytes, encoding = null) {
+  let pathInfo;
+  try {
+    pathInfo = await lstat(path);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Error(`${label} is missing: ${path}`);
+    }
+    throw error;
+  }
+  if (!pathInfo.isFile()) {
+    throw new Error(`${label} is not a regular file: ${path}`);
+  }
+  let handle;
+  try {
+    handle = await open(path, READ_ONLY_NONBLOCK);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Error(`${label} is missing: ${path}`);
+    }
+    throw error;
+  }
+  try {
+    const before = await handle.stat();
+    if (
+      !before.isFile() ||
+      pathInfo.dev !== before.dev ||
+      pathInfo.ino !== before.ino
+    ) {
+      throw new Error(`${label} changed before it was read: ${path}`);
+    }
+    if (before.size > maxBytes) {
+      throw new Error(`${label} exceeds the size limit: ${path}`);
+    }
+    const chunks = [];
+    let total = 0;
+    while (total <= maxBytes) {
+      const buffer = Buffer.allocUnsafe(
+        Math.min(FILE_READ_CHUNK_BYTES, maxBytes + 1 - total)
+      );
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) {
+        break;
+      }
+      chunks.push(buffer.subarray(0, bytesRead));
+      total += bytesRead;
+    }
+    if (total > maxBytes) {
+      throw new Error(`${label} exceeds the size limit: ${path}`);
+    }
+    const bytes = Buffer.concat(chunks, total);
+    const after = await handle.stat();
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.size !== after.size ||
+      before.mtimeMs !== after.mtimeMs ||
+      before.ctimeMs !== after.ctimeMs
+    ) {
+      throw new Error(`${label} changed while it was being read: ${path}`);
+    }
+    return encoding ? bytes.toString(encoding) : bytes;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function cleanupBundleBuildStages(outputRoot, bundleName) {
+  const directory = tmpdir();
+  for (const name of await readdir(directory)) {
+    const match = name.match(
+      /^kova-artifact-bundle-([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})[.]tmp[.]owner$/
+    );
+    if (!match) {
+      continue;
+    }
+    const ownerPath = join(directory, name);
+    const marker = await readOwnedStageMarker(ownerPath);
+    if (
+      marker?.schemaVersion !== "kova.bundleBuildStage.v1" ||
+      typeof marker.transaction !== "string" ||
+      typeof marker.outputRoot !== "string" ||
+      typeof marker.bundleName !== "string" ||
+      marker.transaction !== match[1] ||
+      resolve(marker.outputRoot) !== resolve(outputRoot) ||
+      marker.bundleName !== bundleName
+    ) {
+      continue;
+    }
+    const stage = ownerPath.slice(0, -".owner".length);
+    const info = await lstat(stage).catch(() => null);
+    if (info && !isOwnedByCurrentUser(info)) {
+      continue;
+    }
+    if (info && !info.isDirectory()) {
+      throw new Error(`report bundle staging path is not a directory: ${stage}`);
+    }
+    if (info) {
+      await rm(stage, { recursive: true });
+    }
+    await rm(ownerPath);
+  }
+  await syncDirectory(directory);
+}
+
+async function cleanupBundlePairStages(outputPath, checksumPath) {
+  const directory = dirname(outputPath);
+  const pattern = new RegExp(
+    `^${escapeRegExp(basename(outputPath))}[.]` +
+    "[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}[.]tmp[.]owner$"
+  );
+  for (const name of await readdir(directory)) {
+    if (pattern.test(name)) {
+      await cleanupOwnedBundlePairStage(join(directory, name), {
+        outputPath,
+        checksumPath
+      });
+    }
+  }
+  await syncDirectory(directory);
+}
+
+async function cleanupOwnedBundlePairStage(ownerPath, expected) {
+  const marker = await readOwnedStageMarker(ownerPath);
+  const transaction = marker?.transaction;
+  if (
+    marker?.schemaVersion !== "kova.bundlePairStage.v1" ||
+    typeof transaction !== "string" ||
+    typeof marker.outputPath !== "string" ||
+    typeof marker.checksumPath !== "string"
+  ) {
+    return;
+  }
+  const outputPath = resolve(marker.outputPath);
+  const checksumPath = resolve(marker.checksumPath);
+  const valid = (
+    /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/.test(
+      transaction
+    ) &&
+    dirname(outputPath) === dirname(checksumPath) &&
+    ownerPath === `${outputPath}.${transaction}.tmp.owner` &&
+    (
+      expected.outputPath === undefined ||
+      outputPath === resolve(expected.outputPath)
+    ) &&
+    (
+      expected.checksumPath === undefined ||
+      checksumPath === resolve(expected.checksumPath)
+    ) &&
+    (
+      expected.outputRoot === undefined ||
+      dirname(outputPath) === resolve(expected.outputRoot)
+    ) &&
+    (
+      expected.bundleName === undefined ||
+      basename(outputPath).startsWith(`${expected.bundleName}-`)
+    )
+  );
+  if (!valid) {
+    return;
+  }
+  const stages = [
+    `${outputPath}.${transaction}.tmp`,
+    `${checksumPath}.${transaction}.tmp`
+  ];
+  const stageInfos = await Promise.all(
+    stages.map((stage) => lstat(stage).catch(() => null))
+  );
+  if (stageInfos.some((info) => info && !isOwnedByCurrentUser(info))) {
+    return;
+  }
+  for (const [index, stage] of stages.entries()) {
+    const info = stageInfos[index];
+    if (info && !info.isFile()) {
+      throw new Error(`report bundle staging path is not a regular file: ${stage}`);
+    }
+    if (info) {
+      await rm(stage);
+    }
+  }
+  await rm(ownerPath);
+  await syncDirectory(dirname(outputPath));
+}
+
+async function cleanupRetainedArtifactStages(outputRoot) {
+  const parent = dirname(outputRoot);
+  const prefix = `.${basename(outputRoot)}.`;
+  for (const name of await readdir(parent)) {
+    if (
+      !name.startsWith(prefix) ||
+      !/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}[.]tmp[.]owner$/.test(
+        name.slice(prefix.length)
+      )
+    ) {
+      continue;
+    }
+    const ownerPath = join(parent, name);
+    const marker = await readOwnedStageMarker(ownerPath);
+    const transaction = marker?.transaction;
+    const stage = ownerPath.slice(0, -".owner".length);
+    if (
+      marker?.schemaVersion !== "kova.retainedArtifactStage.v1" ||
+      typeof marker.outputRoot !== "string" ||
+      typeof transaction !== "string" ||
+      resolve(marker.outputRoot) !== resolve(outputRoot) ||
+      !/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/.test(
+        transaction
+      ) ||
+      stage !== join(parent, `.${basename(outputRoot)}.${transaction}.tmp`)
+    ) {
+      continue;
+    }
+    const info = await lstat(stage).catch(() => null);
+    if (info && !isOwnedByCurrentUser(info)) {
+      continue;
+    }
+    if (info && !info.isDirectory()) {
+      throw new Error(`retained artifact staging path is not a directory: ${stage}`);
+    }
+    if (info) {
+      await rm(stage, { recursive: true });
+    }
+    await rm(ownerPath);
+  }
+  await syncDirectory(parent);
+}
+
+async function readOwnedStageMarker(path) {
+  try {
+    const info = await lstat(path);
+    if (
+      !info.isFile() ||
+      !isOwnedByCurrentUser(info)
+    ) {
+      return null;
+    }
+    const content = await readStableRegularFile(
+      path,
+      "Kova stage owner marker",
+      MAX_BUNDLE_CHECKSUM_BYTES,
+      "utf8"
+    );
+    const marker = JSON.parse(content);
+    return marker && typeof marker === "object" && !Array.isArray(marker)
+      ? marker
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isOwnedByCurrentUser(info) {
+  return typeof process.getuid !== "function" || info.uid === process.getuid();
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 async function requireRegularFile(path, label) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -210,6 +210,7 @@ async function publishBundlePairLocked({ archive, outputPath, checksumPath, chec
     stagedPath: `${entry.path}.${randomUUID()}.tmp`
   }));
   let archivePublished = false;
+  let checksumPublished = false;
   try {
     for (const entry of staged) {
       await writeDurableFile(entry.stagedPath, entry.content);
@@ -227,24 +228,35 @@ async function publishBundlePairLocked({ archive, outputPath, checksumPath, chec
       const existingHash = existing ? createHash("sha256").update(existing).digest("hex") : null;
       const expectedHash = createHash("sha256").update(archive).digest("hex");
       const existingChecksum = checksumExists ? await readFile(checksumPath, "utf8") : null;
-      if (existingHash !== expectedHash || (existingChecksum !== null && existingChecksum !== checksum)) {
+      if (
+        (existingHash !== null && existingHash !== expectedHash) ||
+        (existingChecksum !== null && existingChecksum !== checksum)
+      ) {
         throw new Error(`bundle destination collision: ${outputPath}`);
       }
-      if (!checksumExists) {
+      if (!checksumExists && outputExists) {
         await rename(staged[1].stagedPath, checksumPath);
+      } else if (!outputExists && checksumExists) {
+        await rename(staged[0].stagedPath, outputPath);
       }
       return;
     }
+    await rename(staged[1].stagedPath, checksumPath);
+    checksumPublished = true;
+    // The archive is the bundle commit marker. A checksum-only crash state is
+    // harmless and is completed by the recovery branch above.
     await rename(staged[0].stagedPath, outputPath);
     archivePublished = true;
-    await rename(staged[1].stagedPath, checksumPath);
   } catch (error) {
     if (archivePublished) {
       await rm(outputPath, { force: true });
     }
+    if (checksumPublished) {
+      await rm(checksumPath, { force: true });
+    }
     throw error;
   } finally {
-    await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true })));
+    await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true }).catch(() => {})));
   }
 }
 
@@ -258,11 +270,11 @@ async function replaceRetainedArtifactTree({
   const parent = dirname(outputRoot);
   const transaction = randomUUID();
   const stage = join(parent, `.${basename(outputRoot)}.${transaction}.tmp`);
-  const backup = join(parent, `.${basename(outputRoot)}.${transaction}.bak`);
+  const backup = join(parent, `.${basename(outputRoot)}.bak`);
   let oldTreeBackedUp = false;
-  let preserveBackup = false;
 
   try {
+    await recoverRetainedArtifactTree(outputRoot, backup);
     await assertManagedRetentionDirectory(outputRoot);
     await mkdir(stage, { recursive: false, mode: 0o700 });
     await cp(sourceJsonPath, join(stage, "report.json"));
@@ -306,7 +318,6 @@ async function replaceRetainedArtifactTree({
     // Publication commits at the directory rename. Cleanup cannot safely
     // restore a backup once recursive deletion may have started.
     oldTreeBackedUp = false;
-    preserveBackup = true;
     await rm(backup, { recursive: true, force: true }).catch(() => {});
     return receipt;
   } catch (error) {
@@ -315,19 +326,28 @@ async function replaceRetainedArtifactTree({
       await rename(backup, outputRoot).catch((rollbackError) => rollbackErrors.push(rollbackError));
     }
     if (rollbackErrors.length > 0) {
-      preserveBackup = true;
       throw new AggregateError([error, ...rollbackErrors], "retained artifact publication failed and rollback was incomplete");
     }
     throw error;
   } finally {
     await rm(stage, { recursive: true, force: true });
-    if (!preserveBackup) {
-      await rm(backup, { recursive: true, force: true });
-    }
   }
 }
 
-async function assertManagedRetentionDirectory(path) {
+async function recoverRetainedArtifactTree(outputRoot, backup) {
+  if (!await pathExists(backup)) {
+    return;
+  }
+  await assertManagedRetentionDirectory(backup, outputRoot, false);
+  if (!await pathExists(outputRoot)) {
+    await rename(backup, outputRoot);
+    return;
+  }
+  await assertManagedRetentionDirectory(outputRoot);
+  await rm(backup, { recursive: true });
+}
+
+async function assertManagedRetentionDirectory(path, expectedOutputRoot = path, allowEmpty = true) {
   if (!await pathExists(path)) {
     return;
   }
@@ -337,7 +357,10 @@ async function assertManagedRetentionDirectory(path) {
   }
   const entries = await readdir(path);
   if (entries.length === 0) {
-    return;
+    if (allowEmpty) {
+      return;
+    }
+    throw new Error(`retained artifact backup is incomplete: ${path}`);
   }
   const receiptPath = join(path, "retained-artifacts.json");
   let receipt;
@@ -348,10 +371,10 @@ async function assertManagedRetentionDirectory(path) {
   }
   if (
     receipt?.schemaVersion !== "kova.releaseGate.retainedArtifacts.v1" ||
-    resolve(receipt.outputDir ?? "") !== resolve(path) ||
-    resolve(receipt.reportPath ?? "") !== resolve(path, "report.md") ||
-    resolve(receipt.jsonPath ?? "") !== resolve(path, "report.json") ||
-    resolve(receipt.pasteSummaryPath ?? "") !== resolve(path, "paste-summary.txt")
+    resolve(receipt.outputDir ?? "") !== resolve(expectedOutputRoot) ||
+    resolve(receipt.reportPath ?? "") !== resolve(expectedOutputRoot, "report.md") ||
+    resolve(receipt.jsonPath ?? "") !== resolve(expectedOutputRoot, "report.json") ||
+    resolve(receipt.pasteSummaryPath ?? "") !== resolve(expectedOutputRoot, "paste-summary.txt")
   ) {
     throw new Error(`retained artifact destination must be empty or Kova-managed: ${path}`);
   }
@@ -366,13 +389,16 @@ async function assertManagedRetentionDirectory(path) {
       continue;
     }
     const resolvedArtifactPath = resolve(artifactPath);
-    if (dirname(resolvedArtifactPath) !== resolve(path)) {
+    if (dirname(resolvedArtifactPath) !== resolve(expectedOutputRoot)) {
       throw new Error(`retained artifact destination must be empty or Kova-managed: ${path}`);
     }
     managedEntries.add(basename(resolvedArtifactPath));
   }
-  if (entries.some((entry) => !managedEntries.has(entry))) {
-    throw new Error(`retained artifact destination contains unmanaged files: ${path}`);
+  for (const entry of entries) {
+    const info = await lstat(join(path, entry));
+    if (!managedEntries.has(entry) || !info.isFile()) {
+      throw new Error(`retained artifact destination contains unmanaged files: ${path}`);
+    }
   }
 }
 

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -1,11 +1,18 @@
 import { createHash, randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { cp, lstat, mkdir, mkdtemp, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, cp, lstat, mkdir, mkdtemp, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { withFileLock } from "../file-lock.mjs";
 import { artifactsDir } from "../paths.mjs";
 import { renderPasteSummary } from "./report.mjs";
+
+const RESERVED_RETAINED_FILENAMES = new Set([
+  "paste-summary.txt",
+  "report.json",
+  "report.md",
+  "retained-artifacts.json"
+]);
 
 export async function bundleReport(reportPath, options = {}) {
   const sourceJsonPath = resolve(reportPath);
@@ -129,6 +136,20 @@ export async function retainGateArtifacts(reportPath, bundle, options = {}) {
     throw new Error("retained report bundle requires both archive and checksum");
   }
   if (hasBundle) {
+    if (bundle.runId !== report.runId) {
+      throw new Error(`retained report bundle run ID does not match report: ${bundle.runId ?? "missing"}`);
+    }
+    const retainedFilenames = [
+      basename(bundle.outputPath),
+      basename(bundle.checksumPath)
+    ];
+    const retainedFilenameKeys = retainedFilenames.map(portableRetentionFilenameKey);
+    if (new Set(retainedFilenameKeys).size !== retainedFilenameKeys.length) {
+      throw new Error("retained report bundle and checksum must use distinct filenames");
+    }
+    if (retainedFilenameKeys.some((name) => RESERVED_RETAINED_FILENAMES.has(name))) {
+      throw new Error("retained report bundle filenames conflict with reserved retained artifacts");
+    }
     await requireRegularFile(bundle.outputPath, "report bundle");
     await requireRegularFile(bundle.checksumPath, "report bundle checksum");
     await validateBundlePair(bundle.outputPath, bundle.checksumPath);
@@ -156,6 +177,17 @@ function safeRunIdSegment(value) {
     return runId;
   }
   return `external-${createHash("sha256").update(runId).digest("hex").slice(0, 24)}`;
+}
+
+function portableRetentionFilenameKey(value) {
+  if (
+    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value) ||
+    value.endsWith(".") ||
+    /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.|$)/i.test(value)
+  ) {
+    throw new Error("retained report bundle filenames must use portable filenames");
+  }
+  return value.toLowerCase();
 }
 
 function isCanonicalRunId(value) {
@@ -304,12 +336,10 @@ async function replaceRetainedArtifactTree({
       ? join(outputRoot, basename(bundle.checksumPath))
       : null;
     if (bundle?.outputPath) {
-      await cp(bundle.outputPath, join(stage, basename(bundle.outputPath)));
-      await syncFile(join(stage, basename(bundle.outputPath)));
+      await copyDurableFile(bundle.outputPath, join(stage, basename(bundle.outputPath)));
     }
     if (bundle?.checksumPath) {
-      await cp(bundle.checksumPath, join(stage, basename(bundle.checksumPath)));
-      await syncFile(join(stage, basename(bundle.checksumPath)));
+      await copyDurableFile(bundle.checksumPath, join(stage, basename(bundle.checksumPath)));
     }
 
     const receipt = {
@@ -561,6 +591,14 @@ async function syncFile(path) {
   } finally {
     await handle.close();
   }
+}
+
+async function copyDurableFile(source, destination) {
+  await cp(source, destination);
+  // The staged copy belongs to this transaction. Normalize its mode so a
+  // read-only source cannot prevent the durability sync.
+  await chmod(destination, 0o600);
+  await syncFile(destination);
 }
 
 async function snapshotReportSet(sourceJsonPath) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -352,9 +352,11 @@ async function replaceRetainedArtifactTree({
     await syncDirectory(stage);
 
     if (await pathExists(outputRoot)) {
+      const treeSha256 = await retainedArtifactTreeDigest(outputRoot);
       await writeDurableMarker(backupMarker, `${JSON.stringify({
-        schemaVersion: "kova.retainedArtifactBackup.v1",
-        outputRoot
+        schemaVersion: "kova.retainedArtifactBackup.v2",
+        outputRoot,
+        treeSha256
       })}\n`);
       await rename(outputRoot, backup);
       oldTreeBackedUp = true;
@@ -367,7 +369,7 @@ async function replaceRetainedArtifactTree({
     // restore a backup once recursive deletion may have started.
     oldTreeBackedUp = false;
     newTreePublished = false;
-    await removeRetainedBackup(backup, backupMarker, parent).catch(() => {});
+    await removeRetainedBackup(backup, backupMarker, outputRoot, parent).catch(() => {});
     return receipt;
   } catch (error) {
     const rollbackErrors = [];
@@ -397,9 +399,8 @@ async function recoverRetainedArtifactTree(outputRoot, backup, backupMarker) {
     await removeOwnedBackupMarker(backupMarker, outputRoot);
     return;
   }
-  await requireOwnedBackupMarker(backupMarker, outputRoot);
+  await requireRetainedBackup(backup, backupMarker, outputRoot);
   if (!await pathExists(outputRoot)) {
-    await assertManagedRetentionDirectory(backup, outputRoot);
     await restoreRetainedBackup(backup, outputRoot, backupMarker, dirname(outputRoot));
     return;
   }
@@ -413,15 +414,19 @@ async function recoverRetainedArtifactTree(outputRoot, backup, backupMarker) {
     // committed tree only after proving the backup is valid.
   }
   if (currentComplete) {
-    await removeRetainedBackup(backup, backupMarker, dirname(outputRoot));
+    await removeRetainedBackup(backup, backupMarker, outputRoot, dirname(outputRoot));
     return;
   }
-  await assertManagedRetentionDirectory(backup, outputRoot);
   await rm(outputRoot, { recursive: true });
   await restoreRetainedBackup(backup, outputRoot, backupMarker, dirname(outputRoot));
 }
 
-async function removeRetainedBackup(backup, backupMarker, parent) {
+async function removeRetainedBackup(backup, backupMarker, outputRoot, parent) {
+  if (!await pathExists(backup)) {
+    await removeOwnedBackupMarker(backupMarker, outputRoot);
+    return;
+  }
+  await requireRetainedBackup(backup, backupMarker, outputRoot);
   // The owner marker must outlive the backup directory on durable storage.
   // Recovery rejects a backup whose marker disappeared first.
   await rm(backup, { recursive: true, force: true });
@@ -431,6 +436,7 @@ async function removeRetainedBackup(backup, backupMarker, parent) {
 }
 
 async function restoreRetainedBackup(backup, outputRoot, backupMarker, parent) {
+  await requireRetainedBackup(backup, backupMarker, outputRoot);
   await rename(backup, outputRoot);
   await syncDirectory(parent);
   await rm(backupMarker, { force: true });
@@ -449,10 +455,24 @@ async function requireOwnedBackupMarker(path, outputRoot) {
     throw new Error(`retained artifact backup is not Kova-managed: ${path}`);
   }
   if (
-    marker?.schemaVersion !== "kova.retainedArtifactBackup.v1" ||
-    resolve(marker.outputRoot ?? "") !== resolve(outputRoot)
+    marker?.schemaVersion !== "kova.retainedArtifactBackup.v2" ||
+    resolve(marker.outputRoot ?? "") !== resolve(outputRoot) ||
+    !/^[a-f0-9]{64}$/.test(marker.treeSha256 ?? "")
   ) {
     throw new Error(`retained artifact backup is not Kova-managed: ${path}`);
+  }
+  return marker;
+}
+
+async function requireRetainedBackup(backup, backupMarker, outputRoot) {
+  const marker = await requireOwnedBackupMarker(backupMarker, outputRoot);
+  try {
+    await assertManagedRetentionDirectory(backup, outputRoot);
+    if (await retainedArtifactTreeDigest(backup) !== marker.treeSha256) {
+      throw new Error("tree digest mismatch");
+    }
+  } catch {
+    throw new Error(`retained artifact backup is not Kova-managed: ${backup}`);
   }
 }
 
@@ -536,6 +556,22 @@ async function assertManagedRetentionDirectory(path, expectedOutputRoot = path, 
       );
     }
   }
+}
+
+export async function retainedArtifactTreeDigest(path) {
+  const digest = createHash("sha256");
+  const entries = (await readdir(path)).toSorted();
+  for (const entry of entries) {
+    const entryPath = join(path, entry);
+    const info = await lstat(entryPath);
+    if (!info.isFile()) {
+      throw new Error(`retained artifact tree contains a non-file entry: ${entryPath}`);
+    }
+    const content = await readFile(entryPath);
+    digest.update(`${entry}\0${content.length}\0`);
+    digest.update(content);
+  }
+  return digest.digest("hex");
 }
 
 async function writeDurableFile(path, content) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -558,15 +558,21 @@ async function snapshotReportSet(sourceJsonPath) {
     await requireRegularFile(sourceJsonPath, "report JSON");
     await requireRegularFile(markdownPath, "report Markdown");
     const before = await lstat(sourceJsonPath);
+    const markdownBefore = await lstat(markdownPath);
     const json = await readFile(sourceJsonPath);
     const markdown = await readFile(markdownPath);
     const committedJson = await readFile(sourceJsonPath);
     const after = await lstat(sourceJsonPath);
+    const markdownAfter = await lstat(markdownPath);
     if (
       before.dev === after.dev &&
       before.ino === after.ino &&
       before.size === after.size &&
       before.mtimeMs === after.mtimeMs &&
+      markdownBefore.dev === markdownAfter.dev &&
+      markdownBefore.ino === markdownAfter.ino &&
+      markdownBefore.size === markdownAfter.size &&
+      markdownBefore.mtimeMs === markdownAfter.mtimeMs &&
       json.equals(committedJson)
     ) {
       return { json, markdown, markdownPath };

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { withFileLock } from "../file-lock.mjs";
 import { artifactsDir } from "../paths.mjs";
+import { reportTransactionLockPath } from "../run/report-output.mjs";
 import { artifactRunIdSegment, isCanonicalRunId } from "./artifact-names.mjs";
 import { renderPasteSummary } from "./report.mjs";
 
@@ -859,6 +860,13 @@ async function copyDurableFile(source, destination) {
 }
 
 async function snapshotReportSet(sourceJsonPath) {
+  return withFileLock(
+    reportTransactionLockPath(sourceJsonPath),
+    () => snapshotReportSetLocked(sourceJsonPath)
+  );
+}
+
+async function snapshotReportSetLocked(sourceJsonPath) {
   const markdownPath = siblingMarkdownPath(sourceJsonPath);
   for (let attempt = 0; attempt < 3; attempt += 1) {
     await requireRegularFile(sourceJsonPath, "report JSON");

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -637,6 +637,10 @@ async function cleanupOrphanBundleChecksums(outputRoot, bundleName) {
     if (!name.startsWith(prefix) || !name.endsWith(suffix)) {
       continue;
     }
+    const digest = name.slice(prefix.length, -suffix.length);
+    if (!/^[a-f0-9]{64}$/.test(digest)) {
+      continue;
+    }
     const checksumPath = join(outputRoot, name);
     const archivePath = checksumPath.slice(0, -".sha256".length);
     if (!await pathExists(archivePath)) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -121,11 +121,15 @@ export async function retainGateArtifacts(reportPath, bundle, options = {}) {
 
   const markdownPath = siblingMarkdownPath(sourceJsonPath);
   await requireRegularFile(markdownPath, "report Markdown");
-  if (bundle?.outputPath) {
-    await requireRegularFile(bundle.outputPath, "report bundle");
+  const hasBundle = Boolean(bundle?.outputPath);
+  const hasChecksum = Boolean(bundle?.checksumPath);
+  if (hasBundle !== hasChecksum) {
+    throw new Error("retained report bundle requires both archive and checksum");
   }
-  if (bundle?.checksumPath) {
+  if (hasBundle) {
+    await requireRegularFile(bundle.outputPath, "report bundle");
     await requireRegularFile(bundle.checksumPath, "report bundle checksum");
+    await validateBundlePair(bundle.outputPath, bundle.checksumPath);
   }
 
   const lockPath = `${outputRoot}.lock`;
@@ -192,6 +196,9 @@ async function listFiles(root, dir) {
 }
 
 export async function publishBundlePair({ archive, outputPath, checksumPath, checksum }) {
+  if (dirname(outputPath) !== dirname(checksumPath)) {
+    throw new Error("report bundle and checksum must share one publication directory");
+  }
   return withFileLock(`${outputPath}.lock`, () => publishBundlePairLocked({
     archive,
     outputPath,
@@ -236,17 +243,21 @@ async function publishBundlePairLocked({ archive, outputPath, checksumPath, chec
       }
       if (!checksumExists && outputExists) {
         await rename(staged[1].stagedPath, checksumPath);
+        await syncDirectory(dirname(outputPath));
       } else if (!outputExists && checksumExists) {
         await rename(staged[0].stagedPath, outputPath);
+        await syncDirectory(dirname(outputPath));
       }
       return;
     }
     await rename(staged[1].stagedPath, checksumPath);
     checksumPublished = true;
+    await syncDirectory(dirname(outputPath));
     // The archive is the bundle commit marker. A checksum-only crash state is
     // harmless and is completed by the recovery branch above.
     await rename(staged[0].stagedPath, outputPath);
     archivePublished = true;
+    await syncDirectory(dirname(outputPath));
   } catch (error) {
     if (archivePublished) {
       await rm(outputPath, { force: true });
@@ -254,6 +265,7 @@ async function publishBundlePairLocked({ archive, outputPath, checksumPath, chec
     if (checksumPublished) {
       await rm(checksumPath, { force: true });
     }
+    await syncDirectory(dirname(outputPath)).catch(() => {});
     throw error;
   } finally {
     await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true }).catch(() => {})));
@@ -278,8 +290,10 @@ async function replaceRetainedArtifactTree({
     await assertManagedRetentionDirectory(outputRoot);
     await mkdir(stage, { recursive: false, mode: 0o700 });
     await cp(sourceJsonPath, join(stage, "report.json"));
+    await syncFile(join(stage, "report.json"));
     await cp(markdownPath, join(stage, "report.md"));
-    await writeFile(join(stage, "paste-summary.txt"), renderPasteSummary(report), "utf8");
+    await syncFile(join(stage, "report.md"));
+    await writeDurableFile(join(stage, "paste-summary.txt"), renderPasteSummary(report));
 
     const retainedBundlePath = bundle?.outputPath
       ? join(outputRoot, basename(bundle.outputPath))
@@ -289,9 +303,11 @@ async function replaceRetainedArtifactTree({
       : null;
     if (bundle?.outputPath) {
       await cp(bundle.outputPath, join(stage, basename(bundle.outputPath)));
+      await syncFile(join(stage, basename(bundle.outputPath)));
     }
     if (bundle?.checksumPath) {
       await cp(bundle.checksumPath, join(stage, basename(bundle.checksumPath)));
+      await syncFile(join(stage, basename(bundle.checksumPath)));
     }
 
     const receipt = {
@@ -308,22 +324,32 @@ async function replaceRetainedArtifactTree({
     };
     // The receipt is the retained tree's commit marker and is written only
     // after every referenced artifact is present in the staging directory.
-    await writeFile(join(stage, "retained-artifacts.json"), `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+    await writeDurableFile(
+      join(stage, "retained-artifacts.json"),
+      `${JSON.stringify(receipt, null, 2)}\n`
+    );
+    await syncDirectory(stage);
 
     if (await pathExists(outputRoot)) {
       await rename(outputRoot, backup);
       oldTreeBackedUp = true;
+      await syncDirectory(parent);
     }
     await rename(stage, outputRoot);
+    await syncDirectory(parent);
     // Publication commits at the directory rename. Cleanup cannot safely
     // restore a backup once recursive deletion may have started.
     oldTreeBackedUp = false;
-    await rm(backup, { recursive: true, force: true }).catch(() => {});
+    await rm(backup, { recursive: true, force: true })
+      .then(() => syncDirectory(parent))
+      .catch(() => {});
     return receipt;
   } catch (error) {
     const rollbackErrors = [];
     if (oldTreeBackedUp) {
-      await rename(backup, outputRoot).catch((rollbackError) => rollbackErrors.push(rollbackError));
+      await rename(backup, outputRoot)
+        .then(() => syncDirectory(parent))
+        .catch((rollbackError) => rollbackErrors.push(rollbackError));
     }
     if (rollbackErrors.length > 0) {
       throw new AggregateError([error, ...rollbackErrors], "retained artifact publication failed and rollback was incomplete");
@@ -341,13 +367,23 @@ async function recoverRetainedArtifactTree(outputRoot, backup) {
   await assertManagedRetentionDirectory(backup, outputRoot);
   if (!await pathExists(outputRoot)) {
     await rename(backup, outputRoot);
+    await syncDirectory(dirname(outputRoot));
     return;
   }
   await assertManagedRetentionDirectory(outputRoot);
+  try {
+    await assertManagedRetentionDirectory(outputRoot, outputRoot, true);
+  } catch {
+    await rm(outputRoot, { recursive: true });
+    await rename(backup, outputRoot);
+    await syncDirectory(dirname(outputRoot));
+    return;
+  }
   await rm(backup, { recursive: true });
+  await syncDirectory(dirname(outputRoot));
 }
 
-async function assertManagedRetentionDirectory(path, expectedOutputRoot = path) {
+async function assertManagedRetentionDirectory(path, expectedOutputRoot = path, requireComplete = false) {
   if (!await pathExists(path)) {
     return;
   }
@@ -397,6 +433,24 @@ async function assertManagedRetentionDirectory(path, expectedOutputRoot = path) 
       throw new Error(`retained artifact destination contains unmanaged files: ${path}`);
     }
   }
+  if (requireComplete) {
+    for (const entry of managedEntries) {
+      if (!entries.includes(entry)) {
+        throw new Error(`retained artifact destination is incomplete: ${path}`);
+      }
+    }
+    const hasBundle = Boolean(receipt.bundlePath);
+    const hasChecksum = Boolean(receipt.checksumPath);
+    if (hasBundle !== hasChecksum) {
+      throw new Error(`retained artifact destination has an incomplete bundle pair: ${path}`);
+    }
+    if (hasBundle) {
+      await validateBundlePair(
+        join(path, basename(receipt.bundlePath)),
+        join(path, basename(receipt.checksumPath))
+      );
+    }
+  }
 }
 
 async function writeDurableFile(path, content) {
@@ -406,6 +460,39 @@ async function writeDurableFile(path, content) {
     await handle.sync();
   } finally {
     await handle.close();
+  }
+}
+
+async function syncFile(path) {
+  const handle = await open(path, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function syncDirectory(path) {
+  if (process.platform === "win32") {
+    return;
+  }
+  const handle = await open(path, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function validateBundlePair(archivePath, checksumPath) {
+  const [archive, checksum] = await Promise.all([
+    readFile(archivePath),
+    readFile(checksumPath, "utf8")
+  ]);
+  const sha256 = createHash("sha256").update(archive).digest("hex");
+  const expected = `${sha256}  ${basename(archivePath)}\n`;
+  if (checksum !== expected) {
+    throw new Error(`report bundle checksum does not match archive: ${archivePath}`);
   }
 }
 

--- a/src/reporting/bundle-contract.mjs
+++ b/src/reporting/bundle-contract.mjs
@@ -1,0 +1,54 @@
+import { posix } from "node:path";
+import { caseFold } from "unicode-case-folding";
+
+export const MAX_BUNDLE_COMPRESSED_BYTES = 256 * 1024 * 1024;
+export const MAX_BUNDLE_CHECKSUM_BYTES = 8 * 1024;
+export const MAX_BUNDLE_UNPACKED_BYTES = 512 * 1024 * 1024;
+export const MAX_BUNDLE_DECLARED_BYTES = 512 * 1024 * 1024;
+export const MAX_BUNDLE_MANIFEST_BYTES = 64 * 1024;
+export const MAX_BUNDLE_PHYSICAL_HEADERS = 10_000;
+export const MAX_BUNDLE_ENTRIES = 10_000;
+export const MAX_BUNDLE_NAME_BYTES = 4 * 1024;
+export const MAX_BUNDLE_PATH_DEPTH = 64;
+export const MAX_BUNDLE_ANCESTORS = 100_000;
+
+export function normalizeArchiveMember(name, type) {
+  if (
+    !name ||
+    !["file", "directory"].includes(type) ||
+    name.startsWith("/") ||
+    /[<>:"\\|?*]/.test(name) ||
+    /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u.test(name)
+  ) {
+    return null;
+  }
+  const hasTrailingSlash = name.endsWith("/");
+  if (hasTrailingSlash && type !== "directory") {
+    return null;
+  }
+  const canonicalName = hasTrailingSlash ? name.slice(0, -1) : name;
+  const normalized = posix.normalize(canonicalName);
+  const segments = canonicalName.split("/");
+  if (
+    normalized !== canonicalName ||
+    segments.length === 0 ||
+    segments.length > MAX_BUNDLE_PATH_DEPTH ||
+    segments.some((segment) =>
+      !segment ||
+      segment === "." ||
+      segment === ".." ||
+      segment.startsWith("-") ||
+      /[. ]$/.test(segment) ||
+      /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:[.]|$)/i.test(segment)
+    )
+  ) {
+    return null;
+  }
+  const portableSegments = segments.map((segment) =>
+    caseFold(segment.normalize("NFC")).normalize("NFC"));
+  return {
+    path: normalized,
+    portablePath: portableSegments.join("/"),
+    portableSegments
+  };
+}

--- a/src/reporting/render-cleanup.mjs
+++ b/src/reporting/render-cleanup.mjs
@@ -25,7 +25,10 @@ export function renderCleanupEnvs({ envs, results, execute }, flags = {}, env = 
   }
 
   sections.push("");
-  sections.push(renderHint(execute, envs.length === 0 ? "no-envs" : "envs", ui, { kind: "envs" }));
+  sections.push(renderHint(execute, envs.length === 0 ? "no-envs" : "envs", ui, {
+    kind: "envs",
+    verdict
+  }));
   return withMargin(sections.join("\n"), ui.leftPad);
 }
 
@@ -49,7 +52,12 @@ export function renderCleanupArtifacts({ candidates, results, execute, artifacts
   }
 
   sections.push("");
-  sections.push(renderHint(execute, candidates.length === 0 ? "none" : "candidates", ui, { kind: "artifacts", olderThanDays, artifactsDir }));
+  sections.push(renderHint(execute, candidates.length === 0 ? "none" : "candidates", ui, {
+    kind: "artifacts",
+    olderThanDays,
+    artifactsDir,
+    verdict
+  }));
   return withMargin(sections.join("\n"), ui.leftPad);
 }
 
@@ -59,6 +67,8 @@ function deriveEnvsVerdict({ envs, results, execute }) {
     return { label: "DRY-RUN", tone: "INCOMPLETE", status: "PLANNED" };
   }
   const failed = results.filter((r) => r.status !== 0).length;
+  const missing = missingEnvResultCount(envs, results);
+  if (missing > 0) return { label: "INCOMPLETE", tone: "FAIL", status: "INCOMPLETE" };
   if (failed > 0) return { label: "PARTIAL", tone: "FAIL", status: "FAILED" };
   return { label: "CLEANED", tone: "PASS", status: "DONE" };
 }
@@ -69,15 +79,25 @@ function deriveArtifactsVerdict({ candidates, results, execute }) {
     return { label: "DRY-RUN", tone: "INCOMPLETE", status: "PLANNED" };
   }
   const failed = results.filter((r) => r.status !== 0).length;
+  const missing = missingArtifactResultCount(candidates, results);
+  if (missing > 0) return { label: "INCOMPLETE", tone: "FAIL", status: "INCOMPLETE" };
   if (failed > 0) return { label: "PARTIAL", tone: "FAIL", status: "FAILED" };
   return { label: "CLEANED", tone: "PASS", status: "DONE" };
 }
 
 function buildEnvsHeadline({ envs, results, execute }) {
-  if (!execute) return envs.length === 0 ? "nothing to do" : `${envs.length} would be removed`;
+  const eligible = eligibleEnvCount(envs);
+  if (!execute) return envs.length === 0 ? "nothing to do" : `${eligible} would be removed`;
   const removed = results.filter((r) => r.status === 0).length;
   const failed = results.filter((r) => r.status !== 0).length;
-  if (failed > 0) return `${removed} removed · ${failed} failed`;
+  const missing = missingEnvResultCount(envs, results);
+  if (failed > 0 || missing > 0) {
+    return [
+      `${removed} removed`,
+      ...(failed > 0 ? [`${failed} failed`] : []),
+      ...(missing > 0 ? [`${missing} not attempted`] : [])
+    ].join(" · ");
+  }
   return `${removed} removed`;
 }
 
@@ -85,18 +105,28 @@ function buildArtifactsHeadline({ candidates, results, execute }) {
   if (!execute) return candidates.length === 0 ? "nothing to do" : `${candidates.length} would be removed`;
   const removed = results.filter((r) => r.status === 0).length;
   const failed = results.filter((r) => r.status !== 0).length;
-  if (failed > 0) return `${removed} removed · ${failed} failed`;
+  const missing = missingArtifactResultCount(candidates, results);
+  if (failed > 0 || missing > 0) {
+    return [
+      `${removed} removed`,
+      ...(failed > 0 ? [`${failed} failed`] : []),
+      ...(missing > 0 ? [`${missing} not attempted`] : [])
+    ].join(" · ");
+  }
   return `${removed} removed`;
 }
 
 function renderEnvsKpi({ envs, results, execute }, ui) {
+  const eligible = eligibleEnvCount(envs);
   const removed = execute ? results.filter((r) => r.status === 0).length : 0;
-  const failed = execute ? results.filter((r) => r.status !== 0).length : 0;
+  const failed = execute
+    ? results.filter((r) => r.status !== 0).length + missingEnvResultCount(envs, results)
+    : 0;
   return kpiStrip([
     { label: "Stale envs", value: String(envs.length), hint: "matched", tone: "neutral" },
     {
       label: execute ? "Removed" : "Would remove",
-      value: execute ? String(removed) : String(envs.length),
+      value: execute ? String(removed) : String(eligible),
       hint: execute ? "destroyed" : "with --execute",
       tone: execute ? (removed > 0 ? "ok" : "dim") : "neutral",
     },
@@ -106,7 +136,9 @@ function renderEnvsKpi({ envs, results, execute }, ui) {
 
 function renderArtifactsKpi({ candidates, results, execute }, ui) {
   const removed = execute ? results.filter((r) => r.status === 0).length : 0;
-  const failed = execute ? results.filter((r) => r.status !== 0).length : 0;
+  const failed = execute
+    ? results.filter((r) => r.status !== 0).length + missingArtifactResultCount(candidates, results)
+    : 0;
   return kpiStrip([
     { label: "Candidates", value: String(candidates.length), hint: "matched", tone: "neutral" },
     {
@@ -179,10 +211,29 @@ function renderHint(execute, kind, ui, ctx = {}) {
   } else if (!execute) {
     const target = ctx.kind === "envs" ? "destroy the envs above" : "remove the dirs above";
     lines.push(`  ${c.head(g.arrow)} ${c.dim(`Re-run with --execute to ${target}.`)}`);
-  } else {
+  } else if (ctx.verdict?.status === "DONE") {
     lines.push(`  ${c.ok(g.check)} ${c.dim("Done.")}`);
+  } else {
+    lines.push(`  ${c.err(g.cross)} ${c.dim("Cleanup did not complete; review failed or skipped items above.")}`);
   }
   return lines.join("\n");
+}
+
+function eligibleEnvCount(envs) {
+  return envs.filter((env) => typeof env === "string" || env.eligible === true).length;
+}
+
+function missingEnvResultCount(envs, results) {
+  const completed = new Set(results.map((result) => result.env ?? extractEnvFromCommand(result.command)));
+  return envs
+    .filter((env) => typeof env === "string" || env.eligible === true)
+    .filter((env) => !completed.has(typeof env === "string" ? env : env.name))
+    .length;
+}
+
+function missingArtifactResultCount(candidates, results) {
+  const completed = new Set(results.map((result) => result.path));
+  return candidates.filter((candidate) => !completed.has(candidate.path)).length;
 }
 
 function extractEnvFromCommand(command) {

--- a/src/run/report-finalization.mjs
+++ b/src/run/report-finalization.mjs
@@ -3,7 +3,8 @@ import {
   loadBaselineStore,
   reviewBaselineUpdate,
   saveBaselineStore,
-  updateBaselineStore
+  updateBaselineStore,
+  withBaselineStoreLock
 } from "../performance/baselines.mjs";
 import { platformInfo } from "../platform.mjs";
 import { summarizeRecords } from "../reporting/report.mjs";
@@ -69,16 +70,21 @@ export async function saveBaselineUpdate(report, options) {
   if (!options.saveBaselinePath) {
     return report;
   }
-  const existingStore = await loadBaselineStore(options.saveBaselinePath);
   const review = reviewBaselineUpdate(report, { reviewedGood: options.reviewedGood === true });
-  const updatedStore = updateBaselineStore(existingStore, report, {
-    targetPlan: options.targetPlan,
-    reviewedGood: options.reviewedGood === true
+  const saved = await withBaselineStoreLock(options.saveBaselinePath, async () => {
+    // The lock owns the entire read-modify-write sequence so separate Kova
+    // processes cannot commit stores derived from the same stale snapshot.
+    const existingStore = await loadBaselineStore(options.saveBaselinePath);
+    const updatedStore = updateBaselineStore(existingStore, report, {
+      targetPlan: options.targetPlan,
+      reviewedGood: options.reviewedGood === true
+    });
+    return saveBaselineStore(options.saveBaselinePath, updatedStore);
   });
   report.baseline = {
     ...(report.baseline ?? {}),
     review,
-    saved: await saveBaselineStore(options.saveBaselinePath, updatedStore)
+    saved
   };
   return report;
 }

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -162,13 +162,9 @@ async function replaceReportFileSet(entries, canonicalPath) {
   } finally {
     await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true }).catch(() => {})));
     if (committed) {
-      await Promise.all(staged.map((entry) => rm(entry.backupPath, { force: true }).catch(() => {})));
-      await rm(transactionPath, { force: true }).catch(() => {});
-      await syncDirectories(staged).catch(() => {});
+      await removeReportBackupsAndMarker(staged, transactionPath).catch(() => {});
     } else if (!preserveBackups) {
-      await Promise.all(staged.map((entry) => rm(entry.backupPath, { force: true })));
-      await rm(transactionPath, { force: true });
-      await syncDirectories(staged);
+      await removeReportBackupsAndMarker(staged, transactionPath);
     }
   }
 }
@@ -187,13 +183,12 @@ async function recoverReportFileSet(entries, canonicalPath, transactionPath) {
   }
   if (backupEntries.length === 0) {
     await rm(transactionPath, { force: true });
+    await syncDirectories(entries);
     return;
   }
 
   if (await currentReportMatchesTransaction(entries, canonicalPath, transactionPath)) {
-    await Promise.all(backupEntries.map((entry) => rm(entry.backupPath, { force: true })));
-    await rm(transactionPath, { force: true });
-    await syncDirectories(entries);
+    await removeReportBackupsAndMarker(entries, transactionPath);
     return;
   }
 
@@ -205,6 +200,16 @@ async function recoverReportFileSet(entries, canonicalPath, transactionPath) {
     await rm(entry.path, { force: true });
     await rename(entry.backupPath, entry.path);
   }
+  await syncDirectories(entries);
+  await rm(transactionPath, { force: true });
+  await syncDirectories(entries);
+}
+
+async function removeReportBackupsAndMarker(entries, transactionPath) {
+  // Keep the transaction marker durable until backup deletion is durable.
+  // Otherwise recovery cannot distinguish a committed generation from a mix.
+  await Promise.all(entries.map((entry) => rm(entry.backupPath, { force: true })));
+  await syncDirectories(entries);
   await rm(transactionPath, { force: true });
   await syncDirectories(entries);
 }

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -185,8 +185,12 @@ async function recoverReportFileSet(entries, canonicalPath) {
     return;
   }
 
-  await Promise.all(entries.map((entry) => rm(entry.path, { force: true })));
-  for (const entry of backupEntries) {
+  const restoreOrder = [
+    ...backupEntries.filter((entry) => entry.path !== canonicalPath),
+    ...backupEntries.filter((entry) => entry.path === canonicalPath)
+  ];
+  for (const entry of restoreOrder) {
+    await rm(entry.path, { force: true });
     await rename(entry.backupPath, entry.path);
   }
   await syncDirectories(entries);

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -1,5 +1,5 @@
-import { randomUUID } from "node:crypto";
-import { lstat, mkdir, open, rename, rm, stat, writeFile } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { lstat, mkdir, open, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { buildReportSummary, renderMarkdownReport } from "../reporting/report.mjs";
 import { createRunId } from "./run-id.mjs";
@@ -83,6 +83,10 @@ async function anyPathExists(paths) {
 
 async function replaceReportFileSet(entries, canonicalPath) {
   const transaction = randomUUID();
+  const transactionPath = join(
+    dirname(canonicalPath),
+    `.${basename(canonicalPath)}.kova-transaction`
+  );
   const staged = entries.map((entry) => ({
     ...entry,
     stagedPath: join(dirname(entry.path), `.${transaction}-${basename(entry.path)}.tmp`),
@@ -93,11 +97,18 @@ async function replaceReportFileSet(entries, canonicalPath) {
   let preserveBackups = false;
   let committed = false;
 
-  await recoverReportFileSet(staged, canonicalPath);
+  await recoverReportFileSet(staged, canonicalPath, transactionPath);
   try {
     for (const entry of staged) {
       await writeDurableFile(entry.stagedPath, entry.content);
     }
+    // Hash the complete generation before moving the old files. Recovery must
+    // not mistake a mixed set left by an incomplete rollback for a commit.
+    await writeDurableFile(
+      transactionPath,
+      `${JSON.stringify(buildReportTransaction(staged, canonicalPath), null, 2)}\n`
+    );
+    await syncDirectories(staged);
 
     // Remove the canonical JSON first and publish it last. Report readers use
     // that file as the commit marker and never observe a newly partial set.
@@ -152,15 +163,17 @@ async function replaceReportFileSet(entries, canonicalPath) {
     await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true }).catch(() => {})));
     if (committed) {
       await Promise.all(staged.map((entry) => rm(entry.backupPath, { force: true }).catch(() => {})));
+      await rm(transactionPath, { force: true }).catch(() => {});
       await syncDirectories(staged).catch(() => {});
     } else if (!preserveBackups) {
       await Promise.all(staged.map((entry) => rm(entry.backupPath, { force: true })));
+      await rm(transactionPath, { force: true });
       await syncDirectories(staged);
     }
   }
 }
 
-async function recoverReportFileSet(entries, canonicalPath) {
+async function recoverReportFileSet(entries, canonicalPath, transactionPath) {
   const backupEntries = [];
   for (const entry of entries) {
     if (!await pathExists(entry.backupPath)) {
@@ -173,22 +186,13 @@ async function recoverReportFileSet(entries, canonicalPath) {
     backupEntries.push(entry);
   }
   if (backupEntries.length === 0) {
+    await rm(transactionPath, { force: true });
     return;
   }
 
-  const canonicalExists = await pathExists(canonicalPath);
-  let currentComplete = canonicalExists;
-  if (currentComplete) {
-    for (const entry of entries) {
-      const info = await lstat(entry.path).catch(() => null);
-      if (!info?.isFile()) {
-        currentComplete = false;
-        break;
-      }
-    }
-  }
-  if (currentComplete) {
+  if (await currentReportMatchesTransaction(entries, canonicalPath, transactionPath)) {
     await Promise.all(backupEntries.map((entry) => rm(entry.backupPath, { force: true })));
+    await rm(transactionPath, { force: true });
     await syncDirectories(entries);
     return;
   }
@@ -201,7 +205,65 @@ async function recoverReportFileSet(entries, canonicalPath) {
     await rm(entry.path, { force: true });
     await rename(entry.backupPath, entry.path);
   }
+  await rm(transactionPath, { force: true });
   await syncDirectories(entries);
+}
+
+function buildReportTransaction(entries, canonicalPath) {
+  return {
+    schemaVersion: "kova.reportTransaction.v1",
+    canonical: basename(canonicalPath),
+    files: entries.map((entry) => ({
+      name: basename(entry.path),
+      sha256: createHash("sha256").update(entry.content).digest("hex")
+    }))
+  };
+}
+
+async function currentReportMatchesTransaction(entries, canonicalPath, transactionPath) {
+  const marker = await readReportTransaction(transactionPath, entries, canonicalPath);
+  if (!marker) {
+    return false;
+  }
+  for (const expected of marker.files) {
+    const entry = entries.find((candidate) => basename(candidate.path) === expected.name);
+    const info = await lstat(entry.path).catch(() => null);
+    if (!info?.isFile()) {
+      return false;
+    }
+    const actual = createHash("sha256").update(await readFile(entry.path)).digest("hex");
+    if (actual !== expected.sha256) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function readReportTransaction(transactionPath, entries, canonicalPath) {
+  let marker;
+  try {
+    marker = JSON.parse(await readFile(transactionPath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return null;
+    }
+    throw new Error(`report transaction marker is invalid: ${transactionPath}`, { cause: error });
+  }
+  const expectedNames = entries.map((entry) => basename(entry.path)).sort();
+  const markerNames = Array.isArray(marker?.files)
+    ? marker.files.map((entry) => entry?.name).sort()
+    : [];
+  const valid = (
+    marker?.schemaVersion === "kova.reportTransaction.v1" &&
+    marker.canonical === basename(canonicalPath) &&
+    markerNames.length === expectedNames.length &&
+    markerNames.every((name, index) => name === expectedNames[index]) &&
+    marker.files.every((entry) => /^[a-f0-9]{64}$/.test(entry?.sha256 ?? ""))
+  );
+  if (!valid) {
+    throw new Error(`report transaction marker is invalid: ${transactionPath}`);
+  }
+  return marker;
 }
 
 async function writeDurableFile(path, content) {

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -196,8 +196,11 @@ async function recoverReportFileSet(entries, canonicalPath, transactionPath) {
     ...backupEntries.filter((entry) => entry.path !== canonicalPath),
     ...backupEntries.filter((entry) => entry.path === canonicalPath)
   ];
+  // Outputs without backups were absent from the prior generation. Remove
+  // every transaction path so an interrupted publish cannot leave them mixed
+  // with the restored canonical report.
+  await Promise.all(entries.map((entry) => rm(entry.path, { force: true })));
   for (const entry of restoreOrder) {
-    await rm(entry.path, { force: true });
     await rename(entry.backupPath, entry.path);
   }
   await syncDirectories(entries);

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -68,6 +68,10 @@ export async function releaseReportOutputLock(lockPath) {
   }
 }
 
+export function reportTransactionLockPath(canonicalPath) {
+  return `${reportTransactionPath(canonicalPath)}.lock`;
+}
+
 async function anyPathExists(paths) {
   for (const path of paths) {
     try {
@@ -83,13 +87,17 @@ async function anyPathExists(paths) {
 }
 
 async function replaceReportFileSet(entries, canonicalPath) {
-  const transactionPath = join(
+  const transactionPath = reportTransactionPath(canonicalPath);
+  return withFileLock(reportTransactionLockPath(canonicalPath), () => (
+    replaceReportFileSetLocked(entries, canonicalPath, transactionPath)
+  ));
+}
+
+function reportTransactionPath(canonicalPath) {
+  return join(
     dirname(canonicalPath),
     `.${basename(canonicalPath)}.kova-transaction`
   );
-  return withFileLock(`${transactionPath}.lock`, () => (
-    replaceReportFileSetLocked(entries, canonicalPath, transactionPath)
-  ));
 }
 
 async function replaceReportFileSetLocked(entries, canonicalPath, transactionPath) {

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -86,12 +86,14 @@ async function replaceReportFileSet(entries, canonicalPath) {
   const staged = entries.map((entry) => ({
     ...entry,
     stagedPath: join(dirname(entry.path), `.${transaction}-${basename(entry.path)}.tmp`),
-    backupPath: join(dirname(entry.path), `.${transaction}-${basename(entry.path)}.bak`)
+    backupPath: join(dirname(entry.path), `.${basename(entry.path)}.kova-backup`)
   }));
   const backups = [];
   const published = [];
   let preserveBackups = false;
+  let committed = false;
 
+  await recoverReportFileSet(staged, canonicalPath);
   try {
     for (const entry of staged) {
       await writeDurableFile(entry.stagedPath, entry.content);
@@ -109,15 +111,21 @@ async function replaceReportFileSet(entries, canonicalPath) {
         backups.push(entry);
       }
     }
+    await syncDirectories(staged);
 
     const publishOrder = [
       ...staged.filter((entry) => entry.path !== canonicalPath),
       ...staged.filter((entry) => entry.path === canonicalPath)
     ];
     for (const entry of publishOrder) {
+      if (entry.path === canonicalPath) {
+        await syncDirectories(staged);
+      }
       await rename(entry.stagedPath, entry.path);
       published.push(entry);
     }
+    await syncDirectories(staged);
+    committed = true;
   } catch (error) {
     const rollbackErrors = [];
     for (const entry of published.toReversed()) {
@@ -126,17 +134,62 @@ async function replaceReportFileSet(entries, canonicalPath) {
     for (const entry of backups.toReversed()) {
       await rename(entry.backupPath, entry.path).catch((rollbackError) => rollbackErrors.push(rollbackError));
     }
+    await syncDirectories(staged).catch((rollbackError) => rollbackErrors.push(rollbackError));
     if (rollbackErrors.length > 0) {
       preserveBackups = true;
       throw new AggregateError([error, ...rollbackErrors], "report publication failed and rollback was incomplete");
     }
     throw error;
   } finally {
-    await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true })));
-    if (!preserveBackups) {
+    await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true }).catch(() => {})));
+    if (committed) {
+      await Promise.all(staged.map((entry) => rm(entry.backupPath, { force: true }).catch(() => {})));
+      await syncDirectories(staged).catch(() => {});
+    } else if (!preserveBackups) {
       await Promise.all(staged.map((entry) => rm(entry.backupPath, { force: true })));
+      await syncDirectories(staged);
     }
   }
+}
+
+async function recoverReportFileSet(entries, canonicalPath) {
+  const backupEntries = [];
+  for (const entry of entries) {
+    if (!await pathExists(entry.backupPath)) {
+      continue;
+    }
+    const info = await lstat(entry.backupPath);
+    if (!info.isFile()) {
+      throw new Error(`report backup is not a regular file: ${entry.backupPath}`);
+    }
+    backupEntries.push(entry);
+  }
+  if (backupEntries.length === 0) {
+    return;
+  }
+
+  const canonicalExists = await pathExists(canonicalPath);
+  let currentComplete = canonicalExists;
+  if (currentComplete) {
+    for (const entry of entries) {
+      const info = await lstat(entry.path).catch(() => null);
+      if (!info?.isFile()) {
+        currentComplete = false;
+        break;
+      }
+    }
+  }
+  if (currentComplete) {
+    await Promise.all(backupEntries.map((entry) => rm(entry.backupPath, { force: true })));
+    await syncDirectories(entries);
+    return;
+  }
+
+  await Promise.all(entries.map((entry) => rm(entry.path, { force: true })));
+  for (const entry of backupEntries) {
+    await rename(entry.backupPath, entry.path);
+  }
+  await syncDirectories(entries);
 }
 
 async function writeDurableFile(path, content) {
@@ -147,6 +200,21 @@ async function writeDurableFile(path, content) {
   } finally {
     await handle.close();
   }
+}
+
+async function syncDirectories(entries) {
+  if (process.platform === "win32") {
+    return;
+  }
+  const directories = [...new Set(entries.map((entry) => dirname(entry.path)))];
+  await Promise.all(directories.map(async (directory) => {
+    const handle = await open(directory, "r");
+    try {
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  }));
 }
 
 async function pathExists(path) {

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -192,11 +192,10 @@ async function recoverReportFileSet(entries, canonicalPath, transactionPath) {
     return;
   }
 
-  if (marker) {
-    await restorePreviousReportSet(entries, backupEntries, marker, canonicalPath);
-  } else {
-    await restoreLegacyReportBackups(backupEntries, canonicalPath);
+  if (!marker) {
+    throw new Error(`report backup is missing transaction marker: ${backupEntries[0].backupPath}`);
   }
+  await restorePreviousReportSet(entries, backupEntries, marker, canonicalPath);
   await syncDirectories(entries);
   await rm(transactionPath, { force: true });
   await syncDirectories(entries);
@@ -224,10 +223,10 @@ async function restorePreviousReportSet(entries, backupEntries, marker, canonica
     }
   }
 
-  await restoreLegacyReportBackups(backupEntries, canonicalPath);
+  await restoreReportBackups(backupEntries, canonicalPath);
 }
 
-async function restoreLegacyReportBackups(backupEntries, canonicalPath) {
+async function restoreReportBackups(backupEntries, canonicalPath) {
   const restoreOrder = [
     ...backupEntries.filter((entry) => entry.path !== canonicalPath),
     ...backupEntries.filter((entry) => entry.path === canonicalPath)

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -104,11 +104,11 @@ async function replaceReportFileSet(entries, canonicalPath) {
     }
     // Hash the complete generation before moving the old files. Recovery must
     // not mistake a mixed set left by an incomplete rollback for a commit.
-    await writeDurableFile(
+    await writeDurableReportTransaction(
       transactionPath,
-      `${JSON.stringify(await buildReportTransaction(staged, canonicalPath), null, 2)}\n`
+      `${JSON.stringify(await buildReportTransaction(staged, canonicalPath), null, 2)}\n`,
+      staged
     );
-    await syncDirectories(staged);
 
     // Remove the canonical JSON first and publish it last. Report readers use
     // that file as the commit marker and never observe a newly partial set.
@@ -170,6 +170,7 @@ async function replaceReportFileSet(entries, canonicalPath) {
 }
 
 async function recoverReportFileSet(entries, canonicalPath, transactionPath) {
+  await rm(`${transactionPath}.tmp`, { force: true });
   const marker = await readReportTransaction(transactionPath, entries, canonicalPath);
   const backupEntries = [];
   for (const entry of entries) {
@@ -328,6 +329,17 @@ async function readReportTransaction(transactionPath, entries, canonicalPath) {
 
 async function fileSha256(path) {
   return createHash("sha256").update(await readFile(path)).digest("hex");
+}
+
+async function writeDurableReportTransaction(path, content, entries) {
+  const stagedPath = `${path}.tmp`;
+  try {
+    await writeDurableFile(stagedPath, content);
+    await rename(stagedPath, path);
+    await syncDirectories(entries);
+  } finally {
+    await rm(stagedPath, { force: true });
+  }
 }
 
 async function writeDurableFile(path, content) {

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
-import { lstat, mkdir, open, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { lstat, mkdir, open, readFile, readdir, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
+import { withFileLock } from "../file-lock.mjs";
 import { buildReportSummary, renderMarkdownReport } from "../reporting/report.mjs";
 import { createRunId } from "./run-id.mjs";
 
@@ -82,17 +83,22 @@ async function anyPathExists(paths) {
 }
 
 async function replaceReportFileSet(entries, canonicalPath) {
-  const transaction = randomUUID();
   const transactionPath = join(
     dirname(canonicalPath),
     `.${basename(canonicalPath)}.kova-transaction`
   );
+  return withFileLock(`${transactionPath}.lock`, () => (
+    replaceReportFileSetLocked(entries, canonicalPath, transactionPath)
+  ));
+}
+
+async function replaceReportFileSetLocked(entries, canonicalPath, transactionPath) {
+  const transaction = randomUUID();
   const staged = entries.map((entry) => ({
     ...entry,
     stagedPath: join(dirname(entry.path), `.${transaction}-${basename(entry.path)}.tmp`),
     backupPath: join(dirname(entry.path), `.${basename(entry.path)}.kova-backup`)
   }));
-  const backups = [];
   const published = [];
   let preserveBackups = false;
   let committed = false;
@@ -105,7 +111,7 @@ async function replaceReportFileSet(entries, canonicalPath) {
     }
     // Hash the complete generation before moving the old files. Recovery must
     // not mistake a mixed set left by an incomplete rollback for a commit.
-    transactionMarker = await buildReportTransaction(staged, canonicalPath);
+    transactionMarker = await buildReportTransaction(staged, canonicalPath, transaction);
     await writeDurableReportTransaction(
       transactionPath,
       `${JSON.stringify(transactionMarker, null, 2)}\n`,
@@ -121,7 +127,6 @@ async function replaceReportFileSet(entries, canonicalPath) {
     for (const entry of backupOrder) {
       if (await pathExists(entry.path)) {
         await rename(entry.path, entry.backupPath);
-        backups.push(entry);
       }
     }
     await syncDirectories(staged);
@@ -144,16 +149,17 @@ async function replaceReportFileSet(entries, canonicalPath) {
     for (const entry of published.toReversed()) {
       await rm(entry.path, { force: true }).catch((rollbackError) => rollbackErrors.push(rollbackError));
     }
-    const companionBackups = backups
-      .filter((entry) => entry.path !== canonicalPath)
-      .toReversed();
-    for (const entry of companionBackups) {
-      await rename(entry.backupPath, entry.path).catch((rollbackError) => rollbackErrors.push(rollbackError));
-    }
-    const canonicalBackup = backups.find((entry) => entry.path === canonicalPath);
-    if (rollbackErrors.length === 0 && canonicalBackup) {
-      await rename(canonicalBackup.backupPath, canonicalBackup.path)
+    if (rollbackErrors.length === 0 && transactionMarker) {
+      await restorePreviousReportSet(staged, transactionMarker, canonicalPath)
         .catch((rollbackError) => rollbackErrors.push(rollbackError));
+      if (rollbackErrors.length === 0) {
+        await syncDirectories(staged)
+          .catch((rollbackError) => rollbackErrors.push(rollbackError));
+      }
+      if (rollbackErrors.length === 0) {
+        await rm(transactionPath, { force: true })
+          .catch((rollbackError) => rollbackErrors.push(rollbackError));
+      }
     }
     await syncDirectories(staged).catch((rollbackError) => rollbackErrors.push(rollbackError));
     if (rollbackErrors.length > 0) {
@@ -165,7 +171,7 @@ async function replaceReportFileSet(entries, canonicalPath) {
     await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true }).catch(() => {})));
     if (committed) {
       await removeReportBackupsAndMarker(staged, transactionPath, transactionMarker).catch(() => {});
-    } else if (!preserveBackups) {
+    } else if (!preserveBackups && transactionMarker) {
       await removeReportBackupsAndMarker(staged, transactionPath, transactionMarker);
     }
   }
@@ -174,45 +180,33 @@ async function replaceReportFileSet(entries, canonicalPath) {
 async function recoverReportFileSet(entries, canonicalPath, transactionPath) {
   await rm(`${transactionPath}.tmp`, { force: true });
   const marker = await readReportTransaction(transactionPath, entries, canonicalPath);
-  const backupEntries = [];
-  for (const entry of entries) {
-    if (!await pathExists(entry.backupPath)) {
-      continue;
-    }
-    const info = await lstat(entry.backupPath);
-    if (!info.isFile()) {
-      throw new Error(`report backup is not a regular file: ${entry.backupPath}`);
-    }
-    backupEntries.push(entry);
-  }
-  if (!marker && backupEntries.length === 0) {
-    return;
-  }
-
-  if (marker && await currentReportMatchesTransaction(entries, marker)) {
-    await removeReportBackupsAndMarker(entries, transactionPath, marker);
+  if (!marker && !await reportBackupStateExists(entries)) {
     return;
   }
 
   if (!marker) {
-    throw new Error(`report backup is missing transaction marker: ${backupEntries[0].backupPath}`);
+    throw new Error(`report backup is missing transaction marker: ${entries[0].backupPath}`);
   }
-  await restorePreviousReportSet(entries, backupEntries, marker, canonicalPath);
+
+  if (await currentReportMatchesTransaction(entries, marker)) {
+    await removeReportBackupsAndMarker(entries, transactionPath, marker);
+    return;
+  }
+
+  await restorePreviousReportSet(entries, marker, canonicalPath);
   await syncDirectories(entries);
   await rm(transactionPath, { force: true });
   await syncDirectories(entries);
 }
 
-async function restorePreviousReportSet(entries, backupEntries, marker, canonicalPath) {
+async function restorePreviousReportSet(entries, marker, canonicalPath) {
+  const claimedBackups = await claimReportBackups(entries, marker, "restore");
   const previousFiles = new Map(marker.previousFiles.map((entry) => [entry.name, entry.sha256]));
-  const backedUpNames = new Set(backupEntries.map((entry) => basename(entry.path)));
+  const backedUpNames = new Set(claimedBackups.map((entry) => basename(entry.path)));
   for (const entry of entries) {
     const name = basename(entry.path);
     const previousHash = previousFiles.get(name);
     if (backedUpNames.has(name)) {
-      if (!previousHash || await fileSha256(entry.backupPath) !== previousHash) {
-        throw new Error(`report backup does not match transaction marker: ${entry.backupPath}`);
-      }
       continue;
     }
     if (!previousHash) {
@@ -225,49 +219,37 @@ async function restorePreviousReportSet(entries, backupEntries, marker, canonica
     }
   }
 
-  await restoreReportBackups(backupEntries, canonicalPath);
+  await restoreReportBackups(claimedBackups, canonicalPath);
 }
 
-async function restoreReportBackups(backupEntries, canonicalPath) {
+async function restoreReportBackups(claimedBackups, canonicalPath) {
   const restoreOrder = [
-    ...backupEntries.filter((entry) => entry.path !== canonicalPath),
-    ...backupEntries.filter((entry) => entry.path === canonicalPath)
+    ...claimedBackups.filter((entry) => entry.path !== canonicalPath),
+    ...claimedBackups.filter((entry) => entry.path === canonicalPath)
   ];
   for (const entry of restoreOrder) {
+    await validateClaimedReportBackup(entry);
     await rm(entry.path, { force: true });
-    await rename(entry.backupPath, entry.path);
+    await rename(entry.claimPath, entry.path);
+    await rmdir(entry.claimContainer);
   }
 }
 
 async function removeReportBackupsAndMarker(entries, transactionPath, marker) {
   // Keep the transaction marker durable until backup deletion is durable.
   // Otherwise recovery cannot distinguish a committed generation from a mix.
-  const previousFiles = new Map(
-    Array.isArray(marker?.previousFiles)
-      ? marker.previousFiles.map((entry) => [entry.name, entry.sha256])
-      : []
-  );
-  for (const entry of entries) {
-    if (!await pathExists(entry.backupPath)) {
-      continue;
-    }
-    const expectedHash = previousFiles.get(basename(entry.path));
-    const info = await lstat(entry.backupPath);
-    if (
-      !expectedHash ||
-      !info.isFile() ||
-      await fileSha256(entry.backupPath) !== expectedHash
-    ) {
-      throw new Error(`report backup does not match transaction marker: ${entry.backupPath}`);
-    }
+  const claimedBackups = await claimReportBackups(entries, marker, "cleanup");
+  for (const entry of claimedBackups) {
+    await validateClaimedReportBackup(entry);
+    await rm(entry.claimPath, { force: true });
+    await rmdir(entry.claimContainer);
   }
-  await Promise.all(entries.map((entry) => rm(entry.backupPath, { force: true })));
   await syncDirectories(entries);
   await rm(transactionPath, { force: true });
   await syncDirectories(entries);
 }
 
-async function buildReportTransaction(entries, canonicalPath) {
+async function buildReportTransaction(entries, canonicalPath, transaction) {
   const previousFiles = [];
   for (const entry of entries) {
     const info = await lstat(entry.path).catch((error) => {
@@ -288,7 +270,8 @@ async function buildReportTransaction(entries, canonicalPath) {
     });
   }
   return {
-    schemaVersion: "kova.reportTransaction.v2",
+    schemaVersion: "kova.reportTransaction.v3",
+    transaction,
     canonical: basename(canonicalPath),
     previousFiles,
     files: entries.map((entry) => ({
@@ -331,7 +314,10 @@ async function readReportTransaction(transactionPath, entries, canonicalPath) {
     : [];
   const uniquePreviousNames = new Set(previousNames);
   const valid = (
-    marker?.schemaVersion === "kova.reportTransaction.v2" &&
+    marker?.schemaVersion === "kova.reportTransaction.v3" &&
+    /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/.test(
+      marker.transaction ?? ""
+    ) &&
     marker.canonical === basename(canonicalPath) &&
     Array.isArray(marker.previousFiles) &&
     markerNames.length === expectedNames.length &&
@@ -345,6 +331,120 @@ async function readReportTransaction(transactionPath, entries, canonicalPath) {
     throw new Error(`report transaction marker is invalid: ${transactionPath}`);
   }
   return marker;
+}
+
+async function claimReportBackups(entries, marker, mode) {
+  const previousFiles = new Map(marker.previousFiles.map((entry) => [entry.name, entry.sha256]));
+  const claimed = [];
+  for (const entry of entries) {
+    const claimContainer = reportBackupClaimContainer(entry, marker);
+    const claimPath = join(claimContainer, "backup");
+    const backupExists = await pathExists(entry.backupPath);
+    const containerExists = await pathExists(claimContainer);
+    if (!backupExists && !containerExists) {
+      continue;
+    }
+    if (!containerExists) {
+      await mkdir(claimContainer, { recursive: false, mode: 0o700 });
+      await syncDirectory(dirname(claimContainer));
+    }
+    await assertReportClaimContainer(claimContainer);
+    const claimExists = await pathExists(claimPath);
+    if (backupExists && claimExists) {
+      throw new Error(`report backup has a conflicting replacement: ${entry.backupPath}`);
+    }
+    if (!backupExists && !claimExists) {
+      const expectedHash = previousFiles.get(basename(entry.path));
+      const priorFileRestored = (
+        mode === "restore" &&
+        expectedHash &&
+        await regularFileMatches(entry.path, expectedHash)
+      );
+      if (mode !== "cleanup" && !priorFileRestored) {
+        throw new Error(`report backup claim is incomplete: ${claimContainer}`);
+      }
+      await assertEmptyReportClaimContainer(claimContainer);
+      await rmdir(claimContainer);
+      await syncDirectory(dirname(claimContainer));
+      continue;
+    }
+    if (backupExists) {
+      await rename(entry.backupPath, claimPath);
+      await syncDirectory(claimContainer);
+      await syncDirectory(dirname(entry.backupPath));
+    }
+    const expectedHash = previousFiles.get(basename(entry.path));
+    const info = await lstat(claimPath);
+    if (
+      !expectedHash ||
+      !info.isFile() ||
+      await fileSha256(claimPath) !== expectedHash
+    ) {
+      throw new Error(`report backup does not match transaction marker: ${claimPath}`);
+    }
+    claimed.push({ ...entry, claimContainer, claimPath, expectedHash });
+  }
+  return claimed;
+}
+
+async function regularFileMatches(path, expectedHash) {
+  const info = await lstat(path).catch(() => null);
+  return Boolean(info?.isFile() && await fileSha256(path) === expectedHash);
+}
+
+function reportBackupClaimContainer(entry, marker) {
+  return `${entry.backupPath}.claim-${marker.transaction}`;
+}
+
+async function assertReportClaimContainer(path) {
+  const info = await lstat(path);
+  if (!info.isDirectory()) {
+    throw new Error(`report backup claim is invalid: ${path}`);
+  }
+  const names = await readdir(path);
+  if (names.some((name) => name !== "backup")) {
+    throw new Error(`report backup claim is invalid: ${path}`);
+  }
+}
+
+async function assertEmptyReportClaimContainer(path) {
+  await assertReportClaimContainer(path);
+  if ((await readdir(path)).length !== 0) {
+    throw new Error(`report backup claim is not empty: ${path}`);
+  }
+}
+
+async function validateClaimedReportBackup(entry) {
+  // The 0700 claim container and report lock exclude peer Kova writers.
+  // Revalidate immediately before mutation; same-user hostile writers are outside the trust boundary.
+  await assertReportClaimContainer(entry.claimContainer);
+  if (!await regularFileMatches(entry.claimPath, entry.expectedHash)) {
+    throw new Error(`report backup does not match transaction marker: ${entry.claimPath}`);
+  }
+}
+
+async function reportBackupStateExists(entries) {
+  const directories = [...new Set(entries.map((entry) => dirname(entry.backupPath)))];
+  for (const entry of entries) {
+    if (await pathExists(entry.backupPath)) {
+      return true;
+    }
+  }
+  for (const directory of directories) {
+    const names = await readdir(directory).catch((error) => {
+      if (error?.code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    });
+    if (entries.some((entry) => {
+      const prefix = `${basename(entry.backupPath)}.claim-`;
+      return names.some((name) => name.startsWith(prefix));
+    })) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function fileSha256(path) {
@@ -377,14 +477,19 @@ async function syncDirectories(entries) {
     return;
   }
   const directories = [...new Set(entries.map((entry) => dirname(entry.path)))];
-  await Promise.all(directories.map(async (directory) => {
-    const handle = await open(directory, "r");
-    try {
-      await handle.sync();
-    } finally {
-      await handle.close();
-    }
-  }));
+  await Promise.all(directories.map((directory) => syncDirectory(directory)));
+}
+
+async function syncDirectory(directory) {
+  if (process.platform === "win32") {
+    return;
+  }
+  const handle = await open(directory, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
 }
 
 async function pathExists(path) {

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -106,7 +106,7 @@ async function replaceReportFileSet(entries, canonicalPath) {
     // not mistake a mixed set left by an incomplete rollback for a commit.
     await writeDurableFile(
       transactionPath,
-      `${JSON.stringify(buildReportTransaction(staged, canonicalPath), null, 2)}\n`
+      `${JSON.stringify(await buildReportTransaction(staged, canonicalPath), null, 2)}\n`
     );
     await syncDirectories(staged);
 
@@ -170,6 +170,7 @@ async function replaceReportFileSet(entries, canonicalPath) {
 }
 
 async function recoverReportFileSet(entries, canonicalPath, transactionPath) {
+  const marker = await readReportTransaction(transactionPath, entries, canonicalPath);
   const backupEntries = [];
   for (const entry of entries) {
     if (!await pathExists(entry.backupPath)) {
@@ -181,31 +182,59 @@ async function recoverReportFileSet(entries, canonicalPath, transactionPath) {
     }
     backupEntries.push(entry);
   }
-  if (backupEntries.length === 0) {
-    await rm(transactionPath, { force: true });
-    await syncDirectories(entries);
+  if (!marker && backupEntries.length === 0) {
     return;
   }
 
-  if (await currentReportMatchesTransaction(entries, canonicalPath, transactionPath)) {
+  if (marker && await currentReportMatchesTransaction(entries, marker)) {
     await removeReportBackupsAndMarker(entries, transactionPath);
     return;
   }
 
-  const restoreOrder = [
-    ...backupEntries.filter((entry) => entry.path !== canonicalPath),
-    ...backupEntries.filter((entry) => entry.path === canonicalPath)
-  ];
-  // Outputs without backups were absent from the prior generation. Remove
-  // every transaction path so an interrupted publish cannot leave them mixed
-  // with the restored canonical report.
-  await Promise.all(entries.map((entry) => rm(entry.path, { force: true })));
-  for (const entry of restoreOrder) {
-    await rename(entry.backupPath, entry.path);
+  if (marker) {
+    await restorePreviousReportSet(entries, backupEntries, marker, canonicalPath);
+  } else {
+    await restoreLegacyReportBackups(backupEntries, canonicalPath);
   }
   await syncDirectories(entries);
   await rm(transactionPath, { force: true });
   await syncDirectories(entries);
+}
+
+async function restorePreviousReportSet(entries, backupEntries, marker, canonicalPath) {
+  const previousFiles = new Map(marker.previousFiles.map((entry) => [entry.name, entry.sha256]));
+  const backedUpNames = new Set(backupEntries.map((entry) => basename(entry.path)));
+  for (const entry of entries) {
+    const name = basename(entry.path);
+    const previousHash = previousFiles.get(name);
+    if (backedUpNames.has(name)) {
+      if (!previousHash || await fileSha256(entry.backupPath) !== previousHash) {
+        throw new Error(`report backup does not match transaction marker: ${entry.backupPath}`);
+      }
+      continue;
+    }
+    if (!previousHash) {
+      await rm(entry.path, { force: true });
+      continue;
+    }
+    const info = await lstat(entry.path).catch(() => null);
+    if (!info?.isFile() || await fileSha256(entry.path) !== previousHash) {
+      throw new Error(`report prior file does not match transaction marker: ${entry.path}`);
+    }
+  }
+
+  await restoreLegacyReportBackups(backupEntries, canonicalPath);
+}
+
+async function restoreLegacyReportBackups(backupEntries, canonicalPath) {
+  const restoreOrder = [
+    ...backupEntries.filter((entry) => entry.path !== canonicalPath),
+    ...backupEntries.filter((entry) => entry.path === canonicalPath)
+  ];
+  for (const entry of restoreOrder) {
+    await rm(entry.path, { force: true });
+    await rename(entry.backupPath, entry.path);
+  }
 }
 
 async function removeReportBackupsAndMarker(entries, transactionPath) {
@@ -217,10 +246,30 @@ async function removeReportBackupsAndMarker(entries, transactionPath) {
   await syncDirectories(entries);
 }
 
-function buildReportTransaction(entries, canonicalPath) {
+async function buildReportTransaction(entries, canonicalPath) {
+  const previousFiles = [];
+  for (const entry of entries) {
+    const info = await lstat(entry.path).catch((error) => {
+      if (error?.code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    });
+    if (!info) {
+      continue;
+    }
+    if (!info.isFile()) {
+      throw new Error(`report output is not a regular file: ${entry.path}`);
+    }
+    previousFiles.push({
+      name: basename(entry.path),
+      sha256: await fileSha256(entry.path)
+    });
+  }
   return {
-    schemaVersion: "kova.reportTransaction.v1",
+    schemaVersion: "kova.reportTransaction.v2",
     canonical: basename(canonicalPath),
+    previousFiles,
     files: entries.map((entry) => ({
       name: basename(entry.path),
       sha256: createHash("sha256").update(entry.content).digest("hex")
@@ -228,19 +277,14 @@ function buildReportTransaction(entries, canonicalPath) {
   };
 }
 
-async function currentReportMatchesTransaction(entries, canonicalPath, transactionPath) {
-  const marker = await readReportTransaction(transactionPath, entries, canonicalPath);
-  if (!marker) {
-    return false;
-  }
+async function currentReportMatchesTransaction(entries, marker) {
   for (const expected of marker.files) {
     const entry = entries.find((candidate) => basename(candidate.path) === expected.name);
     const info = await lstat(entry.path).catch(() => null);
     if (!info?.isFile()) {
       return false;
     }
-    const actual = createHash("sha256").update(await readFile(entry.path)).digest("hex");
-    if (actual !== expected.sha256) {
+    if (await fileSha256(entry.path) !== expected.sha256) {
       return false;
     }
   }
@@ -261,17 +305,29 @@ async function readReportTransaction(transactionPath, entries, canonicalPath) {
   const markerNames = Array.isArray(marker?.files)
     ? marker.files.map((entry) => entry?.name).sort()
     : [];
+  const previousNames = Array.isArray(marker?.previousFiles)
+    ? marker.previousFiles.map((entry) => entry?.name)
+    : [];
+  const uniquePreviousNames = new Set(previousNames);
   const valid = (
-    marker?.schemaVersion === "kova.reportTransaction.v1" &&
+    marker?.schemaVersion === "kova.reportTransaction.v2" &&
     marker.canonical === basename(canonicalPath) &&
+    Array.isArray(marker.previousFiles) &&
     markerNames.length === expectedNames.length &&
     markerNames.every((name, index) => name === expectedNames[index]) &&
-    marker.files.every((entry) => /^[a-f0-9]{64}$/.test(entry?.sha256 ?? ""))
+    marker.files.every((entry) => /^[a-f0-9]{64}$/.test(entry?.sha256 ?? "")) &&
+    uniquePreviousNames.size === previousNames.length &&
+    previousNames.every((name) => expectedNames.includes(name)) &&
+    marker.previousFiles.every((entry) => /^[a-f0-9]{64}$/.test(entry?.sha256 ?? ""))
   );
   if (!valid) {
     throw new Error(`report transaction marker is invalid: ${transactionPath}`);
   }
   return marker;
+}
+
+async function fileSha256(path) {
+  return createHash("sha256").update(await readFile(path)).digest("hex");
 }
 
 async function writeDurableFile(path, content) {

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -131,8 +131,16 @@ async function replaceReportFileSet(entries, canonicalPath) {
     for (const entry of published.toReversed()) {
       await rm(entry.path, { force: true }).catch((rollbackError) => rollbackErrors.push(rollbackError));
     }
-    for (const entry of backups.toReversed()) {
+    const companionBackups = backups
+      .filter((entry) => entry.path !== canonicalPath)
+      .toReversed();
+    for (const entry of companionBackups) {
       await rename(entry.backupPath, entry.path).catch((rollbackError) => rollbackErrors.push(rollbackError));
+    }
+    const canonicalBackup = backups.find((entry) => entry.path === canonicalPath);
+    if (rollbackErrors.length === 0 && canonicalBackup) {
+      await rename(canonicalBackup.backupPath, canonicalBackup.path)
+        .catch((rollbackError) => rollbackErrors.push(rollbackError));
     }
     await syncDirectories(staged).catch((rollbackError) => rollbackErrors.push(rollbackError));
     if (rollbackErrors.length > 0) {

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -1,5 +1,6 @@
-import { mkdir, rm, stat, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { lstat, mkdir, open, rename, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 import { buildReportSummary, renderMarkdownReport } from "../reporting/report.mjs";
 import { createRunId } from "./run-id.mjs";
 
@@ -18,14 +19,20 @@ export async function allocateReportOutputPaths(reportRoot, suffix = null) {
     const runId = createRunId();
     const outputPaths = buildReportOutputPaths(reportRoot, runId, suffix);
     const lockPath = join(reportRoot, `${runId}.lock`);
+    let lockAcquired = false;
     try {
       await writeFile(lockPath, `${process.pid}\n`, { flag: "wx" });
+      lockAcquired = true;
       if (await anyPathExists(Object.values(outputPaths))) {
         await releaseReportOutputLock(lockPath);
+        lockAcquired = false;
         continue;
       }
       return { runId, outputPaths, lockPath };
     } catch (error) {
+      if (lockAcquired) {
+        await releaseReportOutputLock(lockPath);
+      }
       if (error?.code === "EEXIST") {
         continue;
       }
@@ -37,9 +44,21 @@ export async function allocateReportOutputPaths(reportRoot, suffix = null) {
 
 export async function writeReportOutputs(reportRoot, report) {
   await mkdir(reportRoot, { recursive: true });
-  await writeFile(report.outputPaths.markdown, renderMarkdownReport(report), "utf8");
-  await writeFile(report.outputPaths.json, `${JSON.stringify(report, null, 2)}\n`, "utf8");
-  await writeFile(report.outputPaths.summary, `${JSON.stringify(buildReportSummary(report), null, 2)}\n`, "utf8");
+  const entries = [
+    {
+      path: report.outputPaths.markdown,
+      content: renderMarkdownReport(report)
+    },
+    {
+      path: report.outputPaths.summary,
+      content: `${JSON.stringify(buildReportSummary(report), null, 2)}\n`
+    },
+    {
+      path: report.outputPaths.json,
+      content: `${JSON.stringify(report, null, 2)}\n`
+    }
+  ];
+  await replaceReportFileSet(entries, report.outputPaths.json);
 }
 
 export async function releaseReportOutputLock(lockPath) {
@@ -60,4 +79,84 @@ async function anyPathExists(paths) {
     }
   }
   return false;
+}
+
+async function replaceReportFileSet(entries, canonicalPath) {
+  const transaction = randomUUID();
+  const staged = entries.map((entry) => ({
+    ...entry,
+    stagedPath: join(dirname(entry.path), `.${transaction}-${basename(entry.path)}.tmp`),
+    backupPath: join(dirname(entry.path), `.${transaction}-${basename(entry.path)}.bak`)
+  }));
+  const backups = [];
+  const published = [];
+  let preserveBackups = false;
+
+  try {
+    for (const entry of staged) {
+      await writeDurableFile(entry.stagedPath, entry.content);
+    }
+
+    // Remove the canonical JSON first and publish it last. Report readers use
+    // that file as the commit marker and never observe a newly partial set.
+    const backupOrder = [
+      ...staged.filter((entry) => entry.path === canonicalPath),
+      ...staged.filter((entry) => entry.path !== canonicalPath)
+    ];
+    for (const entry of backupOrder) {
+      if (await pathExists(entry.path)) {
+        await rename(entry.path, entry.backupPath);
+        backups.push(entry);
+      }
+    }
+
+    const publishOrder = [
+      ...staged.filter((entry) => entry.path !== canonicalPath),
+      ...staged.filter((entry) => entry.path === canonicalPath)
+    ];
+    for (const entry of publishOrder) {
+      await rename(entry.stagedPath, entry.path);
+      published.push(entry);
+    }
+  } catch (error) {
+    const rollbackErrors = [];
+    for (const entry of published.toReversed()) {
+      await rm(entry.path, { force: true }).catch((rollbackError) => rollbackErrors.push(rollbackError));
+    }
+    for (const entry of backups.toReversed()) {
+      await rename(entry.backupPath, entry.path).catch((rollbackError) => rollbackErrors.push(rollbackError));
+    }
+    if (rollbackErrors.length > 0) {
+      preserveBackups = true;
+      throw new AggregateError([error, ...rollbackErrors], "report publication failed and rollback was incomplete");
+    }
+    throw error;
+  } finally {
+    await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true })));
+    if (!preserveBackups) {
+      await Promise.all(staged.map((entry) => rm(entry.backupPath, { force: true })));
+    }
+  }
+}
+
+async function writeDurableFile(path, content) {
+  const handle = await open(path, "wx", 0o600);
+  try {
+    await handle.writeFile(content, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function pathExists(path) {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
 }

--- a/src/run/report-output.mjs
+++ b/src/run/report-output.mjs
@@ -96,6 +96,7 @@ async function replaceReportFileSet(entries, canonicalPath) {
   const published = [];
   let preserveBackups = false;
   let committed = false;
+  let transactionMarker = null;
 
   await recoverReportFileSet(staged, canonicalPath, transactionPath);
   try {
@@ -104,9 +105,10 @@ async function replaceReportFileSet(entries, canonicalPath) {
     }
     // Hash the complete generation before moving the old files. Recovery must
     // not mistake a mixed set left by an incomplete rollback for a commit.
+    transactionMarker = await buildReportTransaction(staged, canonicalPath);
     await writeDurableReportTransaction(
       transactionPath,
-      `${JSON.stringify(await buildReportTransaction(staged, canonicalPath), null, 2)}\n`,
+      `${JSON.stringify(transactionMarker, null, 2)}\n`,
       staged
     );
 
@@ -162,9 +164,9 @@ async function replaceReportFileSet(entries, canonicalPath) {
   } finally {
     await Promise.all(staged.map((entry) => rm(entry.stagedPath, { force: true }).catch(() => {})));
     if (committed) {
-      await removeReportBackupsAndMarker(staged, transactionPath).catch(() => {});
+      await removeReportBackupsAndMarker(staged, transactionPath, transactionMarker).catch(() => {});
     } else if (!preserveBackups) {
-      await removeReportBackupsAndMarker(staged, transactionPath);
+      await removeReportBackupsAndMarker(staged, transactionPath, transactionMarker);
     }
   }
 }
@@ -188,7 +190,7 @@ async function recoverReportFileSet(entries, canonicalPath, transactionPath) {
   }
 
   if (marker && await currentReportMatchesTransaction(entries, marker)) {
-    await removeReportBackupsAndMarker(entries, transactionPath);
+    await removeReportBackupsAndMarker(entries, transactionPath, marker);
     return;
   }
 
@@ -237,9 +239,28 @@ async function restoreReportBackups(backupEntries, canonicalPath) {
   }
 }
 
-async function removeReportBackupsAndMarker(entries, transactionPath) {
+async function removeReportBackupsAndMarker(entries, transactionPath, marker) {
   // Keep the transaction marker durable until backup deletion is durable.
   // Otherwise recovery cannot distinguish a committed generation from a mix.
+  const previousFiles = new Map(
+    Array.isArray(marker?.previousFiles)
+      ? marker.previousFiles.map((entry) => [entry.name, entry.sha256])
+      : []
+  );
+  for (const entry of entries) {
+    if (!await pathExists(entry.backupPath)) {
+      continue;
+    }
+    const expectedHash = previousFiles.get(basename(entry.path));
+    const info = await lstat(entry.backupPath);
+    if (
+      !expectedHash ||
+      !info.isFile() ||
+      await fileSha256(entry.backupPath) !== expectedHash
+    ) {
+      throw new Error(`report backup does not match transaction marker: ${entry.backupPath}`);
+    }
+  }
   await Promise.all(entries.map((entry) => rm(entry.backupPath, { force: true })));
   await syncDirectories(entries);
   await rm(transactionPath, { force: true });

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4942,6 +4942,31 @@ async function reportPublicationCheck(tmp) {
     });
     assertEqual(await fileExists(recoverableBundlePath), true, "checksum-only bundle state recovered");
 
+    const symlinkReportPath = join(collisionRoot, "symlink-report.json");
+    const symlinkMarkdownPath = join(collisionRoot, "symlink-report.md");
+    const symlinkMarkdownTarget = join(collisionRoot, "symlink-target.md");
+    await writeFile(symlinkReportPath, `${JSON.stringify({ ...report, runId: "symlink-report" }, null, 2)}\n`);
+    await writeFile(symlinkMarkdownTarget, "linked report\n");
+    let symlinkSupported = true;
+    try {
+      await symlink(symlinkMarkdownTarget, symlinkMarkdownPath);
+    } catch (error) {
+      if (process.platform === "win32" && (error.code === "EPERM" || error.code === "EACCES")) {
+        symlinkSupported = false;
+      } else {
+        throw error;
+      }
+    }
+    if (symlinkSupported) {
+      let symlinkMarkdownRejected = false;
+      try {
+        await bundleReport(symlinkReportPath, { outputDir: bundleRoot });
+      } catch (error) {
+        symlinkMarkdownRejected = /not a regular file/.test(error.message);
+      }
+      assertEqual(symlinkMarkdownRejected, true, "bundle rejects symlinked Markdown");
+    }
+
     const retainedRoot = join(publicationRoot, "retained");
     const retained = await retainGateArtifacts(collisionReports[0], firstBundle, {
       outputDir: retainedRoot
@@ -5046,6 +5071,7 @@ async function fileLockRecoveryCheck(tmp) {
     await writeFile(reusedPidLock, `${JSON.stringify({
       token: "reused-pid",
       pid: process.pid,
+      processIdentity: "ps:reused-process",
       createdAt: new Date(Date.now() - 60_000).toISOString()
     })}\n`);
     await utimes(reusedPidLock, old, old);
@@ -5079,6 +5105,21 @@ async function fileLockRecoveryCheck(tmp) {
     })));
     assertEqual(maxActive, 1, "stale-lock contenders remain serialized");
     assertEqual(await fileExists(racedLock), false, "owned lock removed after serialized callbacks");
+
+    const liveLock = join(tmp, "live-publication.lock");
+    active = 0;
+    maxActive = 0;
+    await Promise.all([0, 1].map(() => withFileLock(liveLock, async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await sleep(40);
+      active -= 1;
+    }, {
+      staleMs: 5,
+      timeoutMs: 2_000,
+      retryMs: 2
+    })));
+    assertEqual(maxActive, 1, "live lock is not reclaimed after its stale threshold");
 
     return {
       id: "file-lock-recovery",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1,10 +1,10 @@
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { access, chmod, cp, link, lstat, mkdir, mkdtemp, open, readFile, readdir, rename, rm, stat, symlink, truncate, utimes, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
-import { gzipSync } from "node:zlib";
+import { gzipSync, gunzipSync } from "node:zlib";
 import { resolveScriptStep } from "mock-ai-provider/dist/providers/openai/common/scripted-response.js";
 import { createBoundedOutputAccumulator, quoteShell, runCommand } from "./commands.mjs";
 import { collectErrorFlags, parseFlags } from "./cli.mjs";
@@ -1634,12 +1634,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       await writeFile(missingSidecarPath, missingSidecarArchive);
       unsafeArchives.push(missingSidecarPath);
 
-      let fifoBundlePath = null;
       if (process.platform !== "win32") {
-        fifoBundlePath = join(tmp, "explicit-bundle.fifo");
-        const fifoBundle = await runCommand(`mkfifo ${quoteShell(fifoBundlePath)}`);
-        assertEqual(fifoBundle.status, 0, "creates explicit bundle FIFO fixture");
-
         const fifoChecksumArchive = buildTarGzipFixture([
           {
             name: `${expectedBundleRoot}/manifest.json`,
@@ -1664,33 +1659,16 @@ async function runScopedSelfCheck(flags, scope, workspace) {
         assertEqual(fifoChecksum.status, 0, "creates checksum FIFO fixture");
         unsafeArchives.push(fifoChecksumPath);
       }
-      const reportWithHostileExplicitBundle = fifoBundlePath
-        ? {
-          ...report,
-          bundle: {
-            path: fifoBundlePath,
-            outputPath: mismatchedExplicitPath
-          },
-          outputPaths: {
-            ...report.outputPaths,
-            bundle: badSidecarPath,
-            bundlePath: missingSidecarPath
-          }
-        }
-        : {
-          ...report,
-          bundle: {
-            path: mismatchedExplicitPath,
-            outputPath: badSidecarPath
-          },
-          outputPaths: {
-            ...report.outputPaths,
-            bundle: missingSidecarPath
-          }
-        };
+      const reportForBundleDiscovery = structuredClone(report);
+      delete reportForBundleDiscovery.bundle;
+      delete reportForBundleDiscovery.bundlePath;
+      if (reportForBundleDiscovery.outputPaths) {
+        delete reportForBundleDiscovery.outputPaths.bundle;
+        delete reportForBundleDiscovery.outputPaths.bundlePath;
+      }
       await writeFile(
         misleadingReportPath,
-        `${JSON.stringify(reportWithHostileExplicitBundle, null, 2)}\n`
+        `${JSON.stringify(reportForBundleDiscovery, null, 2)}\n`
       );
       await writeFile(
         misleadingMarkdownPath,
@@ -1731,6 +1709,36 @@ async function runScopedSelfCheck(flags, scope, workspace) {
             "publish rejects option-like, traversal, aliased, and duplicate tar members"
           );
         }
+      ));
+      const invalidExplicitRoot = join(tmp, "publish-invalid-explicit");
+      const invalidExplicitReportPath = join(invalidExplicitRoot, "report.json");
+      const invalidExplicitBundlePath = join(invalidExplicitRoot, "invalid-bundle.tar.gz");
+      await mkdir(invalidExplicitRoot);
+      await writeFile(invalidExplicitBundlePath, "not a bundle\n");
+      const validExplicitBundlePath = join(
+        invalidExplicitRoot,
+        basename(publishBundle.outputPath)
+      );
+      await cp(publishBundle.outputPath, validExplicitBundlePath);
+      await cp(
+        publishBundle.checksumPath,
+        `${validExplicitBundlePath}.sha256`
+      );
+      await writeFile(
+        invalidExplicitReportPath,
+        `${JSON.stringify({
+          ...report,
+          bundle: {
+            outputPath: validExplicitBundlePath
+          },
+          bundlePath: invalidExplicitBundlePath
+        }, null, 2)}\n`
+      );
+      await writeFile(join(invalidExplicitRoot, "report.md"), "# invalid explicit bundle\n");
+      checks.push(await failingCommandCheck(
+        "publish-rejects-invalid-explicit-bundle",
+        `node bin/kova.mjs publish ${quoteShell(invalidExplicitReportPath)} --ver 2026.7.12-invalid-explicit --release-date 2026-07-12 --sha selfcheck --out-dir ${quoteShell(join(invalidExplicitRoot, "releases"))} --json`,
+        "explicitly referenced report bundle failed integrity verification"
       ));
     }
 
@@ -5467,6 +5475,7 @@ async function performanceBaselineCheck(tmp) {
 
 async function reportPublicationCheck(tmp) {
   const publicationRoot = join(tmp, "report-publication");
+  const globalFixturePaths = [];
   try {
     const report = syntheticPublicationReport();
     await mkdir(publicationRoot, { recursive: true });
@@ -5625,10 +5634,11 @@ async function reportPublicationCheck(tmp) {
       "mid-backup recovery restores the prior canonical report"
     );
 
-    const outputPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000001-aabbcc");
+    const publishedRunId = createRunId();
+    const outputPaths = buildReportOutputPaths(publicationRoot, publishedRunId);
     const publishedReport = {
       ...report,
-      runId: "kova-260712-000001-aabbcc",
+      runId: publishedRunId,
       outputPaths
     };
     await writeReportOutputs(publicationRoot, publishedReport);
@@ -5641,6 +5651,13 @@ async function reportPublicationCheck(tmp) {
     );
     const committedJson = await readFile(outputPaths.json);
     const committedMarkdown = await readFile(outputPaths.markdown);
+    const longArtifactName = `${"l".repeat(120)}.json`;
+    const unicodeArtifactName = "sigma-\u03c3.json";
+    const publishedArtifactsDir = join(tmp, "published-artifacts");
+    const publishedArtifactRoot = join(publishedArtifactsDir, publishedReport.runId);
+    await mkdir(publishedArtifactRoot, { recursive: true });
+    await writeFile(join(publishedArtifactRoot, longArtifactName), "long artifact\n");
+    await writeFile(join(publishedArtifactRoot, unicodeArtifactName), "unicode artifact\n");
     let releaseTransientWriter;
     let markTransientWriterReady;
     const transientWriterRelease = new Promise((resolve) => {
@@ -5666,7 +5683,8 @@ async function reportPublicationCheck(tmp) {
     await transientWriterReady;
     let snapshotSettled = false;
     const serializedBundlePromise = bundleReport(outputPaths.json, {
-      outputDir: join(publicationRoot, "serialized-snapshot-bundles")
+      outputDir: join(publicationRoot, "serialized-snapshot-bundles"),
+      artifactsDir: publishedArtifactsDir
     }).finally(() => {
       snapshotSettled = true;
     });
@@ -5683,6 +5701,44 @@ async function reportPublicationCheck(tmp) {
       serializedBundle.runId,
       publishedReport.runId,
       "report snapshot excludes a rolled-back transient generation"
+    );
+    const serializedEntries = readUstarEntries(await readFile(serializedBundle.outputPath));
+    assertEqual(
+      serializedEntries.some((entry) => ["g", "x", "L", "K", "N"].includes(entry.type)),
+      false,
+      "generated bundle does not require tar extension headers"
+    );
+    const serializedIndexEntry = serializedEntries.find(
+      (entry) => entry.name === `${publishedReport.runId}-bundle/artifact-index.json`
+    );
+    const serializedIndex = JSON.parse(serializedIndexEntry.content.toString("utf8"));
+    for (const originalPath of [
+      `artifacts/${longArtifactName}`,
+      `artifacts/${unicodeArtifactName}`
+    ]) {
+      const indexed = serializedIndex.entries.find((entry) => entry.path === originalPath);
+      assertEqual(Boolean(indexed), true, `artifact index preserves ${originalPath}`);
+      assertEqual(
+        indexed.archivePath.startsWith("mapped/"),
+        true,
+        `artifact index maps non-USTAR path ${originalPath}`
+      );
+      assertEqual(
+        serializedEntries.some(
+          (entry) => entry.name === `${serializedIndex.bundleRoot}/${indexed.archivePath}`
+        ),
+        true,
+        `generated bundle contains mapped artifact ${originalPath}`
+      );
+    }
+    const overlappingBundle = await bundleReport(outputPaths.json, {
+      outputDir: join(publishedArtifactRoot, "bundle-output"),
+      artifactsDir: publishedArtifactsDir
+    });
+    assertEqual(
+      await fileExists(overlappingBundle.outputPath),
+      true,
+      "bundle staging remains outside an overlapping artifact source tree"
     );
     const markerlessBackupPath = join(
       publicationRoot,
@@ -5913,8 +5969,139 @@ async function reportPublicationCheck(tmp) {
     );
     await writeFile(orphanChecksumPath, "orphan\n");
     await writeFile(operatorChecksumPath, "operator copy\n");
+    const staleBundleTransaction = randomUUID();
+    const staleBundleStage = `${firstBundle.outputPath}.${staleBundleTransaction}.tmp`;
+    const staleBundleBuildTransaction = randomUUID();
+    const staleBundleBuild = join(
+      tmpdir(),
+      `kova-artifact-bundle-${staleBundleBuildTransaction}.tmp`
+    );
+    const unownedBundleBuild = join(
+      tmpdir(),
+      `kova-artifact-bundle-${randomUUID()}.tmp`
+    );
+    const malformedBundleBuildTransaction = randomUUID();
+    const malformedBundleBuild = join(
+      tmpdir(),
+      `kova-artifact-bundle-${malformedBundleBuildTransaction}.tmp`
+    );
+    const markerOnlyBundleBuildTransaction = randomUUID();
+    const markerOnlyBundleBuild = join(
+      tmpdir(),
+      `kova-artifact-bundle-${markerOnlyBundleBuildTransaction}.tmp`
+    );
+    globalFixturePaths.push(
+      staleBundleBuild,
+      `${staleBundleBuild}.owner`,
+      unownedBundleBuild,
+      malformedBundleBuild,
+      `${malformedBundleBuild}.owner`,
+      `${markerOnlyBundleBuild}.owner`
+    );
+    await writeFile(staleBundleStage, "stale staged archive\n");
+    await writeFile(`${staleBundleStage}.owner`, `${JSON.stringify({
+      schemaVersion: "kova.bundlePairStage.v1",
+      transaction: staleBundleTransaction,
+      outputPath: firstBundle.outputPath,
+      checksumPath: firstBundle.checksumPath
+    })}\n`);
+    await mkdir(staleBundleBuild);
+    await writeFile(join(staleBundleBuild, "stale.bin"), "stale bundle build\n");
+    await writeFile(`${staleBundleBuild}.owner`, `${JSON.stringify({
+      schemaVersion: "kova.bundleBuildStage.v1",
+      transaction: staleBundleBuildTransaction,
+      outputRoot: bundleRoot,
+      bundleName: firstLogicalBundleName
+    })}\n`);
+    await mkdir(unownedBundleBuild);
+    await writeFile(join(unownedBundleBuild, "operator.bin"), "preserve me\n");
+    await mkdir(malformedBundleBuild);
+    await writeFile(join(malformedBundleBuild, "operator.bin"), "preserve malformed owner\n");
+    await writeFile(`${malformedBundleBuild}.owner`, `${JSON.stringify({
+      schemaVersion: "kova.bundleBuildStage.v1",
+      transaction: malformedBundleBuildTransaction,
+      outputRoot: {},
+      bundleName: firstLogicalBundleName
+    })}\n`);
+    await writeFile(`${markerOnlyBundleBuild}.owner`, `${JSON.stringify({
+      schemaVersion: "kova.bundleBuildStage.v1",
+      transaction: markerOnlyBundleBuildTransaction,
+      outputRoot: bundleRoot,
+      bundleName: firstLogicalBundleName
+    })}\n`);
+    let symlinkOwnedBundleBuild = null;
+    let symlinkOwnedBundleMarker = null;
+    let symlinkOwnedBundleTarget = null;
+    if (process.platform !== "win32") {
+      const transaction = randomUUID();
+      symlinkOwnedBundleBuild = join(
+        tmpdir(),
+        `kova-artifact-bundle-${transaction}.tmp`
+      );
+      symlinkOwnedBundleMarker = `${symlinkOwnedBundleBuild}.owner`;
+      symlinkOwnedBundleTarget = join(tmp, "operator-stage-owner.json");
+      globalFixturePaths.push(
+        symlinkOwnedBundleBuild,
+        symlinkOwnedBundleMarker
+      );
+      await mkdir(symlinkOwnedBundleBuild);
+      await writeFile(
+        join(symlinkOwnedBundleBuild, "operator.bin"),
+        "preserve symlink-owned stage\n"
+      );
+      await writeFile(symlinkOwnedBundleTarget, `${JSON.stringify({
+        schemaVersion: "kova.bundleBuildStage.v1",
+        transaction,
+        outputRoot: bundleRoot,
+        bundleName: firstLogicalBundleName
+      })}\n`);
+      await symlink(symlinkOwnedBundleTarget, symlinkOwnedBundleMarker);
+    }
     await bundleReport(collisionReports[0], { outputDir: bundleRoot });
     assertEqual(await fileExists(orphanChecksumPath), false, "logical bundle retry removes orphan checksum");
+    assertEqual(
+      await fileExists(staleBundleStage),
+      false,
+      "logical bundle retry removes a crashed staged archive"
+    );
+    assertEqual(
+      await fileExists(staleBundleBuild),
+      false,
+      "logical bundle retry removes a crashed build directory"
+    );
+    assertEqual(
+      await fileExists(`${markerOnlyBundleBuild}.owner`),
+      false,
+      "logical bundle retry removes a marker created before its staging directory"
+    );
+    assertEqual(
+      await readFile(join(unownedBundleBuild, "operator.bin"), "utf8"),
+      "preserve me\n",
+      "logical bundle retry preserves an unowned matching directory"
+    );
+    assertEqual(
+      await readFile(join(malformedBundleBuild, "operator.bin"), "utf8"),
+      "preserve malformed owner\n",
+      "logical bundle retry ignores malformed owner marker fields"
+    );
+    if (symlinkOwnedBundleBuild) {
+      assertEqual(
+        await readFile(join(symlinkOwnedBundleBuild, "operator.bin"), "utf8"),
+        "preserve symlink-owned stage\n",
+        "logical bundle retry ignores a symlinked owner marker"
+      );
+      assertEqual(
+        (await lstat(symlinkOwnedBundleMarker)).isSymbolicLink(),
+        true,
+        "symlinked owner marker is preserved"
+      );
+      await rm(symlinkOwnedBundleBuild, { recursive: true });
+      await rm(symlinkOwnedBundleMarker);
+      await rm(symlinkOwnedBundleTarget);
+    }
+    await rm(unownedBundleBuild, { recursive: true });
+    await rm(malformedBundleBuild, { recursive: true });
+    await rm(`${malformedBundleBuild}.owner`);
     assertEqual(
       await fileExists(operatorChecksumPath),
       true,
@@ -6122,10 +6309,58 @@ async function reportPublicationCheck(tmp) {
         symlinkMarkdownRejected = /not a regular file/.test(error.message);
       }
       assertEqual(symlinkMarkdownRejected, true, "bundle rejects symlinked Markdown");
+      const symlinkBundlePath = join(collisionRoot, "linked-bundle.tar.gz");
+      const symlinkBundleChecksumPath = `${symlinkBundlePath}.sha256`;
+      await symlink(firstBundle.outputPath, symlinkBundlePath);
+      await writeFile(
+        symlinkBundleChecksumPath,
+        `${createHash("sha256").update(firstArchive).digest("hex")}  ${basename(symlinkBundlePath)}\n`
+      );
+      let symlinkBundleRejected = false;
+      try {
+        await retainGateArtifacts(collisionReports[0], {
+          runId: "a/b",
+          outputPath: symlinkBundlePath,
+          checksumPath: symlinkBundleChecksumPath
+        }, {
+          outputDir: join(publicationRoot, "symlink-bundle-retained")
+        });
+      } catch (error) {
+        symlinkBundleRejected = /not a regular file/.test(error.message);
+      }
+      assertEqual(symlinkBundleRejected, true, "retention rejects a symlinked bundle");
     }
 
     const emptyRetainedRoot = join(publicationRoot, "empty-retained");
     const emptyRetainedBackup = join(publicationRoot, ".empty-retained.bak");
+    const staleRetainedTransaction = "30000000-0000-4000-8000-000000000002";
+    const staleRetainedStage = join(
+      publicationRoot,
+      `.empty-retained.${staleRetainedTransaction}.tmp`
+    );
+    const unownedRetainedStage = join(
+      publicationRoot,
+      ".empty-retained.30000000-0000-4000-8000-000000000005.tmp"
+    );
+    const markerOnlyRetainedTransaction = "30000000-0000-4000-8000-000000000006";
+    const markerOnlyRetainedStage = join(
+      publicationRoot,
+      `.empty-retained.${markerOnlyRetainedTransaction}.tmp`
+    );
+    await mkdir(staleRetainedStage);
+    await writeFile(join(staleRetainedStage, "stale.bin"), "stale retained stage\n");
+    await writeFile(`${staleRetainedStage}.owner`, `${JSON.stringify({
+      schemaVersion: "kova.retainedArtifactStage.v1",
+      transaction: staleRetainedTransaction,
+      outputRoot: emptyRetainedRoot
+    })}\n`);
+    await mkdir(unownedRetainedStage);
+    await writeFile(join(unownedRetainedStage, "operator.bin"), "preserve me\n");
+    await writeFile(`${markerOnlyRetainedStage}.owner`, `${JSON.stringify({
+      schemaVersion: "kova.retainedArtifactStage.v1",
+      transaction: markerOnlyRetainedTransaction,
+      outputRoot: emptyRetainedRoot
+    })}\n`);
     const emptyRetainedClaimId = "10000000-0000-4000-8000-000000000001";
     await mkdir(emptyRetainedBackup);
     await writeFile(`${emptyRetainedBackup}.owner`, `${JSON.stringify({
@@ -6143,6 +6378,22 @@ async function reportPublicationCheck(tmp) {
     });
     assertEqual(await fileExists(emptyRetainedRoot), true, "empty retained tree backup recovered");
     assertEqual(await fileExists(emptyRetainedBackup), false, "empty retained tree backup removed");
+    assertEqual(
+      await fileExists(staleRetainedStage),
+      false,
+      "retention retry removes a crashed staging directory"
+    );
+    assertEqual(
+      await fileExists(`${markerOnlyRetainedStage}.owner`),
+      false,
+      "retention retry removes a marker created before its staging directory"
+    );
+    assertEqual(
+      await readFile(join(unownedRetainedStage, "operator.bin"), "utf8"),
+      "preserve me\n",
+      "retention retry preserves an unowned matching directory"
+    );
+    await rm(unownedRetainedStage, { recursive: true });
 
     const restoredEmptyRoot = join(publicationRoot, "restored-empty-retained");
     const restoredEmptyBackup = join(publicationRoot, ".restored-empty-retained.bak");
@@ -6462,6 +6713,10 @@ async function reportPublicationCheck(tmp) {
       durationMs: 0,
       message: error.message
     };
+  } finally {
+    for (const path of globalFixturePaths) {
+      await rm(path, { recursive: true, force: true });
+    }
   }
 }
 
@@ -7151,6 +7406,35 @@ function buildTarGzipFixture(entries) {
   }
   blocks.push(Buffer.alloc(1024));
   return gzipSync(Buffer.concat(blocks));
+}
+
+function readUstarEntries(archive) {
+  const tar = gunzipSync(archive);
+  const entries = [];
+  for (let offset = 0; offset + 512 <= tar.length;) {
+    const header = tar.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const sizeText = readTarString(header, 124, 12).trim();
+    const size = sizeText ? Number.parseInt(sizeText, 8) : 0;
+    const contentStart = offset + 512;
+    entries.push({
+      name: prefix ? `${prefix}/${name}` : name,
+      type: String.fromCharCode(header[156] || 0x30),
+      content: tar.subarray(contentStart, contentStart + size)
+    });
+    offset = contentStart + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+function readTarString(buffer, offset, length) {
+  const value = buffer.subarray(offset, offset + length);
+  const terminator = value.indexOf(0);
+  return value.subarray(0, terminator === -1 ? value.length : terminator).toString("utf8");
 }
 
 function writeTarOctal(buffer, offset, length, value) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4943,6 +4943,15 @@ async function reportPublicationCheck(tmp) {
     assertEqual(firstBundle.outputPath === secondBundle.outputPath, false, "colliding run IDs use distinct bundle paths");
     assertEqual(await fileExists(firstBundle.checksumPath), true, "first bundle checksum published");
     assertEqual(await fileExists(secondBundle.checksumPath), true, "second bundle checksum published");
+    const firstLogicalBundleName = basename(firstBundle.outputPath)
+      .replace(/-[a-f0-9]{64}\.tar\.gz$/, "");
+    const orphanChecksumPath = join(
+      bundleRoot,
+      `${firstLogicalBundleName}-${"0".repeat(64)}.tar.gz.sha256`
+    );
+    await writeFile(orphanChecksumPath, "orphan\n");
+    await bundleReport(collisionReports[0], { outputDir: bundleRoot });
+    assertEqual(await fileExists(orphanChecksumPath), false, "logical bundle retry removes orphan checksum");
     const firstArchive = await readFile(firstBundle.outputPath);
     const firstChecksum = await readFile(firstBundle.checksumPath, "utf8");
     await rm(firstBundle.checksumPath);

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4639,6 +4639,20 @@ async function performanceBaselineCheck(tmp) {
       2,
       "concurrent baseline updates preserve both entries"
     );
+    const colocatedBaselinePath = join(tmp, "colocated-baselines.json");
+    await withBaselineStoreLock(colocatedBaselinePath, async () => {
+      const lockNames = (await readdir(tmp))
+        .filter((name) => /^\.kova-baseline-[a-f0-9]{64}\.lock$/.test(name));
+      assertEqual(lockNames.length, 1, "baseline lock is colocated with its store");
+      if (process.platform !== "win32") {
+        const lockInfo = await stat(join(tmp, lockNames[0]));
+        assertEqual(
+          lockInfo.mode & 0o777,
+          0o644,
+          "shared baseline lock metadata is readable but owner-only writable"
+        );
+      }
+    });
     let aliasActive = 0;
     let aliasMaxActive = 0;
     await Promise.all(["Alias-Baseline.json", "alias-baseline.json"].map((name) =>

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4645,6 +4645,24 @@ async function performanceBaselineCheck(tmp) {
       })
     ));
     assertEqual(aliasMaxActive, 1, "case aliases share one baseline lock");
+    if (symlinkSupported) {
+      const canonicalBaselineDir = join(tmp, "canonical-baseline-dir");
+      const aliasedBaselineDir = join(tmp, "aliased-baseline-dir");
+      await mkdir(canonicalBaselineDir);
+      await symlink(canonicalBaselineDir, aliasedBaselineDir);
+      aliasActive = 0;
+      aliasMaxActive = 0;
+      await Promise.all([
+        join(canonicalBaselineDir, "baselines.json"),
+        join(aliasedBaselineDir, "baselines.json")
+      ].map((path) => withBaselineStoreLock(path, async () => {
+        aliasActive += 1;
+        aliasMaxActive = Math.max(aliasMaxActive, aliasActive);
+        await sleep(20);
+        aliasActive -= 1;
+      })));
+      assertEqual(aliasMaxActive, 1, "symlinked parent aliases share one baseline lock");
+    }
     const otherTargetComparison = comparePerformanceToBaseline(baselineReport, loadedStore, {
       targetPlan: { kind: "local-build", value: "/tmp/other-openclaw" }
     });
@@ -4899,6 +4917,16 @@ async function reportPublicationCheck(tmp) {
       false,
       "recovered report backups removed"
     );
+    await rename(
+      outputPaths.json,
+      join(publicationRoot, `.${basename(outputPaths.json)}.kova-backup`)
+    );
+    await writeReportOutputs(publicationRoot, publishedReport);
+    assertEqual(
+      (await readFile(outputPaths.markdown, "utf8")).length > 0,
+      true,
+      "partial report backup recovery preserves untouched files"
+    );
 
     const collisionRoot = join(publicationRoot, "collisions");
     await mkdir(collisionRoot, { recursive: true });
@@ -5065,6 +5093,12 @@ async function reportPublicationCheck(tmp) {
     );
     await rm(unmanagedPath);
     const retainedBackup = join(publicationRoot, ".retained.bak");
+    await rename(retainedRoot, retainedBackup);
+    await mkdir(retainedRoot);
+    await retainGateArtifacts(collisionReports[0], firstBundle, {
+      outputDir: retainedRoot
+    });
+    assertEqual(await fileExists(retained.jsonPath), true, "empty retained tree recovered from backup");
     await rename(retainedRoot, retainedBackup);
     await mkdir(retainedRoot);
     await writeFile(

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -5100,6 +5100,15 @@ async function reportPublicationCheck(tmp) {
     assertEqual(firstBundle.outputPath === secondBundle.outputPath, false, "colliding run IDs use distinct bundle paths");
     assertEqual(await fileExists(firstBundle.checksumPath), true, "first bundle checksum published");
     assertEqual(await fileExists(secondBundle.checksumPath), true, "second bundle checksum published");
+    let mismatchedRunBundleRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], secondBundle, {
+        outputDir: join(publicationRoot, "mismatched-run-retained")
+      });
+    } catch (error) {
+      mismatchedRunBundleRejected = /bundle run ID does not match report/.test(error.message);
+    }
+    assertEqual(mismatchedRunBundleRejected, true, "retention rejects a bundle from another run");
     const firstLogicalBundleName = basename(firstBundle.outputPath)
       .replace(/-[a-f0-9]{64}\.tar\.gz$/, "");
     const orphanChecksumPath = join(
@@ -5111,6 +5120,109 @@ async function reportPublicationCheck(tmp) {
     assertEqual(await fileExists(orphanChecksumPath), false, "logical bundle retry removes orphan checksum");
     const firstArchive = await readFile(firstBundle.outputPath);
     const firstChecksum = await readFile(firstBundle.checksumPath, "utf8");
+    const sameNameArchiveDir = join(publicationRoot, "same-name-archive");
+    const sameNameChecksumDir = join(publicationRoot, "same-name-checksum");
+    const sameNameArchivePath = join(sameNameArchiveDir, "bundle.tar.gz");
+    const sameNameChecksumPath = join(sameNameChecksumDir, "BUNDLE.TAR.GZ");
+    await mkdir(sameNameArchiveDir);
+    await mkdir(sameNameChecksumDir);
+    await writeFile(sameNameArchivePath, firstArchive);
+    await writeFile(
+      sameNameChecksumPath,
+      `${createHash("sha256").update(firstArchive).digest("hex")}  bundle.tar.gz\n`
+    );
+    let sameNameBundleRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], {
+        runId: "a/b",
+        outputPath: sameNameArchivePath,
+        checksumPath: sameNameChecksumPath
+      }, {
+        outputDir: join(publicationRoot, "same-name-retained")
+      });
+    } catch (error) {
+      sameNameBundleRejected = /must use distinct filenames/.test(error.message);
+    }
+    assertEqual(sameNameBundleRejected, true, "retention rejects colliding bundle filenames");
+    const reservedArchivePath = join(sameNameArchiveDir, "report.json");
+    const reservedChecksumPath = join(sameNameChecksumDir, "report.json.sha256");
+    await writeFile(reservedArchivePath, firstArchive);
+    await writeFile(
+      reservedChecksumPath,
+      `${createHash("sha256").update(firstArchive).digest("hex")}  report.json\n`
+    );
+    let reservedBundleNameRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], {
+        runId: "a/b",
+        outputPath: reservedArchivePath,
+        checksumPath: reservedChecksumPath
+      }, {
+        outputDir: join(publicationRoot, "reserved-name-retained")
+      });
+    } catch (error) {
+      reservedBundleNameRejected = /conflict with reserved retained artifacts/.test(error.message);
+    }
+    assertEqual(reservedBundleNameRejected, true, "retention rejects reserved bundle filenames");
+    const unicodeArchivePath = join(sameNameArchiveDir, "σ-bundle.tar.gz");
+    const unicodeChecksumPath = join(sameNameChecksumDir, "ς-bundle.tar.gz.sha256");
+    await writeFile(unicodeArchivePath, firstArchive);
+    await writeFile(unicodeChecksumPath, firstChecksum);
+    let unicodeBundleNameRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], {
+        runId: "a/b",
+        outputPath: unicodeArchivePath,
+        checksumPath: unicodeChecksumPath
+      }, {
+        outputDir: join(publicationRoot, "unicode-name-retained")
+      });
+    } catch (error) {
+      unicodeBundleNameRejected = /must use portable filenames/.test(error.message);
+    }
+    assertEqual(unicodeBundleNameRejected, true, "retention rejects non-portable bundle filenames");
+    for (const [name, archiveName, checksumName] of [
+      ["trailing-period", "bundle.tar.gz", "BUNDLE.TAR.GZ."],
+      ["device-stem-con", "CON.tar.gz", "con.tar.gz.sha256"],
+      ["device-stem-nul", "NUL.bundle", "nul.bundle.sha256"],
+      ["device-stem-com1", "COM1.archive", "com1.archive.sha256"]
+    ]) {
+      let portableBundleNameRejected = false;
+      try {
+        await retainGateArtifacts(collisionReports[0], {
+          runId: "a/b",
+          outputPath: join(sameNameArchiveDir, archiveName),
+          checksumPath: join(sameNameChecksumDir, checksumName)
+        }, {
+          outputDir: join(publicationRoot, `${name}-retained`)
+        });
+      } catch (error) {
+        portableBundleNameRejected = /must use portable filenames/.test(error.message);
+      }
+      assertEqual(portableBundleNameRejected, true, `retention rejects ${name} bundle filenames`);
+    }
+    if (process.platform !== "win32") {
+      await chmod(firstBundle.outputPath, 0o400);
+      await chmod(firstBundle.checksumPath, 0o400);
+      try {
+        const readOnlyRetained = await retainGateArtifacts(collisionReports[0], firstBundle, {
+          outputDir: join(publicationRoot, "read-only-retained")
+        });
+        assertEqual(
+          await fileExists(readOnlyRetained.bundlePath),
+          true,
+          "retention copies a read-only bundle"
+        );
+        assertEqual(
+          await fileExists(readOnlyRetained.checksumPath),
+          true,
+          "retention copies a read-only checksum"
+        );
+      } finally {
+        await chmod(firstBundle.outputPath, 0o600);
+        await chmod(firstBundle.checksumPath, 0o600);
+      }
+    }
     await rm(firstBundle.checksumPath);
     await mkdir(firstBundle.checksumPath);
     let invalidChecksumRejected = false;
@@ -5174,6 +5286,7 @@ async function reportPublicationCheck(tmp) {
     let mismatchedBundleRejected = false;
     try {
       await retainGateArtifacts(collisionReports[0], {
+        runId: "a/b",
         outputPath: firstBundle.outputPath,
         checksumPath: mismatchedChecksumPath
       }, {
@@ -5232,6 +5345,7 @@ async function reportPublicationCheck(tmp) {
     let retainedReplacementRejected = false;
     try {
       await retainGateArtifacts(collisionReports[0], {
+        runId: "a/b",
         outputPath: invalidBundle,
         checksumPath: firstBundle.checksumPath
       }, {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4896,6 +4896,38 @@ async function reportPublicationCheck(tmp) {
       "failed report staging removed transaction files"
     );
 
+    const mixedPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000000-mixed");
+    const oldCanonical = `${JSON.stringify({ runId: "old-generation" })}\n`;
+    await writeFile(
+      join(publicationRoot, `.${basename(mixedPaths.json)}.kova-backup`),
+      oldCanonical
+    );
+    await writeFile(mixedPaths.markdown, "new generation\n");
+    let mixedRecoveryRejected = false;
+    try {
+      await writeReportOutputs(publicationRoot, {
+        ...report,
+        runId: "kova-260712-000000-mixed",
+        outputPaths: {
+          ...mixedPaths,
+          summary: join(publicationRoot, "missing-stage-parent", "summary.json")
+        }
+      });
+    } catch {
+      mixedRecoveryRejected = true;
+    }
+    assertEqual(mixedRecoveryRejected, true, "post-recovery staging failure rejected");
+    assertEqual(
+      await fileExists(mixedPaths.markdown),
+      false,
+      "recovery removes unbacked files from an interrupted generation"
+    );
+    assertEqual(
+      await readFile(mixedPaths.json, "utf8"),
+      oldCanonical,
+      "recovery restores the prior canonical report"
+    );
+
     const outputPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000001-aabbcc");
     const publishedReport = {
       ...report,

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -5653,11 +5653,22 @@ async function reportPublicationCheck(tmp) {
     const committedMarkdown = await readFile(outputPaths.markdown);
     const longArtifactName = `${"l".repeat(120)}.json`;
     const unicodeArtifactName = "sigma-\u03c3.json";
+    const optionArtifactName = "-option.json";
+    const deepArtifactSegments = Array.from({ length: 64 }, (_, index) => `d${index}`);
+    const deepArtifactPath = join(...deepArtifactSegments, "deep.json");
     const publishedArtifactsDir = join(tmp, "published-artifacts");
     const publishedArtifactRoot = join(publishedArtifactsDir, publishedReport.runId);
     await mkdir(publishedArtifactRoot, { recursive: true });
     await writeFile(join(publishedArtifactRoot, longArtifactName), "long artifact\n");
     await writeFile(join(publishedArtifactRoot, unicodeArtifactName), "unicode artifact\n");
+    await writeFile(join(publishedArtifactRoot, optionArtifactName), "option artifact\n");
+    await mkdir(join(publishedArtifactRoot, ...deepArtifactSegments), { recursive: true });
+    await writeFile(join(publishedArtifactRoot, deepArtifactPath), "deep artifact\n");
+    const caseCollisionRoot = join(publishedArtifactRoot, "case-collision");
+    await mkdir(caseCollisionRoot);
+    await writeFile(join(caseCollisionRoot, "Case.json"), "upper\n");
+    await writeFile(join(caseCollisionRoot, "case.json"), "lower\n");
+    const caseCollisionNames = await readdir(caseCollisionRoot);
     let releaseTransientWriter;
     let markTransientWriterReady;
     const transientWriterRelease = new Promise((resolve) => {
@@ -5714,7 +5725,9 @@ async function reportPublicationCheck(tmp) {
     const serializedIndex = JSON.parse(serializedIndexEntry.content.toString("utf8"));
     for (const originalPath of [
       `artifacts/${longArtifactName}`,
-      `artifacts/${unicodeArtifactName}`
+      `artifacts/${unicodeArtifactName}`,
+      `artifacts/${optionArtifactName}`,
+      `artifacts/${deepArtifactPath.split("\\").join("/")}`
     ]) {
       const indexed = serializedIndex.entries.find((entry) => entry.path === originalPath);
       assertEqual(Boolean(indexed), true, `artifact index preserves ${originalPath}`);
@@ -5731,6 +5744,22 @@ async function reportPublicationCheck(tmp) {
         `generated bundle contains mapped artifact ${originalPath}`
       );
     }
+    if (caseCollisionNames.length === 2) {
+      const caseCollisionEntries = serializedIndex.entries.filter(
+        (entry) => entry.path.startsWith("artifacts/case-collision/")
+      );
+      assertEqual(caseCollisionEntries.length, 2, "case-distinct artifacts are indexed");
+      assertEqual(
+        new Set(caseCollisionEntries.map((entry) => entry.archivePath)).size,
+        2,
+        "case-folding archive collision is disambiguated"
+      );
+      assertEqual(
+        caseCollisionEntries.some((entry) => entry.archivePath.startsWith("mapped/")),
+        true,
+        "case-folding archive collision uses a mapped path"
+      );
+    }
     const overlappingBundle = await bundleReport(outputPaths.json, {
       outputDir: join(publishedArtifactRoot, "bundle-output"),
       artifactsDir: publishedArtifactsDir
@@ -5740,6 +5769,73 @@ async function reportPublicationCheck(tmp) {
       true,
       "bundle staging remains outside an overlapping artifact source tree"
     );
+    const overlappingEntries = readUstarEntries(
+      await readFile(overlappingBundle.outputPath)
+    );
+    const overlappingIndexEntry = overlappingEntries.find(
+      (entry) => entry.name === `${publishedReport.runId}-bundle/artifact-index.json`
+    );
+    const overlappingIndex = JSON.parse(
+      overlappingIndexEntry.content.toString("utf8")
+    );
+    assertEqual(
+      overlappingIndex.entries.some(
+        (entry) => entry.path.startsWith("artifacts/bundle-output/")
+      ),
+      false,
+      "overlapping bundle output is excluded from the artifact snapshot"
+    );
+    let artifactRootOutputRejected = false;
+    try {
+      await bundleReport(outputPaths.json, {
+        outputDir: publishedArtifactRoot,
+        artifactsDir: publishedArtifactsDir
+      });
+    } catch (error) {
+      artifactRootOutputRejected =
+        /cannot replace the run artifact root/.test(error.message);
+    }
+    assertEqual(
+      artifactRootOutputRejected,
+      true,
+      "bundle output cannot replace the run artifact root"
+    );
+    if (process.platform !== "win32") {
+      const artifactRootAlias = join(tmp, "published-artifact-root-alias");
+      await symlink(publishedArtifactRoot, artifactRootAlias);
+      const aliasedOutputName = "aliased-bundle-output";
+      const aliasedBundle = await bundleReport(outputPaths.json, {
+        outputDir: join(artifactRootAlias, aliasedOutputName),
+        artifactsDir: publishedArtifactsDir
+      });
+      const aliasedEntries = readUstarEntries(await readFile(aliasedBundle.outputPath));
+      const aliasedIndexEntry = aliasedEntries.find(
+        (entry) => entry.name === `${publishedReport.runId}-bundle/artifact-index.json`
+      );
+      const aliasedIndex = JSON.parse(aliasedIndexEntry.content.toString("utf8"));
+      assertEqual(
+        aliasedIndex.entries.some(
+          (entry) => entry.path.startsWith(`artifacts/${aliasedOutputName}/`)
+        ),
+        false,
+        "symlink-aliased bundle output is excluded from the artifact snapshot"
+      );
+      let aliasedArtifactRootRejected = false;
+      try {
+        await bundleReport(outputPaths.json, {
+          outputDir: artifactRootAlias,
+          artifactsDir: publishedArtifactsDir
+        });
+      } catch (error) {
+        aliasedArtifactRootRejected =
+          /cannot replace the run artifact root/.test(error.message);
+      }
+      assertEqual(
+        aliasedArtifactRootRejected,
+        true,
+        "symlink-aliased artifact root cannot be used as bundle output"
+      );
+    }
     const markerlessBackupPath = join(
       publicationRoot,
       `.${basename(outputPaths.json)}.kova-backup`

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1150,6 +1150,23 @@ async function runScopedSelfCheck(flags, scope, workspace) {
           assertEqual((data.artifactIndex?.fileCount ?? 0) > 0, true, "artifact index file count");
         }
       ));
+      const publishBundle = await bundleReport(receiptCheck.data.jsonPath, { outputDir: tmp });
+      const publishRoot = join(tmp, "publish-content-addressed");
+      const publishOutDir = join(publishRoot, "src", "content", "releases");
+      checks.push(await jsonCommandCheck(
+        "publish-content-addressed-bundle",
+        `node bin/kova.mjs publish ${quoteShell(receiptCheck.data.jsonPath)} --ver 2026.7.12-selfcheck --release-date 2026-07-12 --sha selfcheck --out-dir ${quoteShell(publishOutDir)} --json`,
+        async () => {
+          const payload = JSON.parse(await readFile(join(publishOutDir, "2026.7.12-selfcheck.json"), "utf8"));
+          const bundleName = basename(publishBundle.outputPath);
+          assertEqual(payload.runs?.[0]?.bundle?.name, bundleName, "publish discovers content-addressed report bundle");
+          assertEqual(
+            await fileExists(join(publishRoot, "public", "bundles", bundleName)),
+            true,
+            "publish copies content-addressed report bundle"
+          );
+        }
+      ));
     }
 
   const ok = checks.every((check) => check.status === "PASS");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4967,6 +4967,15 @@ async function reportPublicationCheck(tmp) {
       assertEqual(symlinkMarkdownRejected, true, "bundle rejects symlinked Markdown");
     }
 
+    const emptyRetainedRoot = join(publicationRoot, "empty-retained");
+    const emptyRetainedBackup = join(publicationRoot, ".empty-retained.bak");
+    await mkdir(emptyRetainedBackup);
+    await retainGateArtifacts(collisionReports[0], firstBundle, {
+      outputDir: emptyRetainedRoot
+    });
+    assertEqual(await fileExists(emptyRetainedRoot), true, "empty retained tree backup recovered");
+    assertEqual(await fileExists(emptyRetainedBackup), false, "empty retained tree backup removed");
+
     const retainedRoot = join(publicationRoot, "retained");
     const retained = await retainGateArtifacts(collisionReports[0], firstBundle, {
       outputDir: retainedRoot
@@ -5066,6 +5075,19 @@ async function fileLockRecoveryCheck(tmp) {
       retryMs: 5
     });
     assertEqual(malformedAcquired, true, "malformed abandoned lock is reclaimed");
+
+    const incompleteLock = join(tmp, "incomplete-publication.lock");
+    await writeFile(incompleteLock, `${JSON.stringify({ pid: process.pid })}\n`);
+    await utimes(incompleteLock, old, old);
+    let incompleteAcquired = false;
+    await withFileLock(incompleteLock, async () => {
+      incompleteAcquired = true;
+    }, {
+      staleMs: 1_000,
+      timeoutMs: 2_000,
+      retryMs: 5
+    });
+    assertEqual(incompleteAcquired, true, "incomplete abandoned lock is reclaimed");
 
     const reusedPidLock = join(tmp, "reused-pid-publication.lock");
     await writeFile(reusedPidLock, `${JSON.stringify({

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { access, chmod, link, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, truncate, utimes, writeFile } from "node:fs/promises";
+import { access, chmod, link, lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, symlink, truncate, utimes, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { access, chmod, link, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, truncate, utimes, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
@@ -4929,6 +4930,17 @@ async function reportPublicationCheck(tmp) {
       firstChecksum,
       "concurrent identical bundle publication preserves checksum"
     );
+    const recoverableBundlePath = join(bundleRoot, "recoverable-bundle.tar.gz");
+    const recoverableChecksumPath = `${recoverableBundlePath}.sha256`;
+    const recoverableChecksum = `${createHash("sha256").update(firstArchive).digest("hex")}  recoverable-bundle.tar.gz\n`;
+    await writeFile(recoverableChecksumPath, recoverableChecksum);
+    await publishBundlePair({
+      archive: firstArchive,
+      outputPath: recoverableBundlePath,
+      checksumPath: recoverableChecksumPath,
+      checksum: recoverableChecksum
+    });
+    assertEqual(await fileExists(recoverableBundlePath), true, "checksum-only bundle state recovered");
 
     const retainedRoot = join(publicationRoot, "retained");
     const retained = await retainGateArtifacts(collisionReports[0], firstBundle, {
@@ -4971,6 +4983,13 @@ async function reportPublicationCheck(tmp) {
       "retention preserves unrelated destination data"
     );
     await rm(unmanagedPath);
+    const retainedBackup = join(publicationRoot, ".retained.bak");
+    await rename(retainedRoot, retainedBackup);
+    await retainGateArtifacts(collisionReports[0], firstBundle, {
+      outputDir: retainedRoot
+    });
+    assertEqual(await fileExists(retained.jsonPath), true, "interrupted retained tree swap recovered");
+    assertEqual(await fileExists(retainedBackup), false, "recovered retained tree backup removed");
 
     await rm(collisionReports[0].replace(/\.json$/, ".md"));
     let missingMarkdownRejected = false;
@@ -5022,6 +5041,23 @@ async function fileLockRecoveryCheck(tmp) {
       retryMs: 5
     });
     assertEqual(malformedAcquired, true, "malformed abandoned lock is reclaimed");
+
+    const reusedPidLock = join(tmp, "reused-pid-publication.lock");
+    await writeFile(reusedPidLock, `${JSON.stringify({
+      token: "reused-pid",
+      pid: process.pid,
+      createdAt: new Date(Date.now() - 60_000).toISOString()
+    })}\n`);
+    await utimes(reusedPidLock, old, old);
+    let reusedPidAcquired = false;
+    await withFileLock(reusedPidLock, async () => {
+      reusedPidAcquired = true;
+    }, {
+      staleMs: 1_000,
+      timeoutMs: 2_000,
+      retryMs: 5
+    });
+    assertEqual(reusedPidAcquired, true, "stale lock is reclaimed after PID reuse");
 
     const racedLock = join(tmp, "raced-publication.lock");
     await writeFile(racedLock, `${JSON.stringify({

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -5016,6 +5016,17 @@ async function reportPublicationCheck(tmp) {
       publishedReport.runId,
       "canonical report JSON published"
     );
+    const transactionTempPath = join(
+      publicationRoot,
+      `.${basename(outputPaths.json)}.kova-transaction.tmp`
+    );
+    await writeFile(transactionTempPath, "{\n");
+    await writeReportOutputs(publicationRoot, publishedReport);
+    assertEqual(
+      await fileExists(transactionTempPath),
+      false,
+      "retry removes a torn staged transaction marker"
+    );
     for (const path of Object.values(outputPaths)) {
       await rename(path, join(publicationRoot, `.${basename(path)}.kova-backup`));
     }
@@ -5339,6 +5350,28 @@ async function fileLockRecoveryCheck(tmp) {
     }
     assertEqual(foreignDomainProtected, true, "foreign execution-domain lock is not reclaimed locally");
     await rm(foreignDomainLock);
+
+    const foreignHostLock = join(tmp, "foreign-host-publication.lock");
+    await writeFile(foreignHostLock, `${JSON.stringify({
+      pid: 2_147_483_647,
+      executionDomainIdentity: {
+        host: "kova-foreign-host.invalid",
+        boot: "foreign-boot",
+        pidNamespace: null
+      }
+    })}\n`);
+    let foreignHostProtected = false;
+    try {
+      await withFileLock(foreignHostLock, async () => {}, {
+        staleMs: 1,
+        timeoutMs: 25,
+        retryMs: 2
+      });
+    } catch (error) {
+      foreignHostProtected = /timed out waiting for Kova file lock/.test(error.message);
+    }
+    assertEqual(foreignHostProtected, true, "foreign-host lock is not reclaimed locally");
+    await rm(foreignHostLock);
 
     const reusedPidLock = join(tmp, "reused-pid-publication.lock");
     await writeFile(reusedPidLock, `${JSON.stringify({

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1167,6 +1167,42 @@ async function runScopedSelfCheck(flags, scope, workspace) {
           );
         }
       ));
+      const externalReportPath = join(tmp, "external-report.json");
+      const externalMarkdownPath = join(tmp, "external-report.md");
+      const externalReport = {
+        ...report,
+        runId: "external/report",
+        outputPaths: {
+          ...report.outputPaths,
+          json: externalReportPath,
+          markdown: externalMarkdownPath
+        }
+      };
+      await writeFile(externalReportPath, `${JSON.stringify(externalReport, null, 2)}\n`);
+      await writeFile(externalMarkdownPath, "# external report\n");
+      const externalBundle = await bundleReport(externalReportPath, { outputDir: tmp });
+      const externalPublishRoot = join(tmp, "publish-external-content-addressed");
+      const externalPublishOutDir = join(externalPublishRoot, "src", "content", "releases");
+      checks.push(await jsonCommandCheck(
+        "publish-noncanonical-content-addressed-bundle",
+        `node bin/kova.mjs publish ${quoteShell(externalReportPath)} --ver 2026.7.12-external-selfcheck --release-date 2026-07-12 --sha selfcheck --out-dir ${quoteShell(externalPublishOutDir)} --json`,
+        async () => {
+          const payload = JSON.parse(
+            await readFile(join(externalPublishOutDir, "2026.7.12-external-selfcheck.json"), "utf8")
+          );
+          const bundleName = basename(externalBundle.outputPath);
+          assertEqual(
+            payload.runs?.[0]?.bundle?.name,
+            bundleName,
+            "publish uses the producer mapping for noncanonical run IDs"
+          );
+          assertEqual(
+            await fileExists(join(externalPublishRoot, "public", "bundles", bundleName)),
+            true,
+            "publish copies noncanonical content-addressed report bundle"
+          );
+        }
+      ));
     }
 
   const ok = checks.every((check) => check.status === "PASS");
@@ -5518,7 +5554,7 @@ async function fileLockRecoveryCheck(tmp) {
           hardwareMachine: "machine-a",
           installationMachine: "install-a",
           boot: "boot-a",
-          pidNamespace: null
+          pidNamespace: "pid:[1]"
         },
         {
           host: "host-a",
@@ -5530,6 +5566,46 @@ async function fileLockRecoveryCheck(tmp) {
       ),
       "rebooted",
       "proven machine reboot is reclaimable"
+    );
+    assertEqual(
+      classifyExecutionDomain(
+        {
+          host: "host-a",
+          hardwareMachine: "machine-a",
+          installationMachine: "install-a",
+          boot: "boot-a",
+          pidNamespace: "pid:[1]"
+        },
+        {
+          host: "host-a",
+          hardwareMachine: "machine-a",
+          installationMachine: "install-a",
+          boot: "boot-b",
+          pidNamespace: "pid:[2]"
+        }
+      ),
+      "foreign",
+      "foreign PID namespace defeats reboot reclamation"
+    );
+    assertEqual(
+      classifyExecutionDomain(
+        {
+          host: "host-a",
+          hardwareMachine: "machine-a",
+          installationMachine: "install-a",
+          boot: "boot-a",
+          pidNamespace: null
+        },
+        {
+          host: "host-a",
+          hardwareMachine: "machine-a",
+          installationMachine: "install-a",
+          boot: "boot-b",
+          pidNamespace: null
+        }
+      ),
+      "unknown",
+      "missing PID namespace identity defeats reboot reclamation"
     );
     assertEqual(
       classifyExecutionDomain(

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4866,8 +4866,11 @@ async function performanceBaselineCheck(tmp) {
 
 async function reportPublicationCheck(tmp) {
   const publicationRoot = join(tmp, "report-publication");
-  const report = JSON.parse(await readFile("tests/fixtures/reports/pass.json", "utf8"));
   try {
+    const report = JSON.parse(await readFile(
+      join(repoRoot, "tests", "fixtures", "reports", "pass.json"),
+      "utf8"
+    ));
     await mkdir(publicationRoot, { recursive: true });
     const failedPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000000-aabbcc");
     const invalidSummaryPath = join(publicationRoot, "s".repeat(250));

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -136,7 +136,7 @@ import {
   runInSelfCheckScope
 } from "./selfcheck-scope.mjs";
 import { compareReports, renderCompareSummary } from "./reporting/compare.mjs";
-import { bundleReport, retainGateArtifacts } from "./reporting/artifacts.mjs";
+import { bundleReport, publishBundlePair, retainGateArtifacts } from "./reporting/artifacts.mjs";
 import { pickAffectedScenarios, scenarioMetricRows } from "./reporting/compare-aggregate.mjs";
 import { renderCompareAssessment } from "./reporting/render-compare.mjs";
 import { renderAssessment } from "./reporting/render-assessment.mjs";
@@ -187,6 +187,7 @@ import { scriptForMode as buildMockProviderScriptForMode } from "../support/chan
 import { projectInternalReport } from "./web-publish/from-internal-report.mjs";
 import { augmentWithDeltas, findImmediatePrior } from "./web-publish/projector.mjs";
 import { directoryCheck } from "./setup.mjs";
+import { withFileLock } from "./file-lock.mjs";
 
 export async function runSelfCheck(flags = {}) {
   return runInSelfCheckScope(
@@ -926,6 +927,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(embeddedRunLogParserCheck());
     checks.push(runtimeDepsWarmReuseEvaluationCheck());
     checks.push(await performanceBaselineCheck(tmp));
+    checks.push(await fileLockRecoveryCheck(tmp));
     checks.push(await reportPublicationCheck(tmp));
     checks.push(cleanupPublicationReceiptCheck());
     checks.push(markdownFailureCardsCheck());
@@ -4890,6 +4892,24 @@ async function reportPublicationCheck(tmp) {
     assertEqual(firstBundle.outputPath === secondBundle.outputPath, false, "colliding run IDs use distinct bundle paths");
     assertEqual(await fileExists(firstBundle.checksumPath), true, "first bundle checksum published");
     assertEqual(await fileExists(secondBundle.checksumPath), true, "second bundle checksum published");
+    const firstArchive = await readFile(firstBundle.outputPath);
+    const firstChecksum = await readFile(firstBundle.checksumPath, "utf8");
+    await rm(firstBundle.checksumPath);
+    await mkdir(firstBundle.checksumPath);
+    let invalidChecksumRejected = false;
+    try {
+      await publishBundlePair({
+        archive: firstArchive,
+        outputPath: firstBundle.outputPath,
+        checksumPath: firstBundle.checksumPath,
+        checksum: firstChecksum
+      });
+    } catch (error) {
+      invalidChecksumRejected = /not a regular file/.test(error.message);
+    }
+    assertEqual(invalidChecksumRejected, true, "bundle publication rejects invalid existing checksum");
+    await rm(firstBundle.checksumPath, { recursive: true });
+    await writeFile(firstBundle.checksumPath, firstChecksum);
 
     const retainedRoot = join(publicationRoot, "retained");
     const retained = await retainGateArtifacts(collisionReports[0], firstBundle, {
@@ -4945,6 +4965,60 @@ async function reportPublicationCheck(tmp) {
       id: "report-publication-integrity",
       status: "FAIL",
       command: "stage and retain synthetic report artifacts",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function fileLockRecoveryCheck(tmp) {
+  try {
+    const malformedLock = join(tmp, "malformed-publication.lock");
+    await writeFile(malformedLock, "{\n");
+    const old = new Date(Date.now() - 60_000);
+    await utimes(malformedLock, old, old);
+    let malformedAcquired = false;
+    await withFileLock(malformedLock, async () => {
+      malformedAcquired = true;
+    }, {
+      staleMs: 1_000,
+      timeoutMs: 2_000,
+      retryMs: 5
+    });
+    assertEqual(malformedAcquired, true, "malformed abandoned lock is reclaimed");
+
+    const racedLock = join(tmp, "raced-publication.lock");
+    await writeFile(racedLock, `${JSON.stringify({
+      token: "abandoned",
+      pid: 2_147_483_647,
+      createdAt: new Date().toISOString()
+    })}\n`);
+    let active = 0;
+    let maxActive = 0;
+    await Promise.all([0, 1].map(() => withFileLock(racedLock, async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await sleep(20);
+      active -= 1;
+    }, {
+      staleMs: 60_000,
+      timeoutMs: 2_000,
+      retryMs: 5
+    })));
+    assertEqual(maxActive, 1, "stale-lock contenders remain serialized");
+    assertEqual(await fileExists(racedLock), false, "owned lock removed after serialized callbacks");
+
+    return {
+      id: "file-lock-recovery",
+      status: "PASS",
+      command: "reclaim malformed and raced publication locks",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "file-lock-recovery",
+      status: "FAIL",
+      command: "reclaim malformed and raced publication locks",
       durationMs: 0,
       message: error.message
     };

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4889,6 +4889,16 @@ async function reportPublicationCheck(tmp) {
       publishedReport.runId,
       "canonical report JSON published"
     );
+    for (const path of Object.values(outputPaths)) {
+      await rename(path, join(publicationRoot, `.${basename(path)}.kova-backup`));
+    }
+    await writeReportOutputs(publicationRoot, publishedReport);
+    assertEqual(await fileExists(outputPaths.markdown), true, "interrupted report swap recovered");
+    assertEqual(
+      (await readdir(publicationRoot)).some((entry) => entry.endsWith(".kova-backup")),
+      false,
+      "recovered report backups removed"
+    );
 
     const collisionRoot = join(publicationRoot, "collisions");
     await mkdir(collisionRoot, { recursive: true });
@@ -4953,6 +4963,31 @@ async function reportPublicationCheck(tmp) {
       checksum: recoverableChecksum
     });
     assertEqual(await fileExists(recoverableBundlePath), true, "checksum-only bundle state recovered");
+    let incompleteBundleRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], {
+        outputPath: firstBundle.outputPath
+      }, {
+        outputDir: join(publicationRoot, "incomplete-bundle-retained")
+      });
+    } catch (error) {
+      incompleteBundleRejected = /requires both archive and checksum/.test(error.message);
+    }
+    assertEqual(incompleteBundleRejected, true, "retention rejects incomplete bundle pair");
+    const mismatchedChecksumPath = join(publicationRoot, "mismatched.sha256");
+    await writeFile(mismatchedChecksumPath, `0${firstChecksum.slice(1)}`);
+    let mismatchedBundleRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], {
+        outputPath: firstBundle.outputPath,
+        checksumPath: mismatchedChecksumPath
+      }, {
+        outputDir: join(publicationRoot, "mismatched-bundle-retained")
+      });
+    } catch (error) {
+      mismatchedBundleRejected = /checksum does not match archive/.test(error.message);
+    }
+    assertEqual(mismatchedBundleRejected, true, "retention rejects mismatched bundle pair");
 
     const symlinkReportPath = join(collisionRoot, "symlink-report.json");
     const symlinkMarkdownPath = join(collisionRoot, "symlink-report.md");
@@ -5031,10 +5066,15 @@ async function reportPublicationCheck(tmp) {
     await rm(unmanagedPath);
     const retainedBackup = join(publicationRoot, ".retained.bak");
     await rename(retainedRoot, retainedBackup);
+    await mkdir(retainedRoot);
+    await writeFile(
+      join(retainedRoot, "retained-artifacts.json"),
+      `${JSON.stringify(retained, null, 2)}\n`
+    );
     await retainGateArtifacts(collisionReports[0], firstBundle, {
       outputDir: retainedRoot
     });
-    assertEqual(await fileExists(retained.jsonPath), true, "interrupted retained tree swap recovered");
+    assertEqual(await fileExists(retained.jsonPath), true, "incomplete retained tree recovered from backup");
     assertEqual(await fileExists(retainedBackup), false, "recovered retained tree backup removed");
 
     await rm(collisionReports[0].replace(/\.json$/, ".md"));

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -189,7 +189,12 @@ import { scriptForMode as buildMockProviderScriptForMode } from "../support/chan
 import { projectInternalReport } from "./web-publish/from-internal-report.mjs";
 import { augmentWithDeltas, findImmediatePrior } from "./web-publish/projector.mjs";
 import { directoryCheck } from "./setup.mjs";
-import { withFileLock } from "./file-lock.mjs";
+import {
+  classifyExecutionDomain,
+  currentExecutionDomainIdentity,
+  normalizeMachineIdentity,
+  withFileLock
+} from "./file-lock.mjs";
 
 export async function runSelfCheck(flags = {}) {
   return runInSelfCheckScope(
@@ -5457,32 +5462,197 @@ async function reportPublicationCheck(tmp) {
 
 async function fileLockRecoveryCheck(tmp) {
   try {
+    assertEqual(normalizeMachineIdentity("uninitialized"), "", "placeholder machine ID rejected");
+    assertEqual(normalizeMachineIdentity("0".repeat(32)), "", "zero machine ID rejected");
+    assertEqual(normalizeMachineIdentity("f".repeat(32)), "", "all-F machine ID rejected");
+    assertEqual(
+      normalizeMachineIdentity("A".repeat(32)),
+      "a".repeat(32),
+      "valid machine UUID normalized"
+    );
+    assertEqual(
+      classifyExecutionDomain(
+        {
+          host: "host-a",
+          hardwareMachine: "machine-a",
+          installationMachine: "install-a",
+          boot: "boot-a",
+          pidNamespace: null
+        },
+        {
+          host: "host-a",
+          hardwareMachine: "machine-a",
+          installationMachine: "install-a",
+          boot: "boot-b",
+          pidNamespace: "pid:[1]"
+        }
+      ),
+      "rebooted",
+      "proven machine reboot is reclaimable"
+    );
+    assertEqual(
+      classifyExecutionDomain(
+        {
+          host: "host-a",
+          hardwareMachine: null,
+          installationMachine: "install-a",
+          boot: "boot-a",
+          pidNamespace: null
+        },
+        {
+          host: "host-a",
+          hardwareMachine: null,
+          installationMachine: "install-a",
+          boot: "boot-b",
+          pidNamespace: null
+        }
+      ),
+      "unknown",
+      "clonable installation identity cannot prove a reboot"
+    );
+    assertEqual(
+      classifyExecutionDomain(
+        {
+          host: "host-a",
+          hardwareMachine: null,
+          installationMachine: "install-a",
+          boot: "boot-a",
+          pidNamespace: "pid:[1]"
+        },
+        {
+          host: "host-a",
+          hardwareMachine: "machine-a",
+          installationMachine: null,
+          boot: "boot-a",
+          pidNamespace: "pid:[1]"
+        }
+      ),
+      "local",
+      "same-boot identity-source transition remains local"
+    );
+    assertEqual(
+      classifyExecutionDomain(
+        {
+          host: "host-a",
+          hardwareMachine: "machine-a",
+          installationMachine: null,
+          boot: "boot-a",
+          pidNamespace: null
+        },
+        {
+          host: "host-b",
+          hardwareMachine: "machine-a",
+          installationMachine: null,
+          boot: "boot-b",
+          pidNamespace: null
+        }
+      ),
+      "foreign",
+      "conflicting hosts defeat a cloned machine identity"
+    );
+    assertEqual(
+      classifyExecutionDomain(
+        { hardwareMachine: null, installationMachine: null, boot: "boot-a", pidNamespace: null },
+        { hardwareMachine: null, installationMachine: null, boot: "boot-a", pidNamespace: "pid:[1]" }
+      ),
+      "unknown",
+      "missing PID namespace identity fails closed"
+    );
+    assertEqual(
+      classifyExecutionDomain(
+        { hardwareMachine: "machine-a", boot: "boot-a", pidNamespace: "pid:[1]" },
+        { hardwareMachine: "machine-b", boot: "boot-a", pidNamespace: "pid:[1]" }
+      ),
+      "foreign",
+      "different machine identities remain foreign"
+    );
+    assertEqual(
+      classifyExecutionDomain(
+        {
+          host: "host-a",
+          hardwareMachine: "machine-a",
+          installationMachine: "install-a",
+          boot: {},
+          pidNamespace: null
+        },
+        {
+          host: "host-a",
+          hardwareMachine: "machine-a",
+          installationMachine: "install-a",
+          boot: "boot-a",
+          pidNamespace: null
+        }
+      ),
+      "unknown",
+      "malformed execution-domain fields fail closed"
+    );
+    for (const field of ["host", "pidNamespace"]) {
+      assertEqual(
+        classifyExecutionDomain(
+          {
+            host: "host-a",
+            hardwareMachine: "machine-a",
+            installationMachine: "install-a",
+            boot: "boot-a",
+            pidNamespace: null,
+            [field]: {}
+          },
+          {
+            host: "host-a",
+            hardwareMachine: "machine-a",
+            installationMachine: "install-a",
+            boot: "boot-a",
+            pidNamespace: null
+          }
+        ),
+        "unknown",
+        `malformed ${field} fails closed`
+      );
+    }
+    assertEqual(
+      classifyExecutionDomain(null, currentExecutionDomainIdentity()),
+      "unknown",
+      "missing owner execution domain fails closed"
+    );
+    assertEqual(
+      classifyExecutionDomain(currentExecutionDomainIdentity(), null),
+      "unknown",
+      "missing current execution domain fails closed"
+    );
+    const localExecutionDomain = currentExecutionDomainIdentity();
+    assertEqual(Boolean(localExecutionDomain), true, "current execution domain is available");
     const malformedLock = join(tmp, "malformed-publication.lock");
     await writeFile(malformedLock, "{\n");
     const old = new Date(Date.now() - 60_000);
     await utimes(malformedLock, old, old);
-    let malformedAcquired = false;
-    await withFileLock(malformedLock, async () => {
-      malformedAcquired = true;
-    }, {
-      staleMs: 1_000,
-      timeoutMs: 2_000,
-      retryMs: 5
-    });
-    assertEqual(malformedAcquired, true, "malformed abandoned lock is reclaimed");
+    let malformedProtected = false;
+    try {
+      await withFileLock(malformedLock, async () => {}, {
+        staleMs: 1,
+        timeoutMs: 25,
+        retryMs: 2
+      });
+    } catch (error) {
+      malformedProtected = /timed out waiting for Kova file lock/.test(error.message);
+    }
+    assertEqual(malformedProtected, true, "malformed lock without domain identity is preserved");
+    await rm(malformedLock);
 
     const incompleteLock = join(tmp, "incomplete-publication.lock");
     await writeFile(incompleteLock, `${JSON.stringify({ pid: process.pid })}\n`);
     await utimes(incompleteLock, old, old);
-    let incompleteAcquired = false;
-    await withFileLock(incompleteLock, async () => {
-      incompleteAcquired = true;
-    }, {
-      staleMs: 1_000,
-      timeoutMs: 2_000,
-      retryMs: 5
-    });
-    assertEqual(incompleteAcquired, true, "incomplete abandoned lock is reclaimed");
+    let incompleteProtected = false;
+    try {
+      await withFileLock(incompleteLock, async () => {}, {
+        staleMs: 1,
+        timeoutMs: 25,
+        retryMs: 2
+      });
+    } catch (error) {
+      incompleteProtected = /timed out waiting for Kova file lock/.test(error.message);
+    }
+    assertEqual(incompleteProtected, true, "incomplete lock without domain identity is preserved");
+    await rm(incompleteLock);
 
     const foreignDomainLock = join(tmp, "foreign-domain-publication.lock");
     await writeFile(foreignDomainLock, `${JSON.stringify({
@@ -5524,11 +5694,40 @@ async function fileLockRecoveryCheck(tmp) {
     assertEqual(foreignHostProtected, true, "foreign-host lock is not reclaimed locally");
     await rm(foreignHostLock);
 
+    const sameHostForeignMachineLock = join(tmp, "same-host-foreign-machine.lock");
+    await writeFile(sameHostForeignMachineLock, `${JSON.stringify({
+      pid: 2_147_483_647,
+      executionDomainIdentity: {
+        host: "shared-hostname",
+        hardwareMachine: "foreign-machine",
+        installationMachine: "foreign-installation",
+        boot: "foreign-boot",
+        pidNamespace: null
+      }
+    })}\n`);
+    let sameHostForeignMachineProtected = false;
+    try {
+      await withFileLock(sameHostForeignMachineLock, async () => {}, {
+        staleMs: 1,
+        timeoutMs: 25,
+        retryMs: 2
+      });
+    } catch (error) {
+      sameHostForeignMachineProtected = /timed out waiting for Kova file lock/.test(error.message);
+    }
+    assertEqual(
+      sameHostForeignMachineProtected,
+      true,
+      "same-hostname foreign-machine lock is not reclaimed locally"
+    );
+    await rm(sameHostForeignMachineLock);
+
     const reusedPidLock = join(tmp, "reused-pid-publication.lock");
     await writeFile(reusedPidLock, `${JSON.stringify({
-      token: "reused-pid",
+      token: "x",
       pid: process.pid,
       processIdentity: "ps:reused-process",
+      executionDomainIdentity: localExecutionDomain,
       createdAt: new Date(Date.now() - 60_000).toISOString()
     })}\n`);
     await utimes(reusedPidLock, old, old);
@@ -5544,8 +5743,9 @@ async function fileLockRecoveryCheck(tmp) {
 
     const racedLock = join(tmp, "raced-publication.lock");
     await writeFile(racedLock, `${JSON.stringify({
-      token: "abandoned",
+      token: "y",
       pid: 2_147_483_647,
+      executionDomainIdentity: localExecutionDomain,
       createdAt: new Date().toISOString()
     })}\n`);
     let active = 0;
@@ -5581,14 +5781,14 @@ async function fileLockRecoveryCheck(tmp) {
     return {
       id: "file-lock-recovery",
       status: "PASS",
-      command: "reclaim malformed and raced publication locks",
+      command: "validate and reclaim publication locks",
       durationMs: 0
     };
   } catch (error) {
     return {
       id: "file-lock-recovery",
       status: "FAIL",
-      command: "reclaim malformed and raced publication locks",
+      command: "validate and reclaim publication locks",
       durationMs: 0,
       message: error.message
     };

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4910,6 +4910,25 @@ async function reportPublicationCheck(tmp) {
     assertEqual(invalidChecksumRejected, true, "bundle publication rejects invalid existing checksum");
     await rm(firstBundle.checksumPath, { recursive: true });
     await writeFile(firstBundle.checksumPath, firstChecksum);
+    await Promise.all([
+      publishBundlePair({
+        archive: firstArchive,
+        outputPath: firstBundle.outputPath,
+        checksumPath: firstBundle.checksumPath,
+        checksum: firstChecksum
+      }),
+      publishBundlePair({
+        archive: firstArchive,
+        outputPath: firstBundle.outputPath,
+        checksumPath: firstBundle.checksumPath,
+        checksum: firstChecksum
+      })
+    ]);
+    assertEqual(
+      await readFile(firstBundle.checksumPath, "utf8"),
+      firstChecksum,
+      "concurrent identical bundle publication preserves checksum"
+    );
 
     const retainedRoot = join(publicationRoot, "retained");
     const retained = await retainGateArtifacts(collisionReports[0], firstBundle, {
@@ -4935,6 +4954,23 @@ async function reportPublicationCheck(tmp) {
       retainedBeforeFailure,
       "failed retained replacement preserves prior tree"
     );
+    const unmanagedPath = join(retainedRoot, "operator-note.txt");
+    await writeFile(unmanagedPath, "preserve me\n");
+    let unmanagedRetentionRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], firstBundle, {
+        outputDir: retainedRoot
+      });
+    } catch (error) {
+      unmanagedRetentionRejected = /contains unmanaged files/.test(error.message);
+    }
+    assertEqual(unmanagedRetentionRejected, true, "retention rejects trees with unmanaged files");
+    assertEqual(
+      await readFile(unmanagedPath, "utf8"),
+      "preserve me\n",
+      "retention preserves unrelated destination data"
+    );
+    await rm(unmanagedPath);
 
     await rm(collisionReports[0].replace(/\.json$/, ".md"));
     let missingMarkdownRejected = false;

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4898,6 +4898,22 @@ async function reportPublicationCheck(tmp) {
 
     const mixedPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000000-mixed");
     const oldCanonical = `${JSON.stringify({ runId: "old-generation" })}\n`;
+    const missingSummaryPath = join(publicationRoot, "missing-stage-parent", "summary.json");
+    await writeFile(
+      join(publicationRoot, `.${basename(mixedPaths.json)}.kova-transaction`),
+      `${JSON.stringify({
+        schemaVersion: "kova.reportTransaction.v2",
+        canonical: basename(mixedPaths.json),
+        previousFiles: [{
+          name: basename(mixedPaths.json),
+          sha256: createHash("sha256").update(oldCanonical).digest("hex")
+        }],
+        files: [mixedPaths.markdown, missingSummaryPath, mixedPaths.json].map((path) => ({
+          name: basename(path),
+          sha256: "0".repeat(64)
+        }))
+      })}\n`
+    );
     await writeFile(
       join(publicationRoot, `.${basename(mixedPaths.json)}.kova-backup`),
       oldCanonical
@@ -4910,7 +4926,7 @@ async function reportPublicationCheck(tmp) {
         runId: "kova-260712-000000-mixed",
         outputPaths: {
           ...mixedPaths,
-          summary: join(publicationRoot, "missing-stage-parent", "summary.json")
+          summary: missingSummaryPath
         }
       });
     } catch {
@@ -4926,6 +4942,64 @@ async function reportPublicationCheck(tmp) {
       await readFile(mixedPaths.json, "utf8"),
       oldCanonical,
       "recovery restores the prior canonical report"
+    );
+
+    const midBackupPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000000-mid-backup");
+    const oldMarkdown = "old generation\n";
+    const midBackupSummaryPath = join(
+      publicationRoot,
+      "missing-mid-backup-parent",
+      "summary.json"
+    );
+    await writeFile(
+      join(publicationRoot, `.${basename(midBackupPaths.json)}.kova-transaction`),
+      `${JSON.stringify({
+        schemaVersion: "kova.reportTransaction.v2",
+        canonical: basename(midBackupPaths.json),
+        previousFiles: [
+          {
+            name: basename(midBackupPaths.json),
+            sha256: createHash("sha256").update(oldCanonical).digest("hex")
+          },
+          {
+            name: basename(midBackupPaths.markdown),
+            sha256: createHash("sha256").update(oldMarkdown).digest("hex")
+          }
+        ],
+        files: [midBackupPaths.markdown, midBackupSummaryPath, midBackupPaths.json].map((path) => ({
+          name: basename(path),
+          sha256: "0".repeat(64)
+        }))
+      })}\n`
+    );
+    await writeFile(
+      join(publicationRoot, `.${basename(midBackupPaths.json)}.kova-backup`),
+      oldCanonical
+    );
+    await writeFile(midBackupPaths.markdown, oldMarkdown);
+    let midBackupRecoveryRejected = false;
+    try {
+      await writeReportOutputs(publicationRoot, {
+        ...report,
+        runId: "kova-260712-000000-mid-backup",
+        outputPaths: {
+          ...midBackupPaths,
+          summary: midBackupSummaryPath
+        }
+      });
+    } catch {
+      midBackupRecoveryRejected = true;
+    }
+    assertEqual(midBackupRecoveryRejected, true, "mid-backup staging failure rejected");
+    assertEqual(
+      await readFile(midBackupPaths.markdown, "utf8"),
+      oldMarkdown,
+      "recovery preserves an untouched prior companion"
+    );
+    assertEqual(
+      await readFile(midBackupPaths.json, "utf8"),
+      oldCanonical,
+      "mid-backup recovery restores the prior canonical report"
     );
 
     const outputPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000001-aabbcc");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -138,7 +138,12 @@ import {
   runInSelfCheckScope
 } from "./selfcheck-scope.mjs";
 import { compareReports, renderCompareSummary } from "./reporting/compare.mjs";
-import { bundleReport, publishBundlePair, retainGateArtifacts } from "./reporting/artifacts.mjs";
+import {
+  bundleReport,
+  publishBundlePair,
+  retainedArtifactTreeDigest,
+  retainGateArtifacts
+} from "./reporting/artifacts.mjs";
 import { pickAffectedScenarios, scenarioMetricRows } from "./reporting/compare-aggregate.mjs";
 import { renderCompareAssessment } from "./reporting/render-compare.mjs";
 import { renderAssessment } from "./reporting/render-assessment.mjs";
@@ -1151,6 +1156,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
         }
       ));
       const publishBundle = await bundleReport(receiptCheck.data.jsonPath, { outputDir: tmp });
+      await writeFile(join(tmp, `${report.runId}-bundle.tar.gz`), "stale legacy bundle\n");
       const publishRoot = join(tmp, "publish-content-addressed");
       const publishOutDir = join(publishRoot, "src", "content", "releases");
       checks.push(await jsonCommandCheck(
@@ -5123,6 +5129,22 @@ async function reportPublicationCheck(tmp) {
       "markerless backup is preserved for operator inspection"
     );
     await rm(markerlessBackupPath);
+    await writeTransactionMarker(outputPaths);
+    await writeFile(markerlessBackupPath, "operator replacement\n");
+    let staleReportMarkerRejected = false;
+    try {
+      await writeReportOutputs(publicationRoot, publishedReport);
+    } catch (error) {
+      staleReportMarkerRejected = /report backup does not match transaction marker/.test(error.message);
+    }
+    assertEqual(staleReportMarkerRejected, true, "stale report backup marker fails closed");
+    assertEqual(
+      await readFile(markerlessBackupPath, "utf8"),
+      "operator replacement\n",
+      "stale report backup marker preserves unrelated replacement data"
+    );
+    await rm(markerlessBackupPath);
+    await rm(join(publicationRoot, `.${basename(outputPaths.json)}.kova-transaction`));
     const transactionTempPath = join(
       publicationRoot,
       `.${basename(outputPaths.json)}.kova-transaction.tmp`
@@ -5408,8 +5430,9 @@ async function reportPublicationCheck(tmp) {
     const emptyRetainedBackup = join(publicationRoot, ".empty-retained.bak");
     await mkdir(emptyRetainedBackup);
     await writeFile(`${emptyRetainedBackup}.owner`, `${JSON.stringify({
-      schemaVersion: "kova.retainedArtifactBackup.v1",
-      outputRoot: emptyRetainedRoot
+      schemaVersion: "kova.retainedArtifactBackup.v2",
+      outputRoot: emptyRetainedRoot,
+      treeSha256: await retainedArtifactTreeDigest(emptyRetainedBackup)
     })}\n`);
     await retainGateArtifacts(collisionReports[0], firstBundle, {
       outputDir: emptyRetainedRoot
@@ -5478,10 +5501,14 @@ async function reportPublicationCheck(tmp) {
     );
     await rm(retainedBackup, { recursive: true });
     const retainedBackupMarker = `${retainedBackup}.owner`;
-    const writeRetainedBackupMarker = () => writeFile(retainedBackupMarker, `${JSON.stringify({
-      schemaVersion: "kova.retainedArtifactBackup.v1",
-      outputRoot: retainedRoot
-    })}\n`);
+    const writeRetainedBackupMarker = async () => {
+      const treeSha256 = await retainedArtifactTreeDigest(retainedRoot);
+      await writeFile(retainedBackupMarker, `${JSON.stringify({
+        schemaVersion: "kova.retainedArtifactBackup.v2",
+        outputRoot: retainedRoot,
+        treeSha256
+      })}\n`);
+    };
     await writeRetainedBackupMarker();
     await rename(retainedRoot, retainedBackup);
     await mkdir(retainedRoot);
@@ -5501,6 +5528,32 @@ async function reportPublicationCheck(tmp) {
     });
     assertEqual(await fileExists(retained.jsonPath), true, "incomplete retained tree recovered from backup");
     assertEqual(await fileExists(retainedBackup), false, "recovered retained tree backup removed");
+
+    await writeRetainedBackupMarker();
+    await rename(retainedRoot, retainedBackup);
+    await rm(retainedBackup, { recursive: true });
+    await mkdir(retainedBackup);
+    const unrelatedBackupPath = join(retainedBackup, "operator-backup.txt");
+    await writeFile(unrelatedBackupPath, "preserve me\n");
+    let staleRetainedMarkerRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], firstBundle, {
+        outputDir: retainedRoot
+      });
+    } catch (error) {
+      staleRetainedMarkerRejected = /backup is not Kova-managed/.test(error.message);
+    }
+    assertEqual(staleRetainedMarkerRejected, true, "stale retained backup marker fails closed");
+    assertEqual(
+      await readFile(unrelatedBackupPath, "utf8"),
+      "preserve me\n",
+      "stale retained backup marker preserves unrelated replacement data"
+    );
+    await rm(retainedBackup, { recursive: true });
+    await rm(retainedBackupMarker);
+    await retainGateArtifacts(collisionReports[0], firstBundle, {
+      outputDir: retainedRoot
+    });
 
     await rm(collisionReports[0].replace(/\.json$/, ".md"));
     let missingMarkdownRejected = false;
@@ -5770,6 +5823,21 @@ async function fileLockRecoveryCheck(tmp) {
     }
     assertEqual(incompleteProtected, true, "incomplete lock without domain identity is preserved");
     await rm(incompleteLock);
+
+    const legacyCandidateLock = join(tmp, "legacy-candidate-publication.lock");
+    const legacyCandidatePath = `${legacyCandidateLock}.reclaim-${"a".repeat(64)}.candidate-12345678-1234-4123-8123-123456789abc`;
+    await writeFile(legacyCandidatePath, "{\n");
+    await utimes(legacyCandidatePath, old, old);
+    await withFileLock(legacyCandidateLock, async () => {}, {
+      staleMs: 1,
+      timeoutMs: 25,
+      retryMs: 2
+    });
+    assertEqual(
+      await fileExists(legacyCandidatePath),
+      false,
+      "stale torn legacy reclaim candidate is removed"
+    );
 
     const foreignDomainLock = join(tmp, "foreign-domain-publication.lock");
     await writeFile(foreignDomainLock, `${JSON.stringify({

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { access, chmod, link, lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, symlink, truncate, utimes, writeFile } from "node:fs/promises";
+import { access, chmod, cp, link, lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, symlink, truncate, utimes, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
@@ -4947,20 +4947,28 @@ async function reportPublicationCheck(tmp) {
   try {
     const report = syntheticPublicationReport();
     await mkdir(publicationRoot, { recursive: true });
+    let reportTransactionSequence = 0;
+    const nextReportTransaction = () => {
+      reportTransactionSequence += 1;
+      return `00000000-0000-4000-8000-${String(reportTransactionSequence).padStart(12, "0")}`;
+    };
     const writeTransactionMarker = async (outputPaths) => {
       const previousFiles = await Promise.all(Object.values(outputPaths).map(async (path) => ({
         name: basename(path),
         sha256: createHash("sha256").update(await readFile(path)).digest("hex")
       })));
+      const transaction = nextReportTransaction();
       await writeFile(
         join(publicationRoot, `.${basename(outputPaths.json)}.kova-transaction`),
         `${JSON.stringify({
-          schemaVersion: "kova.reportTransaction.v2",
+          schemaVersion: "kova.reportTransaction.v3",
+          transaction,
           canonical: basename(outputPaths.json),
           previousFiles,
           files: previousFiles
         })}\n`
       );
+      return transaction;
     };
     const failedPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000000-aabbcc");
     const invalidSummaryPath = join(publicationRoot, "s".repeat(250));
@@ -4992,7 +5000,8 @@ async function reportPublicationCheck(tmp) {
     await writeFile(
       join(publicationRoot, `.${basename(mixedPaths.json)}.kova-transaction`),
       `${JSON.stringify({
-        schemaVersion: "kova.reportTransaction.v2",
+        schemaVersion: "kova.reportTransaction.v3",
+        transaction: nextReportTransaction(),
         canonical: basename(mixedPaths.json),
         previousFiles: [{
           name: basename(mixedPaths.json),
@@ -5044,7 +5053,8 @@ async function reportPublicationCheck(tmp) {
     await writeFile(
       join(publicationRoot, `.${basename(midBackupPaths.json)}.kova-transaction`),
       `${JSON.stringify({
-        schemaVersion: "kova.reportTransaction.v2",
+        schemaVersion: "kova.reportTransaction.v3",
+        transaction: nextReportTransaction(),
         canonical: basename(midBackupPaths.json),
         previousFiles: [
           {
@@ -5129,7 +5139,7 @@ async function reportPublicationCheck(tmp) {
       "markerless backup is preserved for operator inspection"
     );
     await rm(markerlessBackupPath);
-    await writeTransactionMarker(outputPaths);
+    const staleReportTransaction = await writeTransactionMarker(outputPaths);
     await writeFile(markerlessBackupPath, "operator replacement\n");
     let staleReportMarkerRejected = false;
     try {
@@ -5139,12 +5149,107 @@ async function reportPublicationCheck(tmp) {
     }
     assertEqual(staleReportMarkerRejected, true, "stale report backup marker fails closed");
     assertEqual(
-      await readFile(markerlessBackupPath, "utf8"),
+      await readFile(
+        join(`${markerlessBackupPath}.claim-${staleReportTransaction}`, "backup"),
+        "utf8"
+      ),
       "operator replacement\n",
-      "stale report backup marker preserves unrelated replacement data"
+      "stale report backup marker preserves unrelated claimed data"
+    );
+    await rm(`${markerlessBackupPath}.claim-${staleReportTransaction}`, { recursive: true });
+    await rm(join(publicationRoot, `.${basename(outputPaths.json)}.kova-transaction`));
+    const conflictingReportTransaction = await writeTransactionMarker(outputPaths);
+    const conflictingReportClaimContainer =
+      `${markerlessBackupPath}.claim-${conflictingReportTransaction}`;
+    const conflictingReportClaim = join(conflictingReportClaimContainer, "backup");
+    await mkdir(conflictingReportClaimContainer);
+    await rename(outputPaths.json, conflictingReportClaim);
+    await writeFile(markerlessBackupPath, "later operator replacement\n");
+    let conflictingReportBackupRejected = false;
+    try {
+      await writeReportOutputs(publicationRoot, publishedReport);
+    } catch (error) {
+      conflictingReportBackupRejected = /conflicting replacement/.test(error.message);
+    }
+    assertEqual(
+      conflictingReportBackupRejected,
+      true,
+      "claimed report backup rejects a fixed-path replacement"
+    );
+    assertEqual(
+      JSON.parse(await readFile(conflictingReportClaim, "utf8")).runId,
+      publishedReport.runId,
+      "claimed report backup remains intact after replacement"
+    );
+    assertEqual(
+      await readFile(markerlessBackupPath, "utf8"),
+      "later operator replacement\n",
+      "fixed-path report replacement remains intact"
     );
     await rm(markerlessBackupPath);
+    await rename(conflictingReportClaim, outputPaths.json);
+    await rm(conflictingReportClaimContainer, { recursive: true });
     await rm(join(publicationRoot, `.${basename(outputPaths.json)}.kova-transaction`));
+    const malformedReportTransaction = await writeTransactionMarker(outputPaths);
+    const malformedReportClaimContainer =
+      `${markerlessBackupPath}.claim-${malformedReportTransaction}`;
+    await rename(outputPaths.json, markerlessBackupPath);
+    await mkdir(malformedReportClaimContainer);
+    await writeFile(join(malformedReportClaimContainer, "foreign.txt"), "preserve me\n");
+    let malformedReportClaimRejected = false;
+    try {
+      await writeReportOutputs(publicationRoot, publishedReport);
+    } catch (error) {
+      malformedReportClaimRejected = /report backup claim is invalid/.test(error.message);
+    }
+    assertEqual(malformedReportClaimRejected, true, "malformed report claim fails closed");
+    assertEqual(
+      await readFile(join(malformedReportClaimContainer, "foreign.txt"), "utf8"),
+      "preserve me\n",
+      "malformed report claim preserves foreign data"
+    );
+    await rm(malformedReportClaimContainer, { recursive: true });
+    await rename(markerlessBackupPath, outputPaths.json);
+    await rm(join(publicationRoot, `.${basename(outputPaths.json)}.kova-transaction`));
+    const emptyReportClaimTransaction = await writeTransactionMarker(outputPaths);
+    const emptyReportClaimContainer =
+      `${markerlessBackupPath}.claim-${emptyReportClaimTransaction}`;
+    await mkdir(emptyReportClaimContainer);
+    await writeReportOutputs(publicationRoot, publishedReport);
+    assertEqual(
+      await fileExists(emptyReportClaimContainer),
+      false,
+      "empty post-cleanup report claim is finalized"
+    );
+    const restoredReportTransaction = nextReportTransaction();
+    const restoredPreviousFiles = await Promise.all(
+      Object.values(outputPaths).map(async (path) => ({
+        name: basename(path),
+        sha256: createHash("sha256").update(await readFile(path)).digest("hex")
+      }))
+    );
+    await writeFile(
+      join(publicationRoot, `.${basename(outputPaths.json)}.kova-transaction`),
+      `${JSON.stringify({
+        schemaVersion: "kova.reportTransaction.v3",
+        transaction: restoredReportTransaction,
+        canonical: basename(outputPaths.json),
+        previousFiles: restoredPreviousFiles,
+        files: restoredPreviousFiles.map((entry) => ({
+          ...entry,
+          sha256: "0".repeat(64)
+        }))
+      })}\n`
+    );
+    const emptyPostRestoreReportClaim =
+      `${markerlessBackupPath}.claim-${restoredReportTransaction}`;
+    await mkdir(emptyPostRestoreReportClaim);
+    await writeReportOutputs(publicationRoot, publishedReport);
+    assertEqual(
+      await fileExists(emptyPostRestoreReportClaim),
+      false,
+      "empty post-restore report claim is finalized from prior hashes"
+    );
     const transactionTempPath = join(
       publicationRoot,
       `.${basename(outputPaths.json)}.kova-transaction.tmp`
@@ -5156,16 +5261,41 @@ async function reportPublicationCheck(tmp) {
       false,
       "retry removes a torn staged transaction marker"
     );
-    await writeTransactionMarker(outputPaths);
+    const claimedReportTransaction = await writeTransactionMarker(outputPaths);
     for (const path of Object.values(outputPaths)) {
       await rename(path, join(publicationRoot, `.${basename(path)}.kova-backup`));
     }
+    const claimedMarkdownContainer = join(
+      publicationRoot,
+      `.${basename(outputPaths.markdown)}.kova-backup.claim-${claimedReportTransaction}`
+    );
+    const claimedMarkdownBackup = join(claimedMarkdownContainer, "backup");
+    await mkdir(claimedMarkdownContainer);
+    await rename(
+      join(publicationRoot, `.${basename(outputPaths.markdown)}.kova-backup`),
+      claimedMarkdownBackup
+    );
+    const claimedSummaryContainer = join(
+      publicationRoot,
+      `.${basename(outputPaths.summary)}.kova-backup.claim-${claimedReportTransaction}`
+    );
+    await mkdir(claimedSummaryContainer);
     await writeReportOutputs(publicationRoot, publishedReport);
     assertEqual(await fileExists(outputPaths.markdown), true, "interrupted report swap recovered");
     assertEqual(
       (await readdir(publicationRoot)).some((entry) => entry.endsWith(".kova-backup")),
       false,
       "recovered report backups removed"
+    );
+    assertEqual(
+      await fileExists(claimedMarkdownBackup),
+      false,
+      "recovered claimed report backup removed"
+    );
+    assertEqual(
+      await fileExists(claimedSummaryContainer),
+      false,
+      "empty report claim container resumes backup move"
     );
     await writeTransactionMarker(outputPaths);
     await rename(
@@ -5428,17 +5558,79 @@ async function reportPublicationCheck(tmp) {
 
     const emptyRetainedRoot = join(publicationRoot, "empty-retained");
     const emptyRetainedBackup = join(publicationRoot, ".empty-retained.bak");
+    const emptyRetainedClaimId = "10000000-0000-4000-8000-000000000001";
     await mkdir(emptyRetainedBackup);
     await writeFile(`${emptyRetainedBackup}.owner`, `${JSON.stringify({
-      schemaVersion: "kova.retainedArtifactBackup.v2",
+      schemaVersion: "kova.retainedArtifactBackup.v3",
       outputRoot: emptyRetainedRoot,
-      treeSha256: await retainedArtifactTreeDigest(emptyRetainedBackup)
+      treeSha256: await retainedArtifactTreeDigest(emptyRetainedBackup),
+      claimId: emptyRetainedClaimId,
+      phase: "pending"
     })}\n`);
+    const emptyRetainedClaimContainer =
+      `${emptyRetainedBackup}.claim-${emptyRetainedClaimId}`;
+    await mkdir(emptyRetainedClaimContainer);
     await retainGateArtifacts(collisionReports[0], firstBundle, {
       outputDir: emptyRetainedRoot
     });
     assertEqual(await fileExists(emptyRetainedRoot), true, "empty retained tree backup recovered");
     assertEqual(await fileExists(emptyRetainedBackup), false, "empty retained tree backup removed");
+
+    const restoredEmptyRoot = join(publicationRoot, "restored-empty-retained");
+    const restoredEmptyBackup = join(publicationRoot, ".restored-empty-retained.bak");
+    const restoredEmptyClaimId = "10000000-0000-4000-8000-000000000002";
+    await mkdir(restoredEmptyRoot);
+    await writeFile(`${restoredEmptyBackup}.owner`, `${JSON.stringify({
+      schemaVersion: "kova.retainedArtifactBackup.v3",
+      outputRoot: restoredEmptyRoot,
+      treeSha256: await retainedArtifactTreeDigest(restoredEmptyRoot),
+      claimId: restoredEmptyClaimId,
+      phase: "pending"
+    })}\n`);
+    await mkdir(`${restoredEmptyBackup}.claim-${restoredEmptyClaimId}`);
+    await retainGateArtifacts(collisionReports[0], firstBundle, {
+      outputDir: restoredEmptyRoot
+    });
+    assertEqual(
+      await fileExists(`${restoredEmptyBackup}.claim-${restoredEmptyClaimId}`),
+      false,
+      "empty restored retained tree finalizes its claim"
+    );
+    const restoredIncompleteRoot = join(publicationRoot, "restored-incomplete-retained");
+    const restoredIncompleteBackup = join(
+      publicationRoot,
+      ".restored-incomplete-retained.bak"
+    );
+    const restoredIncompleteClaimId = "10000000-0000-4000-8000-000000000003";
+    await mkdir(restoredIncompleteRoot);
+    await writeFile(
+      join(restoredIncompleteRoot, "retained-artifacts.json"),
+      `${JSON.stringify({
+        schemaVersion: "kova.releaseGate.retainedArtifacts.v1",
+        outputDir: restoredIncompleteRoot,
+        reportPath: join(restoredIncompleteRoot, "report.md"),
+        jsonPath: join(restoredIncompleteRoot, "report.json"),
+        pasteSummaryPath: join(restoredIncompleteRoot, "paste-summary.txt"),
+        bundlePath: null,
+        checksumPath: null
+      })}\n`
+    );
+    await writeFile(`${restoredIncompleteBackup}.owner`, `${JSON.stringify({
+      schemaVersion: "kova.retainedArtifactBackup.v3",
+      outputRoot: restoredIncompleteRoot,
+      treeSha256: await retainedArtifactTreeDigest(restoredIncompleteRoot),
+      claimId: restoredIncompleteClaimId,
+      phase: "pending"
+    })}\n`);
+    await mkdir(`${restoredIncompleteBackup}.claim-${restoredIncompleteClaimId}`);
+    await retainGateArtifacts(collisionReports[0], firstBundle, {
+      outputDir: restoredIncompleteRoot
+    });
+    assertEqual(
+      await fileExists(`${restoredIncompleteBackup}.claim-${restoredIncompleteClaimId}`),
+      false,
+      "incomplete restored retained tree finalizes its claim"
+    );
 
     const retainedRoot = join(publicationRoot, "retained");
     const retained = await retainGateArtifacts(collisionReports[0], firstBundle, {
@@ -5501,14 +5693,110 @@ async function reportPublicationCheck(tmp) {
     );
     await rm(retainedBackup, { recursive: true });
     const retainedBackupMarker = `${retainedBackup}.owner`;
-    const writeRetainedBackupMarker = async () => {
+    let retainedClaimSequence = 0;
+    const writeRetainedBackupMarker = async (phase = "pending") => {
+      retainedClaimSequence += 1;
+      const claimId = `20000000-0000-4000-8000-${String(retainedClaimSequence).padStart(12, "0")}`;
       const treeSha256 = await retainedArtifactTreeDigest(retainedRoot);
       await writeFile(retainedBackupMarker, `${JSON.stringify({
-        schemaVersion: "kova.retainedArtifactBackup.v2",
+        schemaVersion: "kova.retainedArtifactBackup.v3",
         outputRoot: retainedRoot,
-        treeSha256
+        treeSha256,
+        claimId,
+        phase
       })}\n`);
+      return claimId;
     };
+    const malformedRetainedClaimId = await writeRetainedBackupMarker();
+    await rename(retainedRoot, retainedBackup);
+    const malformedRetainedClaimContainer =
+      `${retainedBackup}.claim-${malformedRetainedClaimId}`;
+    await mkdir(malformedRetainedClaimContainer);
+    await writeFile(join(malformedRetainedClaimContainer, "foreign.txt"), "preserve me\n");
+    let malformedRetainedClaimRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], firstBundle, {
+        outputDir: retainedRoot
+      });
+    } catch (error) {
+      malformedRetainedClaimRejected = /retained artifact backup claim is invalid/.test(
+        error.message
+      );
+    }
+    assertEqual(malformedRetainedClaimRejected, true, "malformed retained claim fails closed");
+    assertEqual(
+      await readFile(join(malformedRetainedClaimContainer, "foreign.txt"), "utf8"),
+      "preserve me\n",
+      "malformed retained claim preserves foreign data"
+    );
+    await rm(malformedRetainedClaimContainer, { recursive: true });
+    await rename(retainedBackup, retainedRoot);
+    await rm(retainedBackupMarker);
+    const emptyPostRestoreClaimId = await writeRetainedBackupMarker();
+    await rename(retainedRoot, retainedBackup);
+    const emptyPostRestoreContainer =
+      `${retainedBackup}.claim-${emptyPostRestoreClaimId}`;
+    const emptyPostRestoreTree = join(emptyPostRestoreContainer, "tree");
+    await mkdir(emptyPostRestoreContainer);
+    await rename(retainedBackup, emptyPostRestoreTree);
+    await rename(emptyPostRestoreTree, retainedRoot);
+    await retainGateArtifacts(collisionReports[0], firstBundle, {
+      outputDir: retainedRoot
+    });
+    assertEqual(
+      await fileExists(emptyPostRestoreContainer),
+      false,
+      "empty post-restore retained claim is finalized"
+    );
+    const missingCurrentSnapshot = join(publicationRoot, "missing-current-snapshot");
+    await cp(retainedRoot, missingCurrentSnapshot, { recursive: true });
+    const missingCurrentClaimId = await writeRetainedBackupMarker("cleanup");
+    await rename(retainedRoot, retainedBackup);
+    const missingCurrentContainer =
+      `${retainedBackup}.claim-${missingCurrentClaimId}`;
+    const missingCurrentTree = join(missingCurrentContainer, "tree");
+    await mkdir(missingCurrentContainer);
+    await rename(retainedBackup, missingCurrentTree);
+    await rm(join(missingCurrentTree, "report.md"));
+    let missingCurrentCleanupRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], firstBundle, {
+        outputDir: retainedRoot
+      });
+    } catch (error) {
+      missingCurrentCleanupRejected = /cleanup is missing current tree/.test(error.message);
+    }
+    assertEqual(
+      missingCurrentCleanupRejected,
+      true,
+      "partial retained cleanup without a current tree fails closed"
+    );
+    assertEqual(
+      await fileExists(missingCurrentTree),
+      true,
+      "failed partial cleanup preserves the remaining claimed tree"
+    );
+    await rm(missingCurrentContainer, { recursive: true });
+    await cp(missingCurrentSnapshot, retainedRoot, { recursive: true });
+    await rm(missingCurrentSnapshot, { recursive: true });
+    await rm(retainedBackupMarker);
+    const partialCleanupClaimId = await writeRetainedBackupMarker("cleanup");
+    await rename(retainedRoot, retainedBackup);
+    const partialCleanupContainer =
+      `${retainedBackup}.claim-${partialCleanupClaimId}`;
+    const partialCleanupTree = join(partialCleanupContainer, "tree");
+    await mkdir(partialCleanupContainer);
+    await rename(retainedBackup, partialCleanupTree);
+    await cp(partialCleanupTree, retainedRoot, { recursive: true });
+    await rm(join(partialCleanupTree, "report.md"));
+    await retainGateArtifacts(collisionReports[0], firstBundle, {
+      outputDir: retainedRoot
+    });
+    assertEqual(
+      await fileExists(partialCleanupContainer),
+      false,
+      "partially deleted retained cleanup claim is finalized"
+    );
     await writeRetainedBackupMarker();
     await rename(retainedRoot, retainedBackup);
     await mkdir(retainedRoot);
@@ -5516,8 +5804,12 @@ async function reportPublicationCheck(tmp) {
       outputDir: retainedRoot
     });
     assertEqual(await fileExists(retained.jsonPath), true, "empty retained tree recovered from backup");
-    await writeRetainedBackupMarker();
+    const claimedRetainedToken = await writeRetainedBackupMarker();
     await rename(retainedRoot, retainedBackup);
+    const claimedRetainedContainer = `${retainedBackup}.claim-${claimedRetainedToken}`;
+    const claimedRetainedBackup = join(claimedRetainedContainer, "tree");
+    await mkdir(claimedRetainedContainer);
+    await rename(retainedBackup, claimedRetainedBackup);
     await mkdir(retainedRoot);
     await writeFile(
       join(retainedRoot, "retained-artifacts.json"),
@@ -5528,10 +5820,18 @@ async function reportPublicationCheck(tmp) {
     });
     assertEqual(await fileExists(retained.jsonPath), true, "incomplete retained tree recovered from backup");
     assertEqual(await fileExists(retainedBackup), false, "recovered retained tree backup removed");
+    assertEqual(
+      await fileExists(claimedRetainedBackup),
+      false,
+      "recovered claimed retained tree backup removed"
+    );
 
-    await writeRetainedBackupMarker();
+    const conflictingRetainedToken = await writeRetainedBackupMarker();
     await rename(retainedRoot, retainedBackup);
-    await rm(retainedBackup, { recursive: true });
+    const conflictingRetainedContainer = `${retainedBackup}.claim-${conflictingRetainedToken}`;
+    const conflictingRetainedClaim = join(conflictingRetainedContainer, "tree");
+    await mkdir(conflictingRetainedContainer);
+    await rename(retainedBackup, conflictingRetainedClaim);
     await mkdir(retainedBackup);
     const unrelatedBackupPath = join(retainedBackup, "operator-backup.txt");
     await writeFile(unrelatedBackupPath, "preserve me\n");
@@ -5541,15 +5841,22 @@ async function reportPublicationCheck(tmp) {
         outputDir: retainedRoot
       });
     } catch (error) {
-      staleRetainedMarkerRejected = /backup is not Kova-managed/.test(error.message);
+      staleRetainedMarkerRejected = /conflicting replacement/.test(error.message);
     }
-    assertEqual(staleRetainedMarkerRejected, true, "stale retained backup marker fails closed");
+    assertEqual(staleRetainedMarkerRejected, true, "claimed retained backup replacement fails closed");
     assertEqual(
       await readFile(unrelatedBackupPath, "utf8"),
       "preserve me\n",
-      "stale retained backup marker preserves unrelated replacement data"
+      "claimed retained backup preserves fixed-path replacement data"
+    );
+    assertEqual(
+      await fileExists(join(conflictingRetainedClaim, "retained-artifacts.json")),
+      true,
+      "claimed retained backup remains intact after replacement"
     );
     await rm(retainedBackup, { recursive: true });
+    await rename(conflictingRetainedClaim, retainedRoot);
+    await rm(conflictingRetainedContainer, { recursive: true });
     await rm(retainedBackupMarker);
     await retainGateArtifacts(collisionReports[0], firstBundle, {
       outputDir: retainedRoot

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4867,10 +4867,7 @@ async function performanceBaselineCheck(tmp) {
 async function reportPublicationCheck(tmp) {
   const publicationRoot = join(tmp, "report-publication");
   try {
-    const report = JSON.parse(await readFile(
-      join(repoRoot, "tests", "fixtures", "reports", "pass.json"),
-      "utf8"
-    ));
+    const report = syntheticPublicationReport();
     await mkdir(publicationRoot, { recursive: true });
     const failedPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000000-aabbcc");
     const invalidSummaryPath = join(publicationRoot, "s".repeat(250));
@@ -5510,6 +5507,33 @@ function syntheticPerformanceReport({ runId, platform, target, records }) {
     target,
     platform,
     records
+  };
+}
+
+function syntheticPublicationReport() {
+  return {
+    schemaVersion: "kova.report.v1",
+    generatedAt: "2026-07-12T00:00:00.000Z",
+    runId: "kova-260712-000000-aabbcc",
+    mode: "execution",
+    target: "runtime:stable",
+    platform: {
+      os: process.platform,
+      release: "self-check",
+      arch: process.arch,
+      node: process.version
+    },
+    records: [{
+      scenario: "fresh-install",
+      surface: "fresh-install",
+      title: "Fresh Install",
+      status: "PASS",
+      target: "runtime:stable",
+      state: { id: "fresh", title: "Fresh" },
+      repeat: { index: 1, total: 1 },
+      measurements: {},
+      phases: []
+    }]
   };
 }
 

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1161,6 +1161,22 @@ async function runScopedSelfCheck(flags, scope, workspace) {
         }
       ));
       const publishBundle = await bundleReport(receiptCheck.data.jsonPath, { outputDir: tmp });
+      const committedReportBytes = await readFile(receiptCheck.data.jsonPath);
+      await writeFile(
+        receiptCheck.data.jsonPath,
+        `${JSON.stringify({ ...report, mode: "stale-generation" }, null, 2)}\n`
+      );
+      const staleGenerationBundle = await bundleReport(
+        receiptCheck.data.jsonPath,
+        { outputDir: tmp }
+      );
+      await writeFile(receiptCheck.data.jsonPath, committedReportBytes);
+      const newerBundleTime = new Date(Date.now() + 60_000);
+      await utimes(
+        staleGenerationBundle.outputPath,
+        newerBundleTime,
+        newerBundleTime
+      );
       await writeFile(join(tmp, `${report.runId}-bundle.tar.gz`), "stale legacy bundle\n");
       const publishRoot = join(tmp, "publish-content-addressed");
       const publishOutDir = join(publishRoot, "src", "content", "releases");
@@ -1171,6 +1187,11 @@ async function runScopedSelfCheck(flags, scope, workspace) {
           const payload = JSON.parse(await readFile(join(publishOutDir, "2026.7.12-selfcheck.json"), "utf8"));
           const bundleName = basename(publishBundle.outputPath);
           assertEqual(payload.runs?.[0]?.bundle?.name, bundleName, "publish discovers content-addressed report bundle");
+          assertEqual(
+            payload.runs?.[0]?.bundle?.name === basename(staleGenerationBundle.outputPath),
+            false,
+            "publish rejects a newer bundle from another report generation"
+          );
           assertEqual(
             await fileExists(join(publishRoot, "public", "bundles", bundleName)),
             true,
@@ -1738,6 +1759,34 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       checks.push(await failingCommandCheck(
         "publish-rejects-invalid-explicit-bundle",
         `node bin/kova.mjs publish ${quoteShell(invalidExplicitReportPath)} --ver 2026.7.12-invalid-explicit --release-date 2026-07-12 --sha selfcheck --out-dir ${quoteShell(join(invalidExplicitRoot, "releases"))} --json`,
+        "explicitly referenced report bundle failed integrity verification"
+      ));
+      const legacyExplicitRoot = join(tmp, "publish-legacy-explicit");
+      const legacyExplicitReportPath = join(legacyExplicitRoot, "report.json");
+      const legacyExplicitMarkdownPath = join(legacyExplicitRoot, "report.md");
+      const legacyExplicitBundlePath = join(legacyExplicitRoot, "report-bundle.tar.gz");
+      await mkdir(legacyExplicitRoot);
+      const legacyExplicitReport = {
+        ...report,
+        bundlePath: legacyExplicitBundlePath
+      };
+      await writeFile(
+        legacyExplicitReportPath,
+        `${JSON.stringify(legacyExplicitReport, null, 2)}\n`
+      );
+      await writeFile(legacyExplicitMarkdownPath, "# legacy explicit bundle\n");
+      const contentAddressedLegacySource = await bundleReport(
+        legacyExplicitReportPath,
+        { outputDir: legacyExplicitRoot }
+      );
+      await cp(contentAddressedLegacySource.outputPath, legacyExplicitBundlePath);
+      await cp(
+        contentAddressedLegacySource.checksumPath,
+        `${legacyExplicitBundlePath}.sha256`
+      );
+      checks.push(await failingCommandCheck(
+        "publish-rejects-non-content-addressed-explicit-bundle",
+        `node bin/kova.mjs publish ${quoteShell(legacyExplicitReportPath)} --ver 2026.7.12-legacy-explicit --release-date 2026-07-12 --sha selfcheck --out-dir ${quoteShell(join(legacyExplicitRoot, "releases"))} --json`,
         "explicitly referenced report bundle failed integrity verification"
       ));
     }
@@ -6065,6 +6114,31 @@ async function reportPublicationCheck(tmp) {
     );
     await writeFile(orphanChecksumPath, "orphan\n");
     await writeFile(operatorChecksumPath, "operator copy\n");
+    const activeArchive = Buffer.from("active bundle publication\n");
+    const activeDigest = createHash("sha256").update(activeArchive).digest("hex");
+    const activeArchivePath = join(
+      bundleRoot,
+      `${firstLogicalBundleName}-${activeDigest}.tar.gz`
+    );
+    const activeChecksumPath = `${activeArchivePath}.sha256`;
+    await writeFile(
+      activeChecksumPath,
+      `${activeDigest}  ${basename(activeArchivePath)}\n`
+    );
+    let releaseActivePublication;
+    let markActivePublicationReady;
+    const activePublicationRelease = new Promise((resolve) => {
+      releaseActivePublication = resolve;
+    });
+    const activePublicationReady = new Promise((resolve) => {
+      markActivePublicationReady = resolve;
+    });
+    const activePublication = withFileLock(`${activeArchivePath}.lock`, async () => {
+      markActivePublicationReady();
+      await activePublicationRelease;
+      await writeFile(activeArchivePath, activeArchive);
+    });
+    await activePublicationReady;
     const staleBundleTransaction = randomUUID();
     const staleBundleStage = `${firstBundle.outputPath}.${staleBundleTransaction}.tmp`;
     const staleBundleBuildTransaction = randomUUID();
@@ -6153,8 +6227,28 @@ async function reportPublicationCheck(tmp) {
       })}\n`);
       await symlink(symlinkOwnedBundleTarget, symlinkOwnedBundleMarker);
     }
-    await bundleReport(collisionReports[0], { outputDir: bundleRoot });
+    let cleanupSettled = false;
+    const cleanupBundlePromise = bundleReport(
+      collisionReports[0],
+      { outputDir: bundleRoot }
+    ).finally(() => {
+      cleanupSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assertEqual(
+      cleanupSettled,
+      false,
+      "orphan cleanup waits for an active bundle-pair publication"
+    );
+    releaseActivePublication();
+    await activePublication;
+    await cleanupBundlePromise;
     assertEqual(await fileExists(orphanChecksumPath), false, "logical bundle retry removes orphan checksum");
+    assertEqual(
+      await fileExists(activeArchivePath) && await fileExists(activeChecksumPath),
+      true,
+      "orphan cleanup preserves an active bundle-pair publication"
+    );
     assertEqual(
       await fileExists(staleBundleStage),
       false,

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -4869,6 +4869,21 @@ async function reportPublicationCheck(tmp) {
   try {
     const report = syntheticPublicationReport();
     await mkdir(publicationRoot, { recursive: true });
+    const writeTransactionMarker = async (outputPaths) => {
+      const previousFiles = await Promise.all(Object.values(outputPaths).map(async (path) => ({
+        name: basename(path),
+        sha256: createHash("sha256").update(await readFile(path)).digest("hex")
+      })));
+      await writeFile(
+        join(publicationRoot, `.${basename(outputPaths.json)}.kova-transaction`),
+        `${JSON.stringify({
+          schemaVersion: "kova.reportTransaction.v2",
+          canonical: basename(outputPaths.json),
+          previousFiles,
+          files: previousFiles
+        })}\n`
+      );
+    };
     const failedPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000000-aabbcc");
     const invalidSummaryPath = join(publicationRoot, "s".repeat(250));
     let partialWriteRejected = false;
@@ -5013,6 +5028,29 @@ async function reportPublicationCheck(tmp) {
       publishedReport.runId,
       "canonical report JSON published"
     );
+    const markerlessBackupPath = join(
+      publicationRoot,
+      `.${basename(outputPaths.json)}.kova-backup`
+    );
+    await writeFile(markerlessBackupPath, oldCanonical);
+    let markerlessBackupRejected = false;
+    try {
+      await writeReportOutputs(publicationRoot, publishedReport);
+    } catch (error) {
+      markerlessBackupRejected = /report backup is missing transaction marker/.test(error.message);
+    }
+    assertEqual(markerlessBackupRejected, true, "markerless report backup rejected");
+    assertEqual(
+      JSON.parse(await readFile(outputPaths.json, "utf8")).runId,
+      publishedReport.runId,
+      "markerless backup does not replace the committed report"
+    );
+    assertEqual(
+      await readFile(markerlessBackupPath, "utf8"),
+      oldCanonical,
+      "markerless backup is preserved for operator inspection"
+    );
+    await rm(markerlessBackupPath);
     const transactionTempPath = join(
       publicationRoot,
       `.${basename(outputPaths.json)}.kova-transaction.tmp`
@@ -5024,6 +5062,7 @@ async function reportPublicationCheck(tmp) {
       false,
       "retry removes a torn staged transaction marker"
     );
+    await writeTransactionMarker(outputPaths);
     for (const path of Object.values(outputPaths)) {
       await rename(path, join(publicationRoot, `.${basename(path)}.kova-backup`));
     }
@@ -5034,6 +5073,7 @@ async function reportPublicationCheck(tmp) {
       false,
       "recovered report backups removed"
     );
+    await writeTransactionMarker(outputPaths);
     await rename(
       outputPaths.json,
       join(publicationRoot, `.${basename(outputPaths.json)}.kova-backup`)

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -6103,6 +6103,7 @@ async function fileLockRecoveryCheck(tmp) {
     const old = new Date(Date.now() - 60_000);
     await utimes(malformedLock, old, old);
     let malformedProtected = false;
+    let malformedTimeoutMessage = "";
     try {
       await withFileLock(malformedLock, async () => {}, {
         staleMs: 1,
@@ -6110,9 +6111,17 @@ async function fileLockRecoveryCheck(tmp) {
         retryMs: 2
       });
     } catch (error) {
+      malformedTimeoutMessage = error.message;
       malformedProtected = /timed out waiting for Kova file lock/.test(error.message);
     }
     assertEqual(malformedProtected, true, "malformed lock without domain identity is preserved");
+    assertEqual(
+      /owner metadata invalid; ageMs=\d+, fingerprint=[a-f0-9]{64}/.test(
+        malformedTimeoutMessage
+      ),
+      true,
+      "malformed lock timeout pins the observed lock generation"
+    );
     await rm(malformedLock);
 
     const incompleteLock = join(tmp, "incomplete-publication.lock");
@@ -6164,16 +6173,22 @@ async function fileLockRecoveryCheck(tmp) {
     assertEqual(foreignDomainProtected, true, "foreign execution-domain lock is not reclaimed locally");
     await rm(foreignDomainLock);
 
-    const foreignHostLock = join(tmp, "foreign-host-publication.lock");
+    const foreignHostLock = join(
+      tmp,
+      `foreign-host-${"p".repeat(180)}.lock`
+    );
+    const hostileHost =
+      `kova-foreign-host.invalid\n\u001b[31m\u009b\u2028\u202e${"x".repeat(300)}`;
     await writeFile(foreignHostLock, `${JSON.stringify({
       pid: 2_147_483_647,
       executionDomainIdentity: {
-        host: "kova-foreign-host.invalid",
+        host: hostileHost,
         boot: "foreign-boot",
         pidNamespace: null
       }
     })}\n`);
     let foreignHostProtected = false;
+    let foreignHostTimeoutMessage = "";
     try {
       await withFileLock(foreignHostLock, async () => {}, {
         staleMs: 1,
@@ -6181,9 +6196,47 @@ async function fileLockRecoveryCheck(tmp) {
         retryMs: 2
       });
     } catch (error) {
+      foreignHostTimeoutMessage = error.message;
       foreignHostProtected = /timed out waiting for Kova file lock/.test(error.message);
     }
     assertEqual(foreignHostProtected, true, "foreign-host lock is not reclaimed locally");
+    assertEqual(
+      foreignHostTimeoutMessage.includes(
+        'host="kova-foreign-host.invalid\\u000a\\u001b[31m\\u009b\\u2028\\u202e'
+      ),
+      true,
+      "foreign-host timeout identifies the escaped lock owner"
+    );
+    assertEqual(
+      foreignHostTimeoutMessage.includes("\n") ||
+        foreignHostTimeoutMessage.includes("\u001b") ||
+        foreignHostTimeoutMessage.includes("\u009b") ||
+        foreignHostTimeoutMessage.includes("\u2028") ||
+        foreignHostTimeoutMessage.includes("\u202e") ||
+        foreignHostTimeoutMessage.includes("x".repeat(200)),
+      false,
+      "foreign-host timeout bounds and escapes untrusted owner metadata"
+    );
+    assertEqual(
+      foreignHostTimeoutMessage.includes(JSON.stringify(foreignHostLock)),
+      true,
+      "foreign-host timeout preserves the complete escaped lock path"
+    );
+    assertEqual(
+      foreignHostTimeoutMessage.includes(
+        "quiescing all Kova writers"
+      ) &&
+        foreignHostTimeoutMessage.includes(
+          "confirm its owner and fingerprint still match this timeout"
+        ),
+      true,
+      "foreign-host timeout gives scoped manual recovery guidance"
+    );
+    assertEqual(
+      /fingerprint=[a-f0-9]{64}/.test(foreignHostTimeoutMessage),
+      true,
+      "foreign-host timeout pins the observed lock generation"
+    );
     await rm(foreignHostLock);
 
     const sameHostForeignMachineLock = join(tmp, "same-host-foreign-machine.lock");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { access, chmod, cp, link, lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, symlink, truncate, utimes, writeFile } from "node:fs/promises";
+import { access, chmod, cp, link, lstat, mkdir, mkdtemp, open, readFile, readdir, rename, rm, stat, symlink, truncate, utimes, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
+import { gzipSync } from "node:zlib";
 import { resolveScriptStep } from "mock-ai-provider/dist/providers/openai/common/scripted-response.js";
 import { createBoundedOutputAccumulator, quoteShell, runCommand } from "./commands.mjs";
 import { collectErrorFlags, parseFlags } from "./cli.mjs";
@@ -152,7 +153,11 @@ import { renderRunReceipt } from "./reporting/render-run-receipt.mjs";
 import { aggregateScenarios } from "./reporting/scenario-aggregate.mjs";
 import { summarizePerformanceReceipt } from "./run/options.mjs";
 import { saveBaselineUpdate } from "./run/report-finalization.mjs";
-import { buildReportOutputPaths, writeReportOutputs } from "./run/report-output.mjs";
+import {
+  buildReportOutputPaths,
+  reportTransactionLockPath,
+  writeReportOutputs
+} from "./run/report-output.mjs";
 import {
   ocmAt,
   ocmEnvDestroy,
@@ -1206,6 +1211,524 @@ async function runScopedSelfCheck(flags, scope, workspace) {
             await fileExists(join(externalPublishRoot, "public", "bundles", bundleName)),
             true,
             "publish copies noncanonical content-addressed report bundle"
+          );
+        }
+      ));
+
+      const misleadingRunId = "kova-260712-235959-deadbe";
+      const misleadingReportPath = join(tmp, `${misleadingRunId}.json`);
+      const misleadingMarkdownPath = join(tmp, `${misleadingRunId}.md`);
+      await writeFile(
+        misleadingReportPath,
+        `${JSON.stringify({ ...report, runId: misleadingRunId }, null, 2)}\n`
+      );
+      await writeFile(misleadingMarkdownPath, "# misleading report\n");
+      const misleadingBundle = await bundleReport(misleadingReportPath, { outputDir: tmp });
+      const expectedBundleRoot = `${report.runId}-bundle`;
+      const unsafeArchives = [];
+      const unsafeEntrySets = [
+        [{ name: "-unsafe/manifest.json", content: JSON.stringify({ runId: report.runId }) }],
+        [{
+          name: `${expectedBundleRoot}/../${expectedBundleRoot}/manifest.json`,
+          content: JSON.stringify({ runId: report.runId })
+        }],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: `${expectedBundleRoot}/./manifest.json`,
+            content: JSON.stringify({ runId: "wrong-run" })
+          }
+        ],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: "wrong-run" })
+          }
+        ],
+        [{
+          name: `${expectedBundleRoot}/format\u00ad\u200b\u200c\u200d\u2060\ufeff/manifest.json`,
+          content: JSON.stringify({ runId: report.runId })
+        }],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: "package.json",
+            content: "{}"
+          }
+        ],
+        [{
+          name: `${expectedBundleRoot}/manifest.json/`,
+          content: JSON.stringify({ runId: report.runId })
+        }],
+        [{
+          name: `C:/${expectedBundleRoot}/manifest.json`,
+          content: JSON.stringify({ runId: report.runId })
+        }],
+        [{
+          name: `server:stream/${expectedBundleRoot}/manifest.json`,
+          content: JSON.stringify({ runId: report.runId })
+        }],
+        [{
+          name: `CON/${expectedBundleRoot}/manifest.json`,
+          content: JSON.stringify({ runId: report.runId })
+        }],
+        [{
+          name: `host\\share\\${expectedBundleRoot}\\manifest.json`,
+          content: JSON.stringify({ runId: report.runId })
+        }],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: "",
+            type: "5"
+          },
+          {
+            name: `${expectedBundleRoot}/manifest.json/payload.json`,
+            content: JSON.stringify({ runId: report.runId })
+          }
+        ],
+        [{
+          name: `${expectedBundleRoot}/manifest.json`,
+          content: "",
+          type: "2",
+          linkName: `${expectedBundleRoot}/other.json`
+        }],
+        [{
+          name: `${expectedBundleRoot}/manifest.json`,
+          content: "",
+          type: "1",
+          linkName: `${expectedBundleRoot}/other.json`
+        }],
+        [
+          {
+            name: "PaxHeader",
+            content: buildPaxRecord("size", String(512 * 1024 * 1024 + 1)),
+            type: "x"
+          },
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          }
+        ],
+        [
+          {
+            name: "LongPath",
+            content: `${expectedBundleRoot}/manifest.json\0`,
+            type: "L"
+          },
+          {
+            name: "placeholder",
+            content: JSON.stringify({ runId: report.runId })
+          }
+        ],
+        [
+          {
+            name: "OldGnuLongPath",
+            content: `${expectedBundleRoot}/manifest.json\0`,
+            type: "N"
+          },
+          {
+            name: "placeholder",
+            content: JSON.stringify({ runId: report.runId })
+          }
+        ],
+        [
+          {
+            name: "LongLink",
+            content: `${expectedBundleRoot}/manifest.json\0`,
+            type: "K"
+          },
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          }
+        ],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: "PaxHeader",
+            content: buildPaxRecord(
+              "path",
+              `${expectedBundleRoot}/./manifest.json`
+            ),
+            type: "x"
+          },
+          {
+            name: "placeholder",
+            content: JSON.stringify({ runId: "wrong-run" })
+          }
+        ],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: `${expectedBundleRoot.toUpperCase()}/MANIFEST.JSON`,
+            content: JSON.stringify({ runId: "wrong-run" })
+          }
+        ],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: `${expectedBundleRoot}/caf\u00e9.json`,
+            content: "{}"
+          },
+          {
+            name: `${expectedBundleRoot}/cafe\u0301.json`,
+            content: "{}"
+          }
+        ],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: `${expectedBundleRoot}/sigma-\u03c3.json`,
+            content: "{}"
+          },
+          {
+            name: `${expectedBundleRoot}/sigma-\u03c2.json`,
+            content: "{}"
+          }
+        ],
+        [
+          { pseudoTerminator: true, content: "" },
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          }
+        ],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: `${expectedBundleRoot}/malformed-size.bin`,
+            content: "",
+            rawSizeField: Buffer.from([0, 0x2d, 0x31])
+          }
+        ],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: "invalid-name",
+            rawNameField: Buffer.from([0xff]),
+            content: "{}"
+          }
+        ],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: "invalid-prefix",
+            rawPrefixField: Buffer.from([0xff]),
+            content: "{}"
+          }
+        ],
+        [{
+          name: `${expectedBundleRoot}/manifest.json`,
+          content: Buffer.concat([
+            Buffer.from(`{"runId":"${report.runId}","note":"`),
+            Buffer.from([0xff]),
+            Buffer.from('"}')
+          ])
+        }],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: `${expectedBundleRoot}/manifest.json/payload.json`,
+            content: "{}"
+          }
+        ],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json/payload.json`,
+            content: "{}"
+          },
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          }
+        ],
+        [{
+          name: `${expectedBundleRoot}/oversized-directory`,
+          content: "x",
+          declaredSize: 1,
+          type: "5"
+        }],
+        [
+          {
+            name: "GlobalPaxHeader",
+            content: buildPaxRecord("path", "../escape"),
+            type: "g"
+          },
+          {
+            name: `${expectedBundleRoot}/safe.json`,
+            content: "{}"
+          }
+        ],
+        [
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: `${expectedBundleRoot}/oversized.bin`,
+            content: "",
+            declaredSize: 512 * 1024 * 1024 + 1
+          }
+        ],
+        [{
+          name: `${expectedBundleRoot}/manifest.json`,
+          content: "x".repeat(64 * 1024 + 1)
+        }],
+        [
+          {
+            name: "PaxHeader",
+            content: buildPaxRecord(
+              "path",
+              `${expectedBundleRoot}/${"x".repeat(4 * 1024 + 1)}`
+            ),
+            type: "x"
+          },
+          {
+            name: "placeholder",
+            content: "{}"
+          }
+        ]
+      ];
+      unsafeEntrySets.push(
+        ...["<", ">", "\"", "|", "?", "*"].map((character) => [{
+          name: `${expectedBundleRoot}/forbidden-${character}.json`,
+          content: JSON.stringify({ runId: report.runId })
+        }]),
+        Array.from({ length: 10_001 }, (_, index) => ({
+          name: `${expectedBundleRoot}/many/${index}.json`,
+          content: "{}"
+        }))
+      );
+      for (const entries of unsafeEntrySets) {
+        const archive = buildTarGzipFixture(entries);
+        const digest = createHash("sha256").update(archive).digest("hex");
+        const path = join(tmp, `${report.runId}-bundle-${digest}.tar.gz`);
+        await writeFile(path, archive);
+        await writeFile(
+          `${path}.sha256`,
+          `${digest}  ${basename(path)}\n`
+        );
+        unsafeArchives.push(path);
+      }
+      const oversizedArchivePath = join(
+        tmp,
+        `${report.runId}-bundle-${"f".repeat(64)}.tar.gz`
+      );
+      await writeFile(oversizedArchivePath, "");
+      await truncate(oversizedArchivePath, 256 * 1024 * 1024 + 1);
+      await writeFile(
+        `${oversizedArchivePath}.sha256`,
+        `${"f".repeat(64)}  ${basename(oversizedArchivePath)}\n`
+      );
+      unsafeArchives.push(oversizedArchivePath);
+      const oversizedChecksumArchive = buildTarGzipFixture([{
+        name: `${expectedBundleRoot}/manifest.json`,
+        content: JSON.stringify({ runId: report.runId })
+      }]);
+      const oversizedChecksumDigest = createHash("sha256")
+        .update(oversizedChecksumArchive)
+        .digest("hex");
+      const oversizedChecksumPath = join(
+        tmp,
+        `${report.runId}-bundle-${oversizedChecksumDigest}.tar.gz`
+      );
+      await writeFile(oversizedChecksumPath, oversizedChecksumArchive);
+      await writeFile(`${oversizedChecksumPath}.sha256`, "x".repeat(8 * 1024 + 1));
+      unsafeArchives.push(oversizedChecksumPath);
+
+      const mismatchedExplicitArchive = buildTarGzipFixture([
+        {
+          name: `${expectedBundleRoot}/manifest.json`,
+          content: JSON.stringify({ runId: report.runId })
+        },
+        {
+          name: `${expectedBundleRoot}/mismatched-explicit.json`,
+          content: "{}"
+        }
+      ]);
+      const mismatchedExplicitDigest = "0".repeat(64);
+      const mismatchedExplicitPath = join(
+        tmp,
+        `${report.runId}-bundle-${mismatchedExplicitDigest}.tar.gz`
+      );
+      await writeFile(mismatchedExplicitPath, mismatchedExplicitArchive);
+      await writeFile(
+        `${mismatchedExplicitPath}.sha256`,
+        `${mismatchedExplicitDigest}  ${basename(mismatchedExplicitPath)}\n`
+      );
+      unsafeArchives.push(mismatchedExplicitPath);
+
+      const badSidecarArchive = buildTarGzipFixture([
+        {
+          name: `${expectedBundleRoot}/manifest.json`,
+          content: JSON.stringify({ runId: report.runId })
+        },
+        {
+          name: `${expectedBundleRoot}/bad-sidecar.json`,
+          content: "{}"
+        }
+      ]);
+      const badSidecarDigest = createHash("sha256")
+        .update(badSidecarArchive)
+        .digest("hex");
+      const badSidecarPath = join(
+        tmp,
+        `${report.runId}-bundle-${badSidecarDigest}.tar.gz`
+      );
+      await writeFile(badSidecarPath, badSidecarArchive);
+      await writeFile(`${badSidecarPath}.sha256`, "bad checksum\n");
+      unsafeArchives.push(badSidecarPath);
+
+      const missingSidecarArchive = buildTarGzipFixture([
+        {
+          name: `${expectedBundleRoot}/manifest.json`,
+          content: JSON.stringify({ runId: report.runId })
+        },
+        {
+          name: `${expectedBundleRoot}/missing-sidecar.json`,
+          content: "{}"
+        }
+      ]);
+      const missingSidecarDigest = createHash("sha256")
+        .update(missingSidecarArchive)
+        .digest("hex");
+      const missingSidecarPath = join(
+        tmp,
+        `${report.runId}-bundle-${missingSidecarDigest}.tar.gz`
+      );
+      await writeFile(missingSidecarPath, missingSidecarArchive);
+      unsafeArchives.push(missingSidecarPath);
+
+      let fifoBundlePath = null;
+      if (process.platform !== "win32") {
+        fifoBundlePath = join(tmp, "explicit-bundle.fifo");
+        const fifoBundle = await runCommand(`mkfifo ${quoteShell(fifoBundlePath)}`);
+        assertEqual(fifoBundle.status, 0, "creates explicit bundle FIFO fixture");
+
+        const fifoChecksumArchive = buildTarGzipFixture([
+          {
+            name: `${expectedBundleRoot}/manifest.json`,
+            content: JSON.stringify({ runId: report.runId })
+          },
+          {
+            name: `${expectedBundleRoot}/fifo-checksum.json`,
+            content: "{}"
+          }
+        ]);
+        const fifoChecksumDigest = createHash("sha256")
+          .update(fifoChecksumArchive)
+          .digest("hex");
+        const fifoChecksumPath = join(
+          tmp,
+          `${report.runId}-bundle-${fifoChecksumDigest}.tar.gz`
+        );
+        await writeFile(fifoChecksumPath, fifoChecksumArchive);
+        const fifoChecksum = await runCommand(
+          `mkfifo ${quoteShell(`${fifoChecksumPath}.sha256`)}`
+        );
+        assertEqual(fifoChecksum.status, 0, "creates checksum FIFO fixture");
+        unsafeArchives.push(fifoChecksumPath);
+      }
+      const reportWithHostileExplicitBundle = fifoBundlePath
+        ? {
+          ...report,
+          bundle: {
+            path: fifoBundlePath,
+            outputPath: mismatchedExplicitPath
+          },
+          outputPaths: {
+            ...report.outputPaths,
+            bundle: badSidecarPath,
+            bundlePath: missingSidecarPath
+          }
+        }
+        : {
+          ...report,
+          bundle: {
+            path: mismatchedExplicitPath,
+            outputPath: badSidecarPath
+          },
+          outputPaths: {
+            ...report.outputPaths,
+            bundle: missingSidecarPath
+          }
+        };
+      await writeFile(
+        misleadingReportPath,
+        `${JSON.stringify(reportWithHostileExplicitBundle, null, 2)}\n`
+      );
+      await writeFile(
+        misleadingMarkdownPath,
+        await readFile(receiptCheck.data.jsonPath.replace(/\.json$/, ".md"), "utf8")
+      );
+      const priorityPublishRoot = join(tmp, "publish-run-id-priority");
+      const priorityPublishOutDir = join(
+        priorityPublishRoot,
+        "src",
+        "content",
+        "releases"
+      );
+      checks.push(await jsonCommandCheck(
+        "publish-prefers-report-run-id-bundle",
+        `node bin/kova.mjs publish ${quoteShell(misleadingReportPath)} --ver 2026.7.12-run-id-priority --release-date 2026-07-12 --sha selfcheck --out-dir ${quoteShell(priorityPublishOutDir)} --json`,
+        async () => {
+          const payload = JSON.parse(
+            await readFile(
+              join(priorityPublishOutDir, "2026.7.12-run-id-priority.json"),
+              "utf8"
+            )
+          );
+          assertEqual(
+            payload.runs?.[0]?.bundle?.name,
+            basename(publishBundle.outputPath),
+            "publish prioritizes the report run ID bundle"
+          );
+          assertEqual(
+            payload.runs?.[0]?.bundle?.name === basename(misleadingBundle.outputPath),
+            false,
+            "publish rejects a newer filename-derived bundle from another run"
+          );
+          assertEqual(
+            unsafeArchives.some(
+              (path) => payload.runs?.[0]?.bundle?.name === basename(path)
+            ),
+            false,
+            "publish rejects option-like, traversal, aliased, and duplicate tar members"
           );
         }
       ));
@@ -5116,6 +5639,51 @@ async function reportPublicationCheck(tmp) {
       publishedReport.runId,
       "canonical report JSON published"
     );
+    const committedJson = await readFile(outputPaths.json);
+    const committedMarkdown = await readFile(outputPaths.markdown);
+    let releaseTransientWriter;
+    let markTransientWriterReady;
+    const transientWriterRelease = new Promise((resolve) => {
+      releaseTransientWriter = resolve;
+    });
+    const transientWriterReady = new Promise((resolve) => {
+      markTransientWriterReady = resolve;
+    });
+    const transientWriter = withFileLock(
+      reportTransactionLockPath(outputPaths.json),
+      async () => {
+        await writeFile(
+          outputPaths.json,
+          `${JSON.stringify({ ...publishedReport, runId: "transient-generation" })}\n`
+        );
+        await writeFile(outputPaths.markdown, "# transient generation\n");
+        markTransientWriterReady();
+        await transientWriterRelease;
+        await writeFile(outputPaths.json, committedJson);
+        await writeFile(outputPaths.markdown, committedMarkdown);
+      }
+    );
+    await transientWriterReady;
+    let snapshotSettled = false;
+    const serializedBundlePromise = bundleReport(outputPaths.json, {
+      outputDir: join(publicationRoot, "serialized-snapshot-bundles")
+    }).finally(() => {
+      snapshotSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assertEqual(
+      snapshotSettled,
+      false,
+      "report snapshot waits for the writer transaction"
+    );
+    releaseTransientWriter();
+    await transientWriter;
+    const serializedBundle = await serializedBundlePromise;
+    assertEqual(
+      serializedBundle.runId,
+      publishedReport.runId,
+      "report snapshot excludes a rolled-back transient generation"
+    );
     const markerlessBackupPath = join(
       publicationRoot,
       `.${basename(outputPaths.json)}.kova-backup`
@@ -6098,6 +6666,135 @@ async function fileLockRecoveryCheck(tmp) {
     );
     const localExecutionDomain = currentExecutionDomainIdentity();
     assertEqual(Boolean(localExecutionDomain), true, "current execution domain is available");
+    const unsupportedLink = (code) => async () => {
+      const error = new Error(`simulated ${code}`);
+      error.code = code;
+      throw error;
+    };
+    for (const code of ["ENOTSUP", "EPERM"]) {
+      const fallbackLock = join(tmp, `fallback-${code.toLowerCase()}.lock`);
+      let callbackRuns = 0;
+      await withFileLock(
+        fallbackLock,
+        async () => {
+          callbackRuns += 1;
+        },
+        { linkFile: unsupportedLink(code) }
+      );
+      assertEqual(callbackRuns, 1, `${code} hard-link fallback acquires the lock`);
+      assertEqual(await fileExists(fallbackLock), false, `${code} fallback releases the lock`);
+    }
+    const fallbackContentionLock = join(tmp, "fallback-contention.lock");
+    let fallbackActive = 0;
+    let fallbackMaximum = 0;
+    await Promise.all([0, 1].map(() => withFileLock(
+      fallbackContentionLock,
+      async () => {
+        fallbackActive += 1;
+        fallbackMaximum = Math.max(fallbackMaximum, fallbackActive);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        fallbackActive -= 1;
+      },
+      {
+        linkFile: unsupportedLink("ENOTSUP"),
+        retryMs: 2,
+        timeoutMs: 1_000
+      }
+    )));
+    assertEqual(fallbackMaximum, 1, "hard-link fallback serializes contenders");
+
+    const closeRetryLock = join(tmp, "fallback-close-retry.lock");
+    let fallbackCloseAttempts = 0;
+    let fallbackCloseCallbackRuns = 0;
+    await withFileLock(
+      closeRetryLock,
+      async () => {
+        fallbackCloseCallbackRuns += 1;
+      },
+      {
+        linkFile: unsupportedLink("ENOTSUP"),
+        openFallbackFile: async (...args) => {
+          const handle = await open(...args);
+          return {
+            writeFile: (...writeArgs) => handle.writeFile(...writeArgs),
+            chmod: (...chmodArgs) => handle.chmod(...chmodArgs),
+            sync: (...syncArgs) => handle.sync(...syncArgs),
+            close: async () => {
+              fallbackCloseAttempts += 1;
+              if (fallbackCloseAttempts === 1) {
+                const error = new Error("simulated close failure");
+                error.code = "EIO";
+                throw error;
+              }
+              return handle.close();
+            }
+          };
+        }
+      }
+    );
+    assertEqual(
+      fallbackCloseCallbackRuns,
+      1,
+      "durable fallback lock proceeds after an initial close failure"
+    );
+    assertEqual(fallbackCloseAttempts, 2, "fallback lock retries close during release");
+    assertEqual(
+      await fileExists(closeRetryLock),
+      false,
+      "fallback lock releases only after the retained handle closes"
+    );
+
+    const tornFallbackLock = join(tmp, "fallback-write-failure.lock");
+    let fallbackWriteRejected = false;
+    try {
+      await withFileLock(
+        tornFallbackLock,
+        async () => {},
+        {
+          linkFile: unsupportedLink("ENOTSUP"),
+          openFallbackFile: async (...args) => {
+            const handle = await open(...args);
+            return {
+              writeFile: async () => {
+                await handle.writeFile("{", "utf8");
+                const error = new Error("simulated metadata write failure");
+                error.code = "EIO";
+                throw error;
+              },
+              chmod: (...chmodArgs) => handle.chmod(...chmodArgs),
+              sync: (...syncArgs) => handle.sync(...syncArgs),
+              close: (...closeArgs) => handle.close(...closeArgs)
+            };
+          }
+        }
+      );
+    } catch (error) {
+      fallbackWriteRejected = error?.code === "EIO";
+    }
+    assertEqual(fallbackWriteRejected, true, "fallback metadata write failure is reported");
+    let tornSuccessorProtected = false;
+    try {
+      await withFileLock(tornFallbackLock, async () => {}, {
+        linkFile: unsupportedLink("ENOTSUP"),
+        retryMs: 2,
+        staleMs: 1,
+        timeoutMs: 25
+      });
+    } catch (error) {
+      tornSuccessorProtected = /timed out waiting for Kova file lock/.test(error.message);
+    }
+    assertEqual(
+      tornSuccessorProtected,
+      true,
+      "successor cannot replace a torn fallback lock"
+    );
+    assertEqual(
+      await readFile(tornFallbackLock, "utf8"),
+      "{",
+      "failed fallback publication remains fail-closed"
+    );
+    await rm(tornFallbackLock);
+
     const malformedLock = join(tmp, "malformed-publication.lock");
     await writeFile(malformedLock, "{\n");
     const old = new Date(Date.now() - 60_000);
@@ -6106,6 +6803,7 @@ async function fileLockRecoveryCheck(tmp) {
     let malformedTimeoutMessage = "";
     try {
       await withFileLock(malformedLock, async () => {}, {
+        linkFile: unsupportedLink("ENOTSUP"),
         staleMs: 1,
         timeoutMs: 25,
         retryMs: 2
@@ -6121,6 +6819,11 @@ async function fileLockRecoveryCheck(tmp) {
       ),
       true,
       "malformed lock timeout pins the observed lock generation"
+    );
+    assertEqual(
+      await readFile(malformedLock, "utf8"),
+      "{\n",
+      "torn hard-link fallback remains fail-closed for manual recovery"
     );
     await rm(malformedLock);
 
@@ -6395,6 +7098,77 @@ async function fileExists(path) {
     }
     throw error;
   }
+}
+
+function buildTarGzipFixture(entries) {
+  const blocks = [];
+  for (const entry of entries) {
+    const content = Buffer.from(entry.content);
+    const header = Buffer.alloc(512);
+    if (entry.pseudoTerminator) {
+      header.write("000400\0 ", 148, 8, "ascii");
+      blocks.push(header);
+      continue;
+    }
+    if (Buffer.byteLength(entry.name) > 100) {
+      throw new Error(`tar fixture path is too long: ${entry.name}`);
+    }
+    header.write(entry.name, 0, 100, "utf8");
+    if (entry.rawNameField) {
+      header.fill(0, 0, 100);
+      entry.rawNameField.copy(header, 0);
+    }
+    writeTarOctal(header, 100, 8, 0o644);
+    writeTarOctal(header, 108, 8, 0);
+    writeTarOctal(header, 116, 8, 0);
+    writeTarOctal(header, 124, 12, entry.declaredSize ?? content.length);
+    if (entry.rawSizeField) {
+      header.fill(0, 124, 136);
+      entry.rawSizeField.copy(header, 124);
+    }
+    writeTarOctal(header, 136, 12, Math.floor(Date.now() / 1000));
+    header.fill(0x20, 148, 156);
+    header.write(entry.type ?? "0", 156, 1, "ascii");
+    if (entry.linkName) {
+      header.write(entry.linkName, 157, 100, "utf8");
+    }
+    header.write("ustar\0", 257, 6, "ascii");
+    header.write("00", 263, 2, "ascii");
+    header.write("kova", 265, 4, "ascii");
+    header.write("kova", 297, 4, "ascii");
+    if (entry.rawPrefixField) {
+      entry.rawPrefixField.copy(header, 345);
+    }
+    const checksum = header.reduce((sum, byte) => sum + byte, 0);
+    header.write(checksum.toString(8).padStart(6, "0"), 148, 6, "ascii");
+    header[154] = 0;
+    header[155] = 0x20;
+    blocks.push(header, content);
+    const remainder = content.length % 512;
+    if (remainder !== 0) {
+      blocks.push(Buffer.alloc(512 - remainder));
+    }
+  }
+  blocks.push(Buffer.alloc(1024));
+  return gzipSync(Buffer.concat(blocks));
+}
+
+function writeTarOctal(buffer, offset, length, value) {
+  buffer.write(
+    `${value.toString(8).padStart(length - 1, "0")}\0`,
+    offset,
+    length,
+    "ascii"
+  );
+}
+
+function buildPaxRecord(key, value) {
+  const body = ` ${key}=${value}\n`;
+  let length = Buffer.byteLength(body) + 1;
+  while (String(length).length + Buffer.byteLength(body) !== length) {
+    length = String(length).length + Buffer.byteLength(body);
+  }
+  return `${length}${body}`;
 }
 
 function syntheticPerformanceReport({ runId, platform, target, records }) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -136,12 +136,16 @@ import {
   runInSelfCheckScope
 } from "./selfcheck-scope.mjs";
 import { compareReports, renderCompareSummary } from "./reporting/compare.mjs";
+import { bundleReport, retainGateArtifacts } from "./reporting/artifacts.mjs";
 import { pickAffectedScenarios, scenarioMetricRows } from "./reporting/compare-aggregate.mjs";
 import { renderCompareAssessment } from "./reporting/render-compare.mjs";
 import { renderAssessment } from "./reporting/render-assessment.mjs";
+import { renderCleanupArtifacts, renderCleanupEnvs } from "./reporting/render-cleanup.mjs";
 import { renderRunReceipt } from "./reporting/render-run-receipt.mjs";
 import { aggregateScenarios } from "./reporting/scenario-aggregate.mjs";
 import { summarizePerformanceReceipt } from "./run/options.mjs";
+import { saveBaselineUpdate } from "./run/report-finalization.mjs";
+import { buildReportOutputPaths, writeReportOutputs } from "./run/report-output.mjs";
 import {
   ocmAt,
   ocmEnvDestroy,
@@ -922,6 +926,8 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(embeddedRunLogParserCheck());
     checks.push(runtimeDepsWarmReuseEvaluationCheck());
     checks.push(await performanceBaselineCheck(tmp));
+    checks.push(await reportPublicationCheck(tmp));
+    checks.push(cleanupPublicationReceiptCheck());
     checks.push(markdownFailureCardsCheck());
     checks.push(reportRecommendedNextScenarioCheck());
     checks.push(readinessClassificationCheck());
@@ -4602,6 +4608,28 @@ async function performanceBaselineCheck(tmp) {
       false,
       "failed baseline replacement removes temporary file"
     );
+    const concurrentBaselinePath = join(tmp, "concurrent-baselines.json");
+    const firstConcurrentReport = structuredClone(baselineReport);
+    firstConcurrentReport.runId = "concurrent-a";
+    const secondConcurrentReport = structuredClone(baselineReport);
+    secondConcurrentReport.runId = "concurrent-b";
+    await Promise.all([
+      saveBaselineUpdate(firstConcurrentReport, {
+        saveBaselinePath: concurrentBaselinePath,
+        targetPlan: { kind: "local-build", value: "/tmp/openclaw-a" },
+        reviewedGood: true
+      }),
+      saveBaselineUpdate(secondConcurrentReport, {
+        saveBaselinePath: concurrentBaselinePath,
+        targetPlan: { kind: "local-build", value: "/tmp/openclaw-b" },
+        reviewedGood: true
+      })
+    ]);
+    assertEqual(
+      Object.keys((await loadBaselineStore(concurrentBaselinePath)).entries).length,
+      2,
+      "concurrent baseline updates preserve both entries"
+    );
     const otherTargetComparison = comparePerformanceToBaseline(baselineReport, loadedStore, {
       targetPlan: { kind: "local-build", value: "/tmp/other-openclaw" }
     });
@@ -4800,6 +4828,183 @@ async function performanceBaselineCheck(tmp) {
       durationMs: 0,
       message: error.message
     };
+  }
+}
+
+async function reportPublicationCheck(tmp) {
+  const publicationRoot = join(tmp, "report-publication");
+  const report = JSON.parse(await readFile("tests/fixtures/reports/pass.json", "utf8"));
+  try {
+    await mkdir(publicationRoot, { recursive: true });
+    const failedPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000000-aabbcc");
+    const invalidSummaryPath = join(publicationRoot, "s".repeat(250));
+    let partialWriteRejected = false;
+    try {
+      await writeReportOutputs(publicationRoot, {
+        ...report,
+        runId: "kova-260712-000000-aabbcc",
+        outputPaths: {
+          ...failedPaths,
+          summary: invalidSummaryPath
+        }
+      });
+    } catch {
+      partialWriteRejected = true;
+    }
+    assertEqual(partialWriteRejected, true, "report staging failure rejected");
+    assertEqual(await fileExists(failedPaths.markdown), false, "failed report did not publish Markdown");
+    assertEqual(await fileExists(failedPaths.json), false, "failed report did not publish canonical JSON");
+    assertEqual(
+      (await readdir(publicationRoot)).some((entry) => entry.endsWith(".tmp") || entry.endsWith(".bak")),
+      false,
+      "failed report staging removed transaction files"
+    );
+
+    const outputPaths = buildReportOutputPaths(publicationRoot, "kova-260712-000001-aabbcc");
+    const publishedReport = {
+      ...report,
+      runId: "kova-260712-000001-aabbcc",
+      outputPaths
+    };
+    await writeReportOutputs(publicationRoot, publishedReport);
+    assertEqual(await fileExists(outputPaths.markdown), true, "report Markdown published");
+    assertEqual(await fileExists(outputPaths.summary), true, "report summary published");
+    assertEqual(
+      JSON.parse(await readFile(outputPaths.json, "utf8")).runId,
+      publishedReport.runId,
+      "canonical report JSON published"
+    );
+
+    const collisionRoot = join(publicationRoot, "collisions");
+    await mkdir(collisionRoot, { recursive: true });
+    const collisionReports = [];
+    for (const [index, runId] of ["a/b", "a b"].entries()) {
+      const path = join(collisionRoot, `collision-${index}.json`);
+      await writeFile(path, `${JSON.stringify({ ...report, runId }, null, 2)}\n`);
+      await writeFile(path.replace(/\.json$/, ".md"), `report ${index}\n`);
+      collisionReports.push(path);
+    }
+    const bundleRoot = join(publicationRoot, "bundles");
+    const firstBundle = await bundleReport(collisionReports[0], { outputDir: bundleRoot });
+    const secondBundle = await bundleReport(collisionReports[1], { outputDir: bundleRoot });
+    assertEqual(firstBundle.outputPath === secondBundle.outputPath, false, "colliding run IDs use distinct bundle paths");
+    assertEqual(await fileExists(firstBundle.checksumPath), true, "first bundle checksum published");
+    assertEqual(await fileExists(secondBundle.checksumPath), true, "second bundle checksum published");
+
+    const retainedRoot = join(publicationRoot, "retained");
+    const retained = await retainGateArtifacts(collisionReports[0], firstBundle, {
+      outputDir: retainedRoot
+    });
+    const retainedBeforeFailure = await readFile(retained.jsonPath, "utf8");
+    const invalidBundle = join(publicationRoot, "invalid-bundle");
+    await mkdir(invalidBundle);
+    let retainedReplacementRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], {
+        outputPath: invalidBundle,
+        checksumPath: firstBundle.checksumPath
+      }, {
+        outputDir: retainedRoot
+      });
+    } catch {
+      retainedReplacementRejected = true;
+    }
+    assertEqual(retainedReplacementRejected, true, "invalid retained replacement rejected");
+    assertEqual(
+      await readFile(retained.jsonPath, "utf8"),
+      retainedBeforeFailure,
+      "failed retained replacement preserves prior tree"
+    );
+
+    await rm(collisionReports[0].replace(/\.json$/, ".md"));
+    let missingMarkdownRejected = false;
+    try {
+      await bundleReport(collisionReports[0], { outputDir: bundleRoot });
+    } catch (error) {
+      missingMarkdownRejected = /report Markdown is missing/.test(error.message);
+    }
+    assertEqual(missingMarkdownRejected, true, "bundle rejects missing Markdown");
+    missingMarkdownRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], firstBundle, {
+        outputDir: retainedRoot
+      });
+    } catch (error) {
+      missingMarkdownRejected = /report Markdown is missing/.test(error.message);
+    }
+    assertEqual(missingMarkdownRejected, true, "retention rejects missing Markdown");
+
+    return {
+      id: "report-publication-integrity",
+      status: "PASS",
+      command: "stage and retain synthetic report artifacts",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "report-publication-integrity",
+      status: "FAIL",
+      command: "stage and retain synthetic report artifacts",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function cleanupPublicationReceiptCheck() {
+  try {
+    const missingEnvResult = renderCleanupEnvs({
+      envs: ["kova-stale"],
+      results: [],
+      execute: true
+    }, { color: "never" });
+    assertEqual(missingEnvResult.includes("INCOMPLETE"), true, "missing env cleanup result is incomplete");
+    assertEqual(missingEnvResult.includes("Done."), false, "missing env cleanup result omits success footer");
+
+    const failedEnvResult = renderCleanupEnvs({
+      envs: ["kova-stale"],
+      results: [{ command: "ocm env destroy 'kova-stale'", status: 1 }],
+      execute: true
+    }, { color: "never" });
+    assertEqual(failedEnvResult.includes("PARTIAL"), true, "failed env cleanup is partial");
+    assertEqual(failedEnvResult.includes("Done."), false, "failed env cleanup omits success footer");
+
+    const missingArtifactResult = renderCleanupArtifacts({
+      candidates: [{ name: "kova-old", path: "/tmp/kova-old", ageDays: 8 }],
+      results: [],
+      execute: true,
+      artifactsDir: "/tmp",
+      olderThanDays: 7
+    }, { color: "never" });
+    assertEqual(missingArtifactResult.includes("INCOMPLETE"), true, "missing artifact cleanup result is incomplete");
+    assertEqual(missingArtifactResult.includes("Done."), false, "missing artifact cleanup result omits success footer");
+
+    return {
+      id: "cleanup-publication-receipts",
+      status: "PASS",
+      command: "render incomplete cleanup receipts",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "cleanup-publication-receipts",
+      status: "FAIL",
+      command: "render incomplete cleanup receipts",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function fileExists(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
   }
 }
 

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -5015,7 +5015,8 @@ async function reportPublicationCheck(tmp) {
     }
     assertEqual(incompleteBundleRejected, true, "retention rejects incomplete bundle pair");
     const mismatchedChecksumPath = join(publicationRoot, "mismatched.sha256");
-    await writeFile(mismatchedChecksumPath, `0${firstChecksum.slice(1)}`);
+    const mismatchedChecksumPrefix = firstChecksum[0] === "0" ? "1" : "0";
+    await writeFile(mismatchedChecksumPath, `${mismatchedChecksumPrefix}${firstChecksum.slice(1)}`);
     let mismatchedBundleRejected = false;
     try {
       await retainGateArtifacts(collisionReports[0], {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -5134,9 +5134,19 @@ async function reportPublicationCheck(tmp) {
       bundleRoot,
       `${firstLogicalBundleName}-${"0".repeat(64)}.tar.gz.sha256`
     );
+    const operatorChecksumPath = join(
+      bundleRoot,
+      `${firstLogicalBundleName}-operator-copy.tar.gz.sha256`
+    );
     await writeFile(orphanChecksumPath, "orphan\n");
+    await writeFile(operatorChecksumPath, "operator copy\n");
     await bundleReport(collisionReports[0], { outputDir: bundleRoot });
     assertEqual(await fileExists(orphanChecksumPath), false, "logical bundle retry removes orphan checksum");
+    assertEqual(
+      await fileExists(operatorChecksumPath),
+      true,
+      "logical bundle retry preserves operator-named checksum"
+    );
     const firstArchive = await readFile(firstBundle.outputPath);
     const firstChecksum = await readFile(firstBundle.checksumPath, "utf8");
     const sameNameArchiveDir = join(publicationRoot, "same-name-archive");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -5054,6 +5054,10 @@ async function reportPublicationCheck(tmp) {
     const emptyRetainedRoot = join(publicationRoot, "empty-retained");
     const emptyRetainedBackup = join(publicationRoot, ".empty-retained.bak");
     await mkdir(emptyRetainedBackup);
+    await writeFile(`${emptyRetainedBackup}.owner`, `${JSON.stringify({
+      schemaVersion: "kova.retainedArtifactBackup.v1",
+      outputRoot: emptyRetainedRoot
+    })}\n`);
     await retainGateArtifacts(collisionReports[0], firstBundle, {
       outputDir: emptyRetainedRoot
     });
@@ -5102,12 +5106,36 @@ async function reportPublicationCheck(tmp) {
     );
     await rm(unmanagedPath);
     const retainedBackup = join(publicationRoot, ".retained.bak");
+    await mkdir(retainedBackup);
+    await writeFile(join(retainedBackup, "operator-backup.txt"), "preserve me\n");
+    let unverifiedBackupRejected = false;
+    try {
+      await retainGateArtifacts(collisionReports[0], firstBundle, {
+        outputDir: retainedRoot
+      });
+    } catch (error) {
+      unverifiedBackupRejected = /backup is not Kova-managed/.test(error.message);
+    }
+    assertEqual(unverifiedBackupRejected, true, "retention rejects an unverified backup directory");
+    assertEqual(
+      await readFile(join(retainedBackup, "operator-backup.txt"), "utf8"),
+      "preserve me\n",
+      "retention preserves an unverified backup directory"
+    );
+    await rm(retainedBackup, { recursive: true });
+    const retainedBackupMarker = `${retainedBackup}.owner`;
+    const writeRetainedBackupMarker = () => writeFile(retainedBackupMarker, `${JSON.stringify({
+      schemaVersion: "kova.retainedArtifactBackup.v1",
+      outputRoot: retainedRoot
+    })}\n`);
+    await writeRetainedBackupMarker();
     await rename(retainedRoot, retainedBackup);
     await mkdir(retainedRoot);
     await retainGateArtifacts(collisionReports[0], firstBundle, {
       outputDir: retainedRoot
     });
     assertEqual(await fileExists(retained.jsonPath), true, "empty retained tree recovered from backup");
+    await writeRetainedBackupMarker();
     await rename(retainedRoot, retainedBackup);
     await mkdir(retainedRoot);
     await writeFile(

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -29,7 +29,8 @@ import {
   resolveBaselinePath,
   reviewBaselineUpdate,
   saveBaselineStore,
-  updateBaselineStore
+  updateBaselineStore,
+  withBaselineStoreLock
 } from "./performance/baselines.mjs";
 import {
   buildPerformanceSummary,
@@ -4633,6 +4634,17 @@ async function performanceBaselineCheck(tmp) {
       2,
       "concurrent baseline updates preserve both entries"
     );
+    let aliasActive = 0;
+    let aliasMaxActive = 0;
+    await Promise.all(["Alias-Baseline.json", "alias-baseline.json"].map((name) =>
+      withBaselineStoreLock(join(tmp, name), async () => {
+        aliasActive += 1;
+        aliasMaxActive = Math.max(aliasMaxActive, aliasActive);
+        await sleep(20);
+        aliasActive -= 1;
+      })
+    ));
+    assertEqual(aliasMaxActive, 1, "case aliases share one baseline lock");
     const otherTargetComparison = comparePerformanceToBaseline(baselineReport, loadedStore, {
       targetPlan: { kind: "local-build", value: "/tmp/other-openclaw" }
     });
@@ -5088,6 +5100,24 @@ async function fileLockRecoveryCheck(tmp) {
       retryMs: 5
     });
     assertEqual(incompleteAcquired, true, "incomplete abandoned lock is reclaimed");
+
+    const foreignDomainLock = join(tmp, "foreign-domain-publication.lock");
+    await writeFile(foreignDomainLock, `${JSON.stringify({
+      pid: 2_147_483_647,
+      executionDomainIdentity: "other-host"
+    })}\n`);
+    let foreignDomainProtected = false;
+    try {
+      await withFileLock(foreignDomainLock, async () => {}, {
+        staleMs: 1,
+        timeoutMs: 25,
+        retryMs: 2
+      });
+    } catch (error) {
+      foreignDomainProtected = /timed out waiting for Kova file lock/.test(error.message);
+    }
+    assertEqual(foreignDomainProtected, true, "foreign execution-domain lock is not reclaimed locally");
+    await rm(foreignDomainLock);
 
     const reusedPidLock = join(tmp, "reused-pid-publication.lock");
     await writeFile(reusedPidLock, `${JSON.stringify({

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { access, chmod, cp, link, lstat, mkdir, mkdtemp, open, readFile, readdir, rename, rm, stat, symlink, truncate, utimes, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, join, win32 } from "node:path";
 import { gzipSync, gunzipSync } from "node:zlib";
 import { resolveScriptStep } from "mock-ai-provider/dist/providers/openai/common/scripted-response.js";
 import { createBoundedOutputAccumulator, quoteShell, runCommand } from "./commands.mjs";
@@ -141,6 +141,7 @@ import {
 import { compareReports, renderCompareSummary } from "./reporting/compare.mjs";
 import {
   bundleReport,
+  pathIsAtOrBelow,
   publishBundlePair,
   retainedArtifactTreeDigest,
   retainGateArtifacts
@@ -5848,6 +5849,15 @@ async function reportPublicationCheck(tmp) {
       artifactRootOutputRejected,
       true,
       "bundle output cannot replace the run artifact root"
+    );
+    assertEqual(
+      pathIsAtOrBelow(
+        "D:\\kova\\bundles",
+        "C:\\kova\\artifacts",
+        win32
+      ),
+      false,
+      "cross-volume bundle output is outside the artifact source tree"
     );
     if (process.platform !== "win32") {
       const artifactRootAlias = join(tmp, "published-artifact-root-alias");

--- a/tests/render-snapshots.mjs
+++ b/tests/render-snapshots.mjs
@@ -115,6 +115,7 @@ function normalize(out, snapshotCase) {
     .replace(/kova-\d{4}-\d{2}-\d{2}t\d{6}z/g, "kova-<runid>")
     .replace(/kova-\d{6}-\d{6}-[a-f0-9]{6}/g, "kova-<runId>")
     .replace(/kova-\d{6}-\d{6}-[a-f0-9]{6}/gi, (match) => match === match.toLowerCase() ? "kova-<runid>" : "kova-<runId>")
+    .replace(/-bundle-[a-f0-9]{64}\.tar\.gz/g, "-bundle-<sha256>.tar.gz")
     // Strip trailing whitespace per line (renderer already does, defensive).
     .split("\n").map((l) => l.replace(/\s+$/, "")).join("\n");
   return normalized;

--- a/tests/snapshots/matrix-run-receipt-dry-json.snap
+++ b/tests/snapshots/matrix-run-receipt-dry-json.snap
@@ -17,8 +17,8 @@
   "reportPath": "<kova-home>/reports/kova-<runId>-smoke.md",
   "jsonPath": "<kova-home>/reports/kova-<runId>-smoke.json",
   "summaryPath": "<kova-home>/reports/kova-<runId>-smoke.summary.json",
-  "bundlePath": "<kova-home>/reports/kova-<runId>-bundle.tar.gz",
-  "checksumPath": "<kova-home>/reports/kova-<runId>-bundle.tar.gz.sha256",
+  "bundlePath": "<kova-home>/reports/kova-<runId>-bundle-<sha256>.tar.gz",
+  "checksumPath": "<kova-home>/reports/kova-<runId>-bundle-<sha256>.tar.gz.sha256",
   "retainedGateArtifacts": null,
   "gate": null,
   "networkFrontage": {

--- a/tests/snapshots/matrix-run-receipt-dry.snap
+++ b/tests/snapshots/matrix-run-receipt-dry.snap
@@ -14,7 +14,7 @@
   ◆ markdown    <kova-home>/reports/kova-<runId>-smoke.md
   ◆ json        <kova-home>/reports/kova-<runId>-smoke.json
   ◆ summary     <kova-home>/reports/kova-<runId>-smoke.summary.json
-  ◆ bundle      <kova-home>/reports/kova-<runId>-bundle.tar.gz
+  ◆ bundle      <kova-home>/reports/kova-<runId>-bundle-<sha256>.tar.gz
 
 ─── scenarios ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What Problem This Solves

Kova report publication could expose mixed generations, race concurrent writers, publish an unrelated bundle for a report, or leave partially cleaned report and retention state after interruption. Bundle handling also trusted legacy filenames and platform-specific path assumptions too broadly.

## Why This Change Was Made

This consolidates publication around recoverable, serialized transactions:

- atomic, durable report and receipt publication
- generation-aware rollback and restart recovery
- canonical shared file locking with conservative foreign-host ownership
- content-addressed bundles bound to the exact report bytes
- structural, bounded USTAR verification with portable path rules
- serialized bundle-pair publication and orphan cleanup
- retained-artifact ownership markers, validated backups, and recoverable cleanup
- canonical artifact snapshots across symlink aliases and Windows cross-volume paths

## User Impact

Report readers now see either the previous complete generation or the next complete generation. Interrupted or overlapping runs recover without deleting unrelated files. Published bundles must match the selected report, pass checksum and archive validation, and use portable content-addressed identities.

## Evidence

- exact head: `ebf9aced13ca934c68164b1eaee297b0404fab51`
- `npm run check:full`
  - selfcheck: `257/257 PASS`
  - snapshots: `21/21 PASS`
  - web payload: `1/1 PASS`
  - release contract checks: PASS
- packed artifact:
  - size: `3,456,062` bytes
  - SHA-256: `7d06b4822364e7938c826d923249978e2f7e6d68d764b34ebcabd2c3a91a6f04`
  - checksum and embedded source metadata verified
  - extracted `setup --ci --json`: PASS
  - extracted package `npm run check`: `257/257 PASS`
- explicit `gpt-5.6-sol` high autoreview:
  - final affected branch slice: no actionable findings, patch correct at `0.84` confidence
  - final cross-volume delta: no actionable findings, patch correct at `0.98` confidence
- base: exact `main` SHA `cb25bb609d341df41baf198b0b4b3bf83ba1fe50`
