### PR TITLE
fix(evidence): accept disabled gateway health proof

### DIFF
--- a/src/evidence/agent-turns.mjs
+++ b/src/evidence/agent-turns.mjs
@@ -671,19 +671,37 @@ function agentTurnLatencyReason(turns, scenario, expectedTurnCount) {
 
 function agentCliNoServiceHealthOk(record) {
   const final = record.measurements?.health?.final;
-  const expectedGatewayState = agentCliRecordExpectsRunningGateway(record) ? "running" : "disabled";
+  const expectsRunningGateway = agentCliRecordExpectsRunningGateway(record);
+  const expectedGatewayState = expectsRunningGateway ? "running" : "disabled";
+  const finalHealthOk = expectsRunningGateway
+    ? final?.gatewayState === "running" && final?.failureCount === 0
+    : final?.gatewayState === "disabled" &&
+      final?.ok === null &&
+      final?.healthOk === null &&
+      final?.failureCount === null;
   return record.measurements?.finalGatewayState === expectedGatewayState &&
-    final?.failureCount === 0 &&
+    finalHealthOk &&
     findCommandResult(record, (result) => result.command?.includes(" -- status"))?.status === 0;
 }
 
 function agentCliNoServiceHealthReason(record) {
-  const expectedGatewayState = agentCliRecordExpectsRunningGateway(record) ? "running" : "disabled";
+  const expectsRunningGateway = agentCliRecordExpectsRunningGateway(record);
+  const expectedGatewayState = expectsRunningGateway ? "running" : "disabled";
+  const final = record.measurements?.health?.final;
   if (record.measurements?.finalGatewayState !== expectedGatewayState) {
     return `final gateway state was ${record.measurements?.finalGatewayState ?? "missing"}`;
   }
-  if (record.measurements?.health?.final?.failureCount !== 0) {
-    return `final health failures were ${record.measurements?.health?.final?.failureCount ?? "missing"}`;
+  if (final?.gatewayState !== expectedGatewayState) {
+    return `final health gateway state was ${final?.gatewayState ?? "missing"}`;
+  }
+  if (expectsRunningGateway && final?.failureCount !== 0) {
+    return `final health failures were ${final?.failureCount ?? "missing"}`;
+  }
+  if (
+    !expectsRunningGateway &&
+    (final?.ok !== null || final?.healthOk !== null || final?.failureCount !== null)
+  ) {
+    return "disabled gateway final health was not explicit not-applicable evidence";
   }
   if (findCommandResult(record, (result) => result.command?.includes(" -- status"))?.status !== 0) {
     return "post-agent status command did not pass";

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -7413,6 +7413,18 @@ function agentCliLocalTurnEvidenceInvariantCheck() {
     const transportProof = nonLocalInvariants.find((invariant) => invariant.id === "agent-cli-local-transport-proof");
     assertEqual(transportProof?.status, "failed", "non-local agent command fails local transport proof");
 
+    const fabricatedDisabledHealthRecord = JSON.parse(JSON.stringify(record));
+    fabricatedDisabledHealthRecord.measurements.health.final.failureCount = 0;
+    const fabricatedDisabledHealthProof = buildAgentCliLocalTurnEvidenceInvariants(
+      fabricatedDisabledHealthRecord,
+      scenario
+    ).find((invariant) => invariant.id === "agent-cli-no-service-health-proof");
+    assertEqual(
+      fabricatedDisabledHealthProof?.status,
+      "missing",
+      "disabled gateway health must remain explicit not-applicable evidence"
+    );
+
     return {
       id: "agent-cli-local-turn-evidence-invariants",
       status: "PASS",
@@ -7548,16 +7560,8 @@ function syntheticAgentCliLocalTurnRecord({
     },
     finalMetrics: {
       service: { gatewayState: "disabled", gatewayPort: 43111 },
-      health: { ok: false, durationMs: null },
-      healthSummary: {
-        count: 0,
-        okCount: 0,
-        failureCount: 0,
-        minMs: null,
-        p50Ms: null,
-        p95Ms: null,
-        maxMs: null
-      },
+      health: null,
+      healthSummary: null,
       logs: zeroLogMetrics(),
       timeline: syntheticTimelineMetrics()
     }


### PR DESCRIPTION
## What Problem This Solves

Release-profile local-agent runs were marked `INCOMPLETE` even though the disposable environment correctly kept its Gateway disabled and the post-agent status command passed. The evidence invariant required a numeric health failure count from a Gateway that was intentionally not running.

## Why This Change Was Made

Makes the two valid final-health contracts explicit. Running Gateways still require zero health failures. Disabled Gateways require a matching disabled state plus explicit not-applicable `null` health fields; missing, fabricated, or contradictory health evidence remains incomplete.

## User Impact

Kova can complete no-service local-agent release evidence without inventing health samples for a disabled Gateway, while preserving strict evidence validation.

## Evidence

- Exact failing OpenClaw main/LTS artifacts: all six affected repeats had `finalGatewayState: disabled`, final health state `disabled`, explicit null health fields, and passing post-agent status commands.
- Local `npm run check`: touched `agent-cli-local-turn-evidence-invariants` passed; 245/249 overall passed. Four unrelated prerequisite checks failed because local OCM is unavailable.
- Fresh autoreview: clean, no accepted/actionable findings.
- Hosted Linux/macOS CI will run the full suite with OCM.
