### PR TITLE
fix(evaluation): keep optional cleanup evidence nullable

### DIFF
--- a/src/evaluation/violations.mjs
+++ b/src/evaluation/violations.mjs
@@ -129,8 +129,17 @@ function resourceAttribution(role, summary) {
   };
 }
 
-export function checkAggregateThreshold(violations, actual, metric, threshold) {
+export function checkAggregateThreshold(
+  violations,
+  actual,
+  metric,
+  threshold,
+  { optionalMeasurement = false } = {}
+) {
   if (!activeFiniteThreshold(violations, metric, threshold)) {
+    return;
+  }
+  if (optionalMeasurement && actual === null) {
     return;
   }
   if (!finiteNonNegativeMeasurement(violations, metric, actual, "measurement") || actual <= threshold) {
@@ -165,8 +174,18 @@ export function checkBooleanThreshold(violations, kind, metric, actual, threshol
   }
 }
 
-export function checkTurnThreshold(violations, turn, metric, threshold, message) {
+export function checkTurnThreshold(
+  violations,
+  turn,
+  metric,
+  threshold,
+  message,
+  { optionalMeasurement = false } = {}
+) {
   if (!turn || !activeFiniteThreshold(violations, metric, threshold)) {
+    return;
+  }
+  if (optionalMeasurement && turn[metric] === null) {
     return;
   }
   if (

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -2257,7 +2257,16 @@ function checkAgentTurnThresholds(violations, turns, selected, thresholds, recor
     if (turn.expectedFailure !== true) {
       checkTurnThreshold(violations, turn, "providerFinalMs", thresholds.providerFinalMs, `${turn.label} provider work took ${turn.providerFinalMs}ms`);
     }
-    checkTurnThreshold(violations, turn, "cleanupMs", thresholds.agentCleanupMs, `${turn.label} agent cleanup took ${turn.cleanupMs}ms`);
+    // Cleanup is source-span evidence: gate it when present, while absence remains
+    // explicit null. Non-null malformed evidence still blocks in the helper.
+    checkTurnThreshold(
+      violations,
+      turn,
+      "cleanupMs",
+      thresholds.agentCleanupMs,
+      `${turn.label} agent cleanup took ${turn.cleanupMs}ms`,
+      { optionalMeasurement: true }
+    );
     if (typeof thresholds.preProviderDominanceRatio === "number" &&
       typeof turn.preProviderDominance === "number" &&
       turn.preProviderDominance > thresholds.preProviderDominanceRatio &&
@@ -2307,8 +2316,20 @@ function checkAgentTurnAggregateThresholds(violations, stats, thresholds) {
   checkAggregateThreshold(violations, stats.preProviderMs.max, "agentPreProviderMaxMs", thresholds.agentPreProviderMaxMs);
   checkAggregateThreshold(violations, stats.providerFinalMs.p95, "agentProviderFinalP95Ms", thresholds.agentProviderFinalP95Ms);
   checkAggregateThreshold(violations, stats.providerFinalMs.max, "agentProviderFinalMaxMs", thresholds.agentProviderFinalMaxMs);
-  checkAggregateThreshold(violations, stats.cleanupMs.p95, "agentCleanupP95Ms", thresholds.agentCleanupP95Ms);
-  checkAggregateThreshold(violations, stats.cleanupMs.max, "agentCleanupMaxMs", thresholds.agentCleanupMaxMs);
+  checkAggregateThreshold(
+    violations,
+    stats.cleanupMs.p95,
+    "agentCleanupP95Ms",
+    thresholds.agentCleanupP95Ms,
+    { optionalMeasurement: true }
+  );
+  checkAggregateThreshold(
+    violations,
+    stats.cleanupMs.max,
+    "agentCleanupMaxMs",
+    thresholds.agentCleanupMaxMs,
+    { optionalMeasurement: true }
+  );
 }
 
 function preProviderDominanceExceededAbsoluteGate(turn, thresholds) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1434,6 +1434,33 @@ function evaluationViolationHelpersCheck() {
       "malformed helper payloads are Kova harness blockers"
     );
 
+    const optionalMeasurements = [];
+    checkTurnThreshold(
+      optionalMeasurements,
+      { phaseId: "turn", cleanupMs: null },
+      "cleanupMs",
+      5000,
+      "agent cleanup was unavailable",
+      { optionalMeasurement: true }
+    );
+    checkAggregateThreshold(
+      optionalMeasurements,
+      null,
+      "agentCleanupMaxMs",
+      5000,
+      { optionalMeasurement: true }
+    );
+    assertEqual(optionalMeasurements.length, 0, "missing optional measurements stay non-blocking");
+    checkTurnThreshold(
+      optionalMeasurements,
+      { phaseId: "turn", cleanupMs: -1 },
+      "cleanupMs",
+      5000,
+      "agent cleanup was malformed",
+      { optionalMeasurement: true }
+    );
+    assertEqual(optionalMeasurements.length, 1, "malformed optional measurements still block");
+
     const malformedRecord = {
       status: "PASS",
       phases: [{
@@ -6148,6 +6175,15 @@ function agentTurnBreakdownCheck() {
     assertEqual(record.measurements.agentTurnStats?.count, 1, "agent turn stats count");
     assertEqual(record.measurements.agentTurnP95Ms, 1000, "agent turn p95");
     assertEqual(record.measurements.agentPreProviderP95Ms, 200, "agent pre-provider p95");
+    const missingCleanupRecord = structuredClone(record);
+    missingCleanupRecord.status = "PASS";
+    evaluateRecord(missingCleanupRecord, {
+      id: "agent-cold-warm-message",
+      agent: { expectedText: "KOVA_AGENT_OK" },
+      thresholds: { agentCleanupMs: 5000 }
+    }, { surface: { thresholds: {} }, targetPlan: { kind: "local-build" } });
+    assertEqual(missingCleanupRecord.status, "PASS", "missing optional cleanup span stays pass");
+    assertEqual(missingCleanupRecord.measurements.agentCleanupMaxMs, null, "missing cleanup remains explicit null");
     const rendered = renderMarkdownReport({
       generatedAt: "2026-05-01T00:00:00.000Z",
       runId: "self-check-agent-turn-breakdown",


### PR DESCRIPTION
## What Problem This Solves

Release-profile agent runs became `BLOCKED` when OpenClaw did not emit the optional `agent.cleanup` source span. The evaluator represented that absence as `cleanupMs: null`, but the malformed-evidence hardening treated the explicit absence as malformed.

## Why This Change Was Made

Keep malformed-evidence validation strict while making the source-span contract explicit: only `null` is accepted as absent for cleanup thresholds. Negative, non-finite, string, and undefined cleanup values still block as harness evidence failures. Required turn measurements remain unchanged.

## User Impact

OpenClaw release performance runs can evaluate agent cold/warm turns when cleanup source-span evidence is unavailable, while still failing on measured cleanup regressions and malformed evidence.

## Evidence

- `npm run check`: 240/244 passed locally; the four failures require the unavailable local `ocm` prerequisite. The touched `evaluation-violation-helpers` and `agent-turn-breakdown` checks passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- CI will run the full suite with OCM on Linux and macOS.
