### PR TITLE
fix(evidence): harden publish and run contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Kova are documented in this file.
 - Stopped parallel matrix workers from scheduling new scenarios after a rejection, drained active workers before rethrowing, and made lifecycle command indexes phase-wide to prevent artifact overwrites.
 - Fixed web release projections to select same-day priors numerically, match headline deltas by scenario, metric, and unit, label comparisons with the measured metric, and median-aggregate repeated turn measurements.
 - Hardened release validation against missing, malformed, misplaced, partial, or incomplete provider, health, snapshot, plugin-security, command-timing, and measurement evidence.
+- Hardened release publishing and run evidence contracts so invalid payloads are rejected and missing final metrics cannot be reported as healthy.
 - Hardened runtime teardown with collision-resistant local-build names, exact OCM missing-resource matching, awaited proxy shutdown, and independent cleanup stages.
 - Centralized disposable environment cleanup in Kova's lifecycle and removed stale scenario cleanup commands and unused raw selector substitutions.
 - Hardened registry and evaluation integrity for capability catalogs, workflow derivation, thresholds, and malformed harness evidence.

--- a/src/commands/publish.mjs
+++ b/src/commands/publish.mjs
@@ -126,7 +126,7 @@ export async function runPublishCommand(flags) {
   const receipt = {
     schemaVersion: WEB_PAYLOAD_SCHEMA_VERSION,
     ver: parsed.ver,
-    releaseDate: augmented.releaseDate,
+    releaseDate: parsed.releaseDate,
     sha: parsed.sha,
     passed: parsed.passed,
     input: { path: displayPath(inputPath), kind },

--- a/src/commands/publish.mjs
+++ b/src/commands/publish.mjs
@@ -28,7 +28,6 @@ import { createGunzip } from "node:zlib";
 import { extract as extractTar } from "tar-stream";
 
 import {
-  parseRelease,
   safeParseRelease,
   WEB_PAYLOAD_SCHEMA_VERSION,
 } from "../web-payload-contract.mjs";
@@ -113,24 +112,23 @@ export async function runPublishCommand(flags) {
       `kova publish: payload failed ${WEB_PAYLOAD_SCHEMA_VERSION} validation:\n${detail}`
     );
   }
-  // Re-parse to get coerced types (Date) for the receipt.
-  const parsed = parseRelease(augmented, displayPath(inputPath));
+  const parsed = validation.data;
 
-  const destPath = join(outDir, `${augmented.ver}.json`);
-  const replacing = priors.some((r) => r.id === augmented.ver);
+  const destPath = join(outDir, `${parsed.ver}.json`);
+  const replacing = priors.some((r) => r.id === parsed.ver);
 
   if (!flags.dry_run) {
     await mkdir(outDir, { recursive: true });
     await copyProjectedBundles(bundleProjection.bundles);
-    await atomicWriteJson(destPath, augmented);
+    await atomicWriteJson(destPath, parsed);
   }
 
   const receipt = {
     schemaVersion: WEB_PAYLOAD_SCHEMA_VERSION,
-    ver: augmented.ver,
+    ver: parsed.ver,
     releaseDate: augmented.releaseDate,
-    sha: augmented.sha,
-    passed: augmented.passed,
+    sha: parsed.sha,
+    passed: parsed.passed,
     input: { path: displayPath(inputPath), kind },
     destination: { path: displayPath(destPath), replacing },
     dryRun: Boolean(flags.dry_run),

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -198,7 +198,7 @@ export function evaluateRecord(record, scenario, options = {}) {
   const postReadyHealthP95Ms = health.postReadySamples?.p95Ms ?? null;
   const startupHealthFailures = health.startupSamples?.failureCount ?? 0;
   const postReadyHealthFailures = health.postReadySamples?.failureCount ?? 0;
-  const finalHealthFailures = health.final?.failureCount ?? 0;
+  const finalHealthFailures = health.final?.failureCount ?? null;
   const soakEvidence = collectSoakEvidence(allResults);
   const mcpBridgeEvidence = collectMcpBridgeEvidence(allResults);
   const cronRuntimeEvidence = collectCronRuntimeEvidence(allResults);
@@ -335,7 +335,11 @@ export function evaluateRecord(record, scenario, options = {}) {
     });
   }
 
-  if (typeof thresholds.finalHealthFailures === "number" && finalHealthFailures > thresholds.finalHealthFailures) {
+  if (
+    typeof thresholds.finalHealthFailures === "number" &&
+    typeof finalHealthFailures === "number" &&
+    finalHealthFailures > thresholds.finalHealthFailures
+  ) {
     violations.push({
       kind: "health",
       metric: "finalHealthFailures",

--- a/src/evidence-ledger.mjs
+++ b/src/evidence-ledger.mjs
@@ -1,5 +1,6 @@
 import { RECORD_STATUS } from "./statuses.mjs";
 import {
+  commandResultFailureReason,
   commandResultFailed,
   commandResultPassed
 } from "./measurement-contract.mjs";
@@ -244,10 +245,7 @@ function commandReason({ executed, result, status, blockingCommand }) {
     if (!result) {
       return `not executed because ${blockingCommand.id} in phase "${blockingCommand.phaseId}" failed: ${blockingCommand.summary} (${blockingCommand.reason})`;
     }
-    if (result?.timedOut) {
-      return "command timed out";
-    }
-    return failedCommandReason(result);
+    return commandResultFailureReason(result);
   }
   return null;
 }
@@ -261,17 +259,10 @@ function firstFailedCommandInPhase(phase, results) {
       id: result.evidenceId ?? phase.evidenceIds?.[index] ?? `command:${phase.id}:${index + 1}`,
       phaseId: phase.id,
       summary: result.evidenceSummary ?? phase.evidenceSummaries?.[index] ?? summarizeCommand(result.command),
-      reason: failedCommandReason(result)
+      reason: commandResultFailureReason(result)
     };
   }
   return null;
-}
-
-function failedCommandReason(result) {
-  if (result?.timedOut) {
-    return "command timed out";
-  }
-  return `command exited ${result?.status ?? result?.exitCode ?? "unknown"}`;
 }
 
 function summarizeEntries(entries) {

--- a/src/evidence-ledger.mjs
+++ b/src/evidence-ledger.mjs
@@ -3,6 +3,7 @@ import {
   commandResultFailed,
   commandResultPassed
 } from "./measurement-contract.mjs";
+import { validHealthSummaryFailureCount } from "./health.mjs";
 
 export const EVIDENCE_LEDGER_SCHEMA = "kova.evidenceLedger.v1";
 
@@ -65,7 +66,7 @@ export function buildEvidenceLedger(record) {
   for (const capability of record.channelCapabilityEvidence ?? []) {
     entries.push(channelCapabilityEntry(capability));
   }
-  if (Object.hasOwn(record, "finalMetrics")) {
+  if (record.status !== RECORD_STATUS.DRY_RUN && record.status !== RECORD_STATUS.SKIPPED) {
     entries.push(finalMetricsEntry(record.finalMetrics));
   }
 
@@ -165,7 +166,7 @@ function finalMetricsEvidence(metrics) {
     return { status: "missing", reason: "final service state was not collected" };
   }
   const healthSamples = Array.isArray(metrics.healthSamples) && metrics.healthSamples.length > 0;
-  const healthSummary = Number.isInteger(metrics.healthSummary?.count) && metrics.healthSummary.count > 0;
+  const healthSummary = validHealthSummaryFailureCount(metrics.healthSummary) !== null;
   const healthResult = typeof metrics.health?.ok === "boolean";
   if (!healthSamples && !healthSummary && !healthResult) {
     return { status: "missing", reason: "final health evidence was not collected" };

--- a/src/evidence-ledger.mjs
+++ b/src/evidence-ledger.mjs
@@ -4,6 +4,7 @@ import {
   commandResultPassed
 } from "./measurement-contract.mjs";
 import {
+  validGatewayState,
   validHealthSamples,
   validHealthSummaryFailureCount
 } from "./health.mjs";
@@ -168,7 +169,7 @@ function finalMetricsEvidence(metrics) {
       reason: String(metrics.error) || "final metrics collection failed"
     };
   }
-  if (typeof metrics.service?.gatewayState !== "string") {
+  if (!validGatewayState(metrics.service?.gatewayState)) {
     return { status: "missing", reason: "final service state was not collected" };
   }
   const healthSamples = validHealthSamples(metrics.healthSamples);

--- a/src/evidence-ledger.mjs
+++ b/src/evidence-ledger.mjs
@@ -159,8 +159,11 @@ function finalMetricsEvidence(metrics) {
   if (!metrics) {
     return { status: "missing", reason: "final metrics were not collected" };
   }
-  if (metrics.error) {
-    return { status: "failed", reason: String(metrics.error) };
+  if (metrics.error !== null && metrics.error !== undefined) {
+    return {
+      status: "failed",
+      reason: String(metrics.error) || "final metrics collection failed"
+    };
   }
   if (typeof metrics.service?.gatewayState !== "string") {
     return { status: "missing", reason: "final service state was not collected" };

--- a/src/evidence-ledger.mjs
+++ b/src/evidence-ledger.mjs
@@ -1,4 +1,8 @@
 import { RECORD_STATUS } from "./statuses.mjs";
+import {
+  commandResultFailed,
+  commandResultPassed
+} from "./measurement-contract.mjs";
 
 export const EVIDENCE_LEDGER_SCHEMA = "kova.evidenceLedger.v1";
 
@@ -60,6 +64,9 @@ export function buildEvidenceLedger(record) {
   }
   for (const capability of record.channelCapabilityEvidence ?? []) {
     entries.push(channelCapabilityEntry(capability));
+  }
+  if (Object.hasOwn(record, "finalMetrics")) {
+    entries.push(finalMetricsEntry(record.finalMetrics));
   }
 
   return {
@@ -132,12 +139,49 @@ function invariantEntry(invariant) {
   };
 }
 
+function finalMetricsEntry(metrics) {
+  const evidence = finalMetricsEvidence(metrics);
+  return {
+    id: "collector:final-metrics",
+    category: "collector",
+    required: true,
+    status: evidence.status,
+    phaseId: "final",
+    commandIndex: null,
+    summary: "final service and health metrics were collected",
+    artifactPath: null,
+    reason: evidence.reason
+  };
+}
+
+function finalMetricsEvidence(metrics) {
+  if (!metrics) {
+    return { status: "missing", reason: "final metrics were not collected" };
+  }
+  if (metrics.error) {
+    return { status: "failed", reason: String(metrics.error) };
+  }
+  if (typeof metrics.service?.gatewayState !== "string") {
+    return { status: "missing", reason: "final service state was not collected" };
+  }
+  const healthSamples = Array.isArray(metrics.healthSamples) && metrics.healthSamples.length > 0;
+  const healthSummary = Number.isInteger(metrics.healthSummary?.count) && metrics.healthSummary.count > 0;
+  const healthResult = typeof metrics.health?.ok === "boolean";
+  if (!healthSamples && !healthSummary && !healthResult) {
+    return { status: "missing", reason: "final health evidence was not collected" };
+  }
+  return { status: "passed", reason: null };
+}
+
 function isBehaviorFailureCategory(category) {
   return category === "command" || category === "invariant" || category === "channel-capability";
 }
 
 function completenessForEntries(entries) {
-  return entries.some((entry) => entry.required && entry.status === "missing")
+  return entries.some((entry) =>
+    entry.required &&
+    (entry.status === "missing" || (entry.status === "failed" && !isBehaviorFailureCategory(entry.category)))
+  )
     ? "incomplete"
     : "complete";
 }
@@ -173,7 +217,10 @@ function commandStatus({ executed, result, blockingCommand }) {
   if (result.evidenceStatus) {
     return result.evidenceStatus;
   }
-  return result.status === 0 ? "passed" : "failed";
+  if (commandResultPassed(result)) {
+    return "passed";
+  }
+  return commandResultFailed(result) ? "failed" : "missing";
 }
 
 function commandReason({ executed, result, status, blockingCommand }) {
@@ -181,7 +228,9 @@ function commandReason({ executed, result, status, blockingCommand }) {
     return "dry-run command was planned but not executed";
   }
   if (status === "missing") {
-    return "command was planned but no result was recorded";
+    return result
+      ? "command result did not contain passing or failing evidence"
+      : "command was planned but no result was recorded";
   }
   if (status === "failed") {
     if (!result) {
@@ -190,7 +239,7 @@ function commandReason({ executed, result, status, blockingCommand }) {
     if (result?.timedOut) {
       return "command timed out";
     }
-    return `command exited ${result?.status ?? "unknown"}`;
+    return failedCommandReason(result);
   }
   return null;
 }
@@ -210,15 +259,11 @@ function firstFailedCommandInPhase(phase, results) {
   return null;
 }
 
-function commandResultFailed(result) {
-  return result && result.evidenceStatus !== "passed" && result.status !== 0;
-}
-
 function failedCommandReason(result) {
   if (result?.timedOut) {
     return "command timed out";
   }
-  return `command exited ${result?.status ?? "unknown"}`;
+  return `command exited ${result?.status ?? result?.exitCode ?? "unknown"}`;
 }
 
 function summarizeEntries(entries) {

--- a/src/evidence-ledger.mjs
+++ b/src/evidence-ledger.mjs
@@ -3,7 +3,10 @@ import {
   commandResultFailed,
   commandResultPassed
 } from "./measurement-contract.mjs";
-import { validHealthSummaryFailureCount } from "./health.mjs";
+import {
+  validHealthSamples,
+  validHealthSummaryFailureCount
+} from "./health.mjs";
 
 export const EVIDENCE_LEDGER_SCHEMA = "kova.evidenceLedger.v1";
 
@@ -168,7 +171,7 @@ function finalMetricsEvidence(metrics) {
   if (typeof metrics.service?.gatewayState !== "string") {
     return { status: "missing", reason: "final service state was not collected" };
   }
-  const healthSamples = Array.isArray(metrics.healthSamples) && metrics.healthSamples.length > 0;
+  const healthSamples = validHealthSamples(metrics.healthSamples);
   const healthSummary = validHealthSummaryFailureCount(metrics.healthSummary) !== null;
   const healthResult = typeof metrics.health?.ok === "boolean";
   if (!healthSamples && !healthSummary && !healthResult) {

--- a/src/evidence/shared.mjs
+++ b/src/evidence/shared.mjs
@@ -1,4 +1,8 @@
 import { collectRecordMetricObjects } from "./metrics.mjs";
+import {
+  commandResultFailed,
+  commandResultPassed
+} from "../measurement-contract.mjs";
 
 export function phaseCommandReceiptsOk(record) {
   return (record.phases ?? []).every((phase) => {
@@ -8,7 +12,7 @@ export function phaseCommandReceiptsOk(record) {
     }
     return Array.from({ length: commandCount }).every((_, index) => {
       const result = phase.results?.[index];
-      return (result?.status === 0 || result?.evidenceStatus === "passed") && result.durationMs !== undefined;
+      return commandResultPassed(result) && result.durationMs !== undefined;
     });
   });
 }
@@ -20,8 +24,8 @@ export function phaseCommandReceiptsReason(record) {
       if (!result) {
         return `${phase.id} command ${index + 1} receipt was not captured`;
       }
-      if (result.status !== 0 && result.evidenceStatus !== "passed") {
-        return `${phase.id} command ${index + 1} exited ${result.status}`;
+      if (commandResultFailed(result)) {
+        return `${phase.id} command ${index + 1} exited ${result.status ?? result.exitCode ?? "unknown"}`;
       }
       if (result.durationMs === undefined) {
         return `${phase.id} command ${index + 1} duration was not captured`;
@@ -391,7 +395,7 @@ export function findPhase(record, phaseId) {
 
 export function commandReceiptOk(record, predicate) {
   const result = findCommandResult(record, predicate);
-  return result?.status === 0 && result.durationMs !== undefined;
+  return commandResultPassed(result) && result.durationMs !== undefined;
 }
 
 export function commandReceiptReason(record, predicate) {
@@ -399,8 +403,8 @@ export function commandReceiptReason(record, predicate) {
   if (!result) {
     return "command receipt was not captured";
   }
-  if (result.status !== 0) {
-    return `command exited ${result.status}`;
+  if (commandResultFailed(result)) {
+    return `command exited ${result.status ?? result.exitCode ?? "unknown"}`;
   }
   if (result.durationMs === undefined) {
     return "command duration was not captured";

--- a/src/evidence/shared.mjs
+++ b/src/evidence/shared.mjs
@@ -1,5 +1,6 @@
 import { collectRecordMetricObjects } from "./metrics.mjs";
 import {
+  commandResultFailureReason,
   commandResultFailed,
   commandResultPassed
 } from "../measurement-contract.mjs";
@@ -25,7 +26,7 @@ export function phaseCommandReceiptsReason(record) {
         return `${phase.id} command ${index + 1} receipt was not captured`;
       }
       if (commandResultFailed(result)) {
-        return `${phase.id} command ${index + 1} exited ${result.status ?? result.exitCode ?? "unknown"}`;
+        return `${phase.id} command ${index + 1}: ${commandResultFailureReason(result)}`;
       }
       if (!commandResultPassed(result)) {
         return `${phase.id} command ${index + 1} result status was not captured`;
@@ -407,7 +408,7 @@ export function commandReceiptReason(record, predicate) {
     return "command receipt was not captured";
   }
   if (commandResultFailed(result)) {
-    return `command exited ${result.status ?? result.exitCode ?? "unknown"}`;
+    return commandResultFailureReason(result);
   }
   if (!commandResultPassed(result)) {
     return "command result status was not captured";
@@ -455,15 +456,18 @@ export function commandProofInPhase(label, phaseId, predicate) {
     label,
     (record) => {
       const result = findCommandResultInPhase(record, phaseId, predicate);
-      return result?.status === 0 && nonNegativeNumber(result.durationMs);
+      return commandResultPassed(result) && nonNegativeNumber(result.durationMs);
     },
     (record) => {
       const result = findCommandResultInPhase(record, phaseId, predicate);
       if (!result) {
         return `command receipt was not captured in ${phaseId}`;
       }
-      if (result.status !== 0) {
-        return `command exited ${result.status}`;
+      if (commandResultFailed(result)) {
+        return commandResultFailureReason(result);
+      }
+      if (!commandResultPassed(result)) {
+        return "command result status was not captured";
       }
       if (!nonNegativeNumber(result.durationMs)) {
         return "command duration was not a non-negative finite measurement";

--- a/src/evidence/shared.mjs
+++ b/src/evidence/shared.mjs
@@ -27,6 +27,9 @@ export function phaseCommandReceiptsReason(record) {
       if (commandResultFailed(result)) {
         return `${phase.id} command ${index + 1} exited ${result.status ?? result.exitCode ?? "unknown"}`;
       }
+      if (!commandResultPassed(result)) {
+        return `${phase.id} command ${index + 1} result status was not captured`;
+      }
       if (result.durationMs === undefined) {
         return `${phase.id} command ${index + 1} duration was not captured`;
       }
@@ -405,6 +408,9 @@ export function commandReceiptReason(record, predicate) {
   }
   if (commandResultFailed(result)) {
     return `command exited ${result.status ?? result.exitCode ?? "unknown"}`;
+  }
+  if (!commandResultPassed(result)) {
+    return "command result status was not captured";
   }
   if (result.durationMs === undefined) {
     return "command duration was not captured";

--- a/src/evidence/upgrade-existing-user.mjs
+++ b/src/evidence/upgrade-existing-user.mjs
@@ -70,6 +70,9 @@ function doctorOutputStatus(result) {
   if (commandResultFailed(result)) {
     return "failed";
   }
+  if (!commandResultPassed(result)) {
+    return "missing";
+  }
   const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
   return output.length > 0 ? "passed" : "missing";
 }
@@ -80,6 +83,9 @@ function doctorOutputReason(result) {
   }
   if (commandResultFailed(result)) {
     return `doctor command exited ${result.status ?? result.exitCode ?? "unknown"}`;
+  }
+  if (!commandResultPassed(result)) {
+    return "doctor command result status was not recorded";
   }
   const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
   return output.length > 0 ? null : "doctor command produced no captured output";
@@ -223,7 +229,7 @@ function failedCommandBeforeOrInPhase(record, phaseId) {
       break;
     }
     for (const [resultIndex, result] of (phase.results ?? []).entries()) {
-      if (!result || commandResultPassed(result)) {
+      if (!result || !commandResultFailed(result)) {
         continue;
       }
       const command = result.command ?? phase.commands?.[resultIndex] ?? "unknown command";

--- a/src/evidence/upgrade-existing-user.mjs
+++ b/src/evidence/upgrade-existing-user.mjs
@@ -11,6 +11,10 @@ import {
   unionStrings,
   zeroCountInvariant
 } from "./shared.mjs";
+import {
+  commandResultFailed,
+  commandResultPassed
+} from "../measurement-contract.mjs";
 
 export function buildUpgradeLogDerivedInvariants(record) {
   if (record.status === "DRY-RUN" || record.status === "SKIPPED") {
@@ -63,7 +67,7 @@ function doctorOutputStatus(result) {
   if (!result) {
     return "missing";
   }
-  if (result.status !== 0) {
+  if (commandResultFailed(result)) {
     return "failed";
   }
   const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
@@ -74,8 +78,8 @@ function doctorOutputReason(result) {
   if (!result) {
     return "doctor command result was not recorded";
   }
-  if (result.status !== 0) {
-    return `doctor command exited ${result.status}`;
+  if (commandResultFailed(result)) {
+    return `doctor command exited ${result.status ?? result.exitCode ?? "unknown"}`;
   }
   const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
   return output.length > 0 ? null : "doctor command produced no captured output";
@@ -219,7 +223,7 @@ function failedCommandBeforeOrInPhase(record, phaseId) {
       break;
     }
     for (const [resultIndex, result] of (phase.results ?? []).entries()) {
-      if (!result || result.evidenceStatus === "passed" || result.status === 0) {
+      if (!result || commandResultPassed(result)) {
         continue;
       }
       const command = result.command ?? phase.commands?.[resultIndex] ?? "unknown command";
@@ -240,5 +244,7 @@ function shortCommand(command) {
 }
 
 function failedResultLabel(result) {
-  return result?.timedOut ? "command timed out" : `command exited ${result?.status ?? "unknown"}`;
+  return result?.timedOut
+    ? "command timed out"
+    : `command exited ${result?.status ?? result?.exitCode ?? "unknown"}`;
 }

--- a/src/evidence/upgrade-existing-user.mjs
+++ b/src/evidence/upgrade-existing-user.mjs
@@ -12,6 +12,7 @@ import {
   zeroCountInvariant
 } from "./shared.mjs";
 import {
+  commandResultFailureReason,
   commandResultFailed,
   commandResultPassed
 } from "../measurement-contract.mjs";
@@ -82,7 +83,7 @@ function doctorOutputReason(result) {
     return "doctor command result was not recorded";
   }
   if (commandResultFailed(result)) {
-    return `doctor command exited ${result.status ?? result.exitCode ?? "unknown"}`;
+    return commandResultFailureReason(result, "doctor command");
   }
   if (!commandResultPassed(result)) {
     return "doctor command result status was not recorded";
@@ -250,7 +251,5 @@ function shortCommand(command) {
 }
 
 function failedResultLabel(result) {
-  return result?.timedOut
-    ? "command timed out"
-    : `command exited ${result?.status ?? result?.exitCode ?? "unknown"}`;
+  return commandResultFailureReason(result);
 }

--- a/src/health.mjs
+++ b/src/health.mjs
@@ -76,9 +76,18 @@ export function healthTotalFailures(health) {
     health?.unknownSamples?.failureCount,
     health?.final?.failureCount
   ];
-  return counts.every(validFailureCount)
-    ? counts.reduce((total, count) => total + count, 0)
-    : null;
+  return counts
+    .filter(validFailureCount)
+    .reduce((total, count) => total + count, 0);
+}
+
+export function healthTotalFailuresComplete(health) {
+  return [
+    health?.startupSamples?.failureCount,
+    health?.postReadySamples?.failureCount,
+    health?.unknownSamples?.failureCount,
+    health?.final?.failureCount
+  ].every(validFailureCount);
 }
 
 export function validHealthSummaryFailureCount(summary) {

--- a/src/health.mjs
+++ b/src/health.mjs
@@ -124,6 +124,10 @@ export function validHealthSamples(samples) {
     );
 }
 
+export function validGatewayState(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 export function measurementMetricValue(measurements, metric) {
   if (!measurements) {
     return null;
@@ -331,9 +335,9 @@ function summarizeFinalHealth(metrics) {
   const evidenceComplete = metrics !== null &&
     metrics !== undefined &&
     collectionError == null &&
-    typeof gatewayState === "string" &&
+    validGatewayState(gatewayState) &&
     measuredFailureCount !== null;
-  const failureCount = evidenceComplete ? measuredFailureCount : null;
+  const failureCount = measuredFailureCount;
   const maxMs = summary?.maxMs ?? metrics?.healthSummary?.maxMs ?? metrics?.health?.durationMs ?? null;
   const p95Ms = summary?.p95Ms ?? metrics?.healthSummary?.p95Ms ?? null;
   const ok = evidenceComplete ? gatewayState === "running" && failureCount === 0 : null;

--- a/src/health.mjs
+++ b/src/health.mjs
@@ -76,18 +76,24 @@ export function healthTotalFailures(health) {
     health?.unknownSamples?.failureCount,
     health?.final?.failureCount
   ];
-  return counts
-    .filter(validFailureCount)
-    .reduce((total, count) => total + count, 0);
+  return counts.every(validFailureCount)
+    ? counts.reduce((total, count) => total + count, 0)
+    : null;
 }
 
-export function healthTotalFailuresComplete(health) {
+export function healthKnownFailures(health) {
   return [
     health?.startupSamples?.failureCount,
     health?.postReadySamples?.failureCount,
     health?.unknownSamples?.failureCount,
     health?.final?.failureCount
-  ].every(validFailureCount);
+  ]
+    .filter(validFailureCount)
+    .reduce((total, count) => total + count, 0);
+}
+
+export function healthTotalFailuresComplete(health) {
+  return healthTotalFailures(health) !== null;
 }
 
 export function validHealthSummaryFailureCount(summary) {

--- a/src/health.mjs
+++ b/src/health.mjs
@@ -96,6 +96,19 @@ export function validHealthSummaryFailureCount(summary) {
   return failureCount;
 }
 
+export function validHealthSamples(samples) {
+  return Array.isArray(samples) &&
+    samples.length > 0 &&
+    samples.every((sample) =>
+      sample !== null &&
+      typeof sample === "object" &&
+      typeof sample.ok === "boolean" &&
+      typeof sample.durationMs === "number" &&
+      Number.isFinite(sample.durationMs) &&
+      sample.durationMs >= 0
+    );
+}
+
 export function measurementMetricValue(measurements, metric) {
   if (!measurements) {
     return null;
@@ -289,7 +302,7 @@ function emptyHealthSummary(scope) {
 }
 
 function summarizeFinalHealth(metrics) {
-  const samples = Array.isArray(metrics?.healthSamples) ? metrics.healthSamples : [];
+  const samples = validHealthSamples(metrics?.healthSamples) ? metrics.healthSamples : [];
   const summary = samples.length > 0 ? summarizeSamples(samples.map((sample) => ({ ...sample, phaseId: "final" })), "final") : null;
   const singleSampleFailureCount = typeof metrics?.health?.ok === "boolean"
     ? healthFailureCount([metrics.health])

--- a/src/health.mjs
+++ b/src/health.mjs
@@ -282,17 +282,25 @@ function summarizeFinalHealth(metrics) {
   const singleSampleFailureCount = typeof metrics?.health?.ok === "boolean"
     ? healthFailureCount([metrics.health])
     : null;
-  const failureCount = summary?.failureCount ?? healthSummaryFailureCount ?? singleSampleFailureCount;
+  const measuredFailureCount = summary?.failureCount ??
+    healthSummaryFailureCount ??
+    singleSampleFailureCount;
+  const collectionError = metrics?.error ?? null;
+  const gatewayState = metrics?.service?.gatewayState ?? null;
+  const evidenceComplete = metrics !== null &&
+    metrics !== undefined &&
+    collectionError == null &&
+    typeof gatewayState === "string" &&
+    measuredFailureCount !== null;
+  const failureCount = evidenceComplete ? measuredFailureCount : null;
   const maxMs = summary?.maxMs ?? metrics?.healthSummary?.maxMs ?? metrics?.health?.durationMs ?? null;
   const p95Ms = summary?.p95Ms ?? metrics?.healthSummary?.p95Ms ?? null;
-  const gatewayState = metrics?.service?.gatewayState ?? null;
-  const ok = Number.isFinite(failureCount)
-    ? (gatewayState === null ? failureCount === 0 : gatewayState === "running" && failureCount === 0)
-    : null;
+  const ok = evidenceComplete ? gatewayState === "running" && failureCount === 0 : null;
   return {
     scope: "final",
     gatewayState,
     ok,
+    collectionError: collectionError ?? null,
     healthOk: metrics?.health?.ok ?? null,
     failureCount,
     p95Ms,

--- a/src/health.mjs
+++ b/src/health.mjs
@@ -81,6 +81,21 @@ export function healthTotalFailures(health) {
     : null;
 }
 
+export function validHealthSummaryFailureCount(summary) {
+  const count = summary?.count;
+  const failureCount = summary?.failureCount;
+  if (
+    !Number.isInteger(count) ||
+    count <= 0 ||
+    !Number.isInteger(failureCount) ||
+    failureCount < 0 ||
+    failureCount > count
+  ) {
+    return null;
+  }
+  return failureCount;
+}
+
 export function measurementMetricValue(measurements, metric) {
   if (!measurements) {
     return null;
@@ -276,14 +291,12 @@ function emptyHealthSummary(scope) {
 function summarizeFinalHealth(metrics) {
   const samples = Array.isArray(metrics?.healthSamples) ? metrics.healthSamples : [];
   const summary = samples.length > 0 ? summarizeSamples(samples.map((sample) => ({ ...sample, phaseId: "final" })), "final") : null;
-  const healthSummaryFailureCount = validFailureCount(metrics?.healthSummary?.failureCount)
-    ? metrics.healthSummary.failureCount
-    : null;
   const singleSampleFailureCount = typeof metrics?.health?.ok === "boolean"
     ? healthFailureCount([metrics.health])
     : null;
+  const aggregateFailureCount = validHealthSummaryFailureCount(metrics?.healthSummary);
   const measuredFailureCount = summary?.failureCount ??
-    healthSummaryFailureCount ??
+    aggregateFailureCount ??
     singleSampleFailureCount;
   const collectionError = metrics?.error ?? null;
   const gatewayState = metrics?.service?.gatewayState ?? null;

--- a/src/measurement-contract.mjs
+++ b/src/measurement-contract.mjs
@@ -70,6 +70,21 @@ export function commandResultFailed(result) {
   return status === "FAIL" || status === "FAILED" || status === "ERROR";
 }
 
+export function commandResultFailureReason(result, subject = "command") {
+  if (result?.timedOut === true) {
+    return `${subject} timed out`;
+  }
+  if (result?.evidenceStatus === "failed") {
+    const evidenceReason = typeof result.evidenceReason === "string"
+      ? result.evidenceReason.trim()
+      : "";
+    return evidenceReason.length > 0
+      ? `${subject} evidence failed: ${evidenceReason}`
+      : `${subject} evidence failed`;
+  }
+  return `${subject} exited ${result?.status ?? result?.exitCode ?? "unknown"}`;
+}
+
 export function readinessThresholdForPhase(scenario, phase) {
   const thresholds = scenario?.thresholds ?? {};
   const defaultMs = thresholds.gatewayReadyMs ?? 30000;

--- a/src/measurement-contract.mjs
+++ b/src/measurement-contract.mjs
@@ -38,6 +38,8 @@ export function commandResultPassed(result) {
   if (!result) {
     return false;
   }
+  // Evidence-producing helpers own the result when they emit a status.
+  // Command exit fields are only the fallback for ordinary process results.
   if (typeof result.evidenceStatus === "string") {
     return result.evidenceStatus === "passed";
   }
@@ -52,8 +54,8 @@ export function commandResultFailed(result) {
   if (!result) {
     return false;
   }
-  if (commandResultPassed(result)) {
-    return false;
+  if (typeof result.evidenceStatus === "string") {
+    return result.evidenceStatus === "failed";
   }
   if (result.timedOut === true) {
     return true;

--- a/src/reporting/report.mjs
+++ b/src/reporting/report.mjs
@@ -1,7 +1,11 @@
 import { summarizeAgentTurnBreakdownForMarkdown } from "../collectors/agent-turns.mjs";
 import { agentCliPreProviderMarkdownRows } from "../collectors/agent-cli-attribution.mjs";
 import { gatewaySessionPreProviderMarkdownRows } from "../collectors/gateway-session-turn-attribution.mjs";
-import { healthTotalFailures, measurementMetricValue } from "../health.mjs";
+import {
+  healthTotalFailures,
+  healthTotalFailuresComplete,
+  measurementMetricValue
+} from "../health.mjs";
 import { RECORD_STATUS, findingSeverityForStatus } from "../statuses.mjs";
 import { firstFailedCommand, summarizeFailureReason } from "./failures.mjs";
 import { summarizeRecords } from "./records.mjs";
@@ -1741,6 +1745,9 @@ function compactRolePeaks(measurements) {
 function pushMeasurementBrief(lines, measurements, { compact }) {
   const readiness = measurements.health?.readiness ?? null;
   const totalHealthFailures = measurements.health ? healthTotalFailures(measurements.health) : null;
+  const totalHealthFailuresComplete = measurements.health
+    ? healthTotalFailuresComplete(measurements.health)
+    : false;
   const readinessReason = readiness?.reason ?? null;
   const readinessNotApplicable = readiness?.classification === "not-applicable";
   const noProcessSamples = !hasValue(measurements.resourceSampleCount);
@@ -1748,7 +1755,10 @@ function pushMeasurementBrief(lines, measurements, { compact }) {
   lines.push(`- startup: listening ${valueMs(readiness?.listeningReadyAtMs, readinessNotApplicable ? "n/a" : "unknown")}; health ${valueMs(readiness?.healthReadyAtMs, readinessNotApplicable ? "n/a" : "unknown")}; readiness ${readiness?.classification ?? "unknown"}${readinessReason ? ` (${readinessReason})` : ""}; gateway ${measurements.finalGatewayState ?? "unknown"}; restarts ${measurements.gatewayRestartCount ?? (readinessNotApplicable ? "n/a" : "unknown")}`);
   if (measurements.health) {
     const healthFallback = readinessNotApplicable ? "n/a" : "not-collected";
-    lines.push(`- health: startup p95 ${valueMs(measurements.health.startupSamples?.p95Ms, healthFallback)}; post-ready p95 ${valueMs(measurements.health.postReadySamples?.p95Ms, healthFallback)}; failures ${totalHealthFailures ?? healthFallback}; final failures ${measurements.health.final?.failureCount ?? healthFallback}${healthSlowestText(measurements)}`);
+    const totalFailuresText = totalHealthFailuresComplete
+      ? String(totalHealthFailures)
+      : `at least ${totalHealthFailures}`;
+    lines.push(`- health: startup p95 ${valueMs(measurements.health.startupSamples?.p95Ms, healthFallback)}; post-ready p95 ${valueMs(measurements.health.postReadySamples?.p95Ms, healthFallback)}; failures ${totalFailuresText}; final failures ${measurements.health.final?.failureCount ?? healthFallback}${healthSlowestText(measurements)}`);
   } else {
     lines.push(`- health: n/a${readinessReason ? ` (${readinessReason})` : ""}`);
   }

--- a/src/reporting/report.mjs
+++ b/src/reporting/report.mjs
@@ -2,6 +2,7 @@ import { summarizeAgentTurnBreakdownForMarkdown } from "../collectors/agent-turn
 import { agentCliPreProviderMarkdownRows } from "../collectors/agent-cli-attribution.mjs";
 import { gatewaySessionPreProviderMarkdownRows } from "../collectors/gateway-session-turn-attribution.mjs";
 import {
+  healthKnownFailures,
   healthTotalFailures,
   healthTotalFailuresComplete,
   measurementMetricValue
@@ -1745,6 +1746,7 @@ function compactRolePeaks(measurements) {
 function pushMeasurementBrief(lines, measurements, { compact }) {
   const readiness = measurements.health?.readiness ?? null;
   const totalHealthFailures = measurements.health ? healthTotalFailures(measurements.health) : null;
+  const knownHealthFailures = measurements.health ? healthKnownFailures(measurements.health) : null;
   const totalHealthFailuresComplete = measurements.health
     ? healthTotalFailuresComplete(measurements.health)
     : false;
@@ -1757,7 +1759,7 @@ function pushMeasurementBrief(lines, measurements, { compact }) {
     const healthFallback = readinessNotApplicable ? "n/a" : "not-collected";
     const totalFailuresText = totalHealthFailuresComplete
       ? String(totalHealthFailures)
-      : `at least ${totalHealthFailures}`;
+      : `at least ${knownHealthFailures}`;
     lines.push(`- health: startup p95 ${valueMs(measurements.health.startupSamples?.p95Ms, healthFallback)}; post-ready p95 ${valueMs(measurements.health.postReadySamples?.p95Ms, healthFallback)}; failures ${totalFailuresText}; final failures ${measurements.health.final?.failureCount ?? healthFallback}${healthSlowestText(measurements)}`);
   } else {
     lines.push(`- health: n/a${readinessReason ? ` (${readinessReason})` : ""}`);

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -16,7 +16,7 @@ import { summarizeCpuProfiles } from "./collectors/node-profiles.mjs";
 import { summarizeHeapProfiles } from "./collectors/heap.mjs";
 import { collectEnvMetrics } from "./metrics.mjs";
 import { compactEvaluatedTimelineEvidence, evaluateRecord } from "./evaluator.mjs";
-import { healthTotalFailures } from "./health.mjs";
+import { buildHealthMeasurement, healthTotalFailures } from "./health.mjs";
 import { evaluateWorkflowCase } from "../support/channel-conformance/evaluator.mjs";
 import { assertValidObservationSet } from "../support/channel-conformance/observation-schema.mjs";
 import { planWorkflowCases } from "../support/channel-conformance/planner.mjs";
@@ -71,7 +71,10 @@ import { isMissingOcmResource } from "./ocm/missing-resource.mjs";
 import { assertSafeScenarioCommand, assertSingleTopLevelShellCommand } from "./safety.mjs";
 import { resolveTarget } from "./targets.mjs";
 import {
+  commandResultFailed,
+  commandResultPassed,
   measurementScopeForPhase,
+  phaseResultStatus,
   readinessThresholdForPhase,
   tagCommandResult
 } from "./measurement-contract.mjs";
@@ -82,6 +85,7 @@ import {
   triggerDiagnosticSession,
   triggerHeapSnapshot
 } from "./collectors/diagnostics.mjs";
+import { safeParseRelease } from "./web-payload-contract.mjs";
 import { assertNetworkFrontageCommandSafe, networkFrontageCommandEnv, stopNetworkFrontage, waitForProxyReady, waitForTcp } from "./network-frontage.mjs";
 import { resolveGatewayEndpoint } from "../support/gateway-endpoint.mjs";
 import {
@@ -228,6 +232,8 @@ async function runScopedSelfCheck(flags, scope, workspace) {
   const tmp = workspace.root;
 
   checks.push(await syntaxCheck());
+  checks.push(await webPayloadContractCheck(tmp));
+  checks.push(commandResultContractCheck());
     checks.push(await jsonCommandCheck("version-json", "node bin/kova.mjs version --json", (data) => {
       assertEqual(data.schemaVersion, "kova.version.v1", "version schema");
       assertString(data.version, "version");
@@ -2987,6 +2993,32 @@ function evidenceLedgerGatingCheck() {
     applyEvidenceLedgerGating(failedRecord);
     assertEqual(failedRecord.status, "FAIL", "failed required ledger entry gates pass");
 
+    const failedMetricsRecord = {
+      ...record,
+      status: "PASS",
+      incompleteReason: undefined,
+      incompleteEvidence: undefined,
+      phases: [],
+      finalMetrics: {
+        error: "service status unavailable",
+        service: null,
+        health: null,
+        healthSamples: []
+      }
+    };
+    const health = buildHealthMeasurement(failedMetricsRecord);
+    assertEqual(health.final.ok, null, "failed final metrics health is unknown");
+    assertEqual(health.final.failureCount, null, "failed final metrics do not report zero failures");
+    attachEvidenceLedger(failedMetricsRecord);
+    applyEvidenceLedgerGating(failedMetricsRecord);
+    assertEqual(failedMetricsRecord.status, "INCOMPLETE", "failed final metrics gate pass as incomplete");
+    assertEqual(failedMetricsRecord.evidenceLedger.completeness, "incomplete", "failed final metrics mark ledger incomplete");
+    assertEqual(
+      failedMetricsRecord.evidenceLedger.entries.find((entry) => entry.id === "collector:final-metrics")?.status,
+      "failed",
+      "failed final metrics ledger status"
+    );
+
     const failedPhaseRecord = {
       ...record,
       status: "FAIL",
@@ -3175,6 +3207,133 @@ function evidenceLedgerGatingCheck() {
       id: "evidence-ledger-gating",
       status: "FAIL",
       command: "evaluate evidence ledger status gating",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function webPayloadContractCheck(tmp) {
+  const inputPath = join(tmp, "web-payload-input.json");
+  const outDir = join(tmp, "web-payload-output");
+  const payload = {
+    ver: "2026.7.12-self-check",
+    releaseDate: "2026-07-12",
+    date: "2026-07-12",
+    sha: "self-check",
+    passed: true,
+    runCount: 1,
+    coldReadyDeltaPct: -12.5,
+    scenarios: [{
+      id: "release-runtime-startup",
+      value: -1,
+      unit: "ms",
+      threshold: 1000.5,
+      state: "pass",
+      spark: [-2, 0, 2]
+    }],
+    runs: [{
+      id: "self-check-run",
+      runtime: "npm:2026.7.12",
+      profile: "release",
+      startedAt: "2026-07-12T01:02:03Z",
+      durationMs: 0,
+      entryCount: 0,
+      state: "pass",
+      scenarios: [{
+        id: "release-runtime-startup",
+        state: "pass",
+        sampleCount: 0
+      }],
+      bundle: {
+        name: "self-check.tar.gz",
+        bytes: 0,
+        href: "/bundles/self-check.tar.gz"
+      }
+    }]
+  };
+
+  assertEqual(safeParseRelease(payload).ok, true, "valid web payload");
+  assertEqual(
+    safeParseRelease({ ...payload, coldReadyDeltaPercent: payload.coldReadyDeltaPct }).ok,
+    false,
+    "unknown web payload field rejected"
+  );
+  assertEqual(
+    safeParseRelease({
+      ...payload,
+      runs: [{ ...payload.runs[0], durationMs: -1 }]
+    }).ok,
+    false,
+    "negative duration rejected"
+  );
+  assertEqual(
+    safeParseRelease({
+      ...payload,
+      runs: [{ ...payload.runs[0], entryCount: 1.5 }]
+    }).ok,
+    false,
+    "fractional count rejected"
+  );
+  assertEqual(
+    safeParseRelease({
+      ...payload,
+      scenarios: [{ ...payload.scenarios[0], threshold: -1 }]
+    }).ok,
+    false,
+    "negative threshold rejected"
+  );
+
+  await writeFile(inputPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  const result = await runCommand(
+    `node bin/kova.mjs publish ${quoteShell(inputPath)} --out-dir ${quoteShell(outDir)} --no-augment --json`,
+    { timeoutMs: 30000, maxOutputChars: 1000000 }
+  );
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || result.stdout.trim() || `publish exited ${result.status}`);
+  }
+  const published = JSON.parse(await readFile(join(outDir, `${payload.ver}.json`), "utf8"));
+  assertEqual(published.releaseDate, "2026-07-12T00:00:00.000Z", "publish writes canonical release date");
+  assertEqual(published.runs[0].startedAt, "2026-07-12T01:02:03.000Z", "publish writes canonical run date");
+  return {
+    id: "web-payload-contract",
+    status: "PASS",
+    command: "validate and publish canonical web payload",
+    durationMs: result.durationMs
+  };
+}
+
+function commandResultContractCheck() {
+  try {
+    assertEqual(commandResultPassed({ exitCode: 0 }), true, "exitCode zero passes");
+    assertEqual(commandResultFailed({ exitCode: 2 }), true, "nonzero exitCode fails");
+    assertEqual(
+      commandResultFailed({ evidenceStatus: "failed", status: 0 }),
+      true,
+      "failed evidence overrides zero command status"
+    );
+    assertEqual(
+      commandResultPassed({ evidenceStatus: "missing", status: 0 }),
+      false,
+      "missing evidence does not pass"
+    );
+    assertEqual(
+      commandResultFailed({ evidenceStatus: "missing", status: 0 }),
+      false,
+      "missing evidence is incomplete rather than failed"
+    );
+    assertEqual(phaseResultStatus([{ exitCode: 0 }]), "success", "phase accepts exitCode result");
+    return {
+      id: "command-result-contract",
+      status: "PASS",
+      command: "evaluate shared command result classification",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "command-result-contract",
+      status: "FAIL",
+      command: "evaluate shared command result classification",
       durationMs: 0,
       message: error.message
     };

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -18,6 +18,7 @@ import { collectEnvMetrics } from "./metrics.mjs";
 import { compactEvaluatedTimelineEvidence, evaluateRecord } from "./evaluator.mjs";
 import {
   buildHealthMeasurement,
+  healthKnownFailures,
   healthTotalFailures,
   healthTotalFailuresComplete
 } from "./health.mjs";
@@ -3037,7 +3038,8 @@ function evidenceLedgerGatingCheck() {
     const health = buildHealthMeasurement(failedMetricsRecord);
     assertEqual(health.final.ok, null, "failed final metrics health is unknown");
     assertEqual(health.final.failureCount, null, "failed final metrics do not report zero failures");
-    assertEqual(healthTotalFailures(health), 0, "missing final metrics retain known health failure lower bound");
+    assertEqual(healthTotalFailures(health), null, "missing final metrics keep exact health failure total unknown");
+    assertEqual(healthKnownFailures(health), 0, "missing final metrics retain known health failure lower bound");
     assertEqual(healthTotalFailuresComplete(health), false, "missing final metrics mark health total incomplete");
     attachEvidenceLedger(failedMetricsRecord);
     applyEvidenceLedgerGating(failedMetricsRecord);
@@ -3117,7 +3119,8 @@ function evidenceLedgerGatingCheck() {
       }]
     };
     const knownFailureHealth = buildHealthMeasurement(knownFailureRecord);
-    assertEqual(healthTotalFailures(knownFailureHealth), 1, "missing final metrics retain observed health failures");
+    assertEqual(healthTotalFailures(knownFailureHealth), null, "observed failures do not fabricate an exact total");
+    assertEqual(healthKnownFailures(knownFailureHealth), 1, "missing final metrics retain observed health failures");
     assertEqual(healthTotalFailuresComplete(knownFailureHealth), false, "observed lower bound remains incomplete");
 
     const failedPhaseRecord = {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -2965,6 +2965,13 @@ function evidenceLedgerGatingCheck() {
           durationMs: 20
         }]
       }],
+      finalMetrics: {
+        error: null,
+        service: { gatewayState: "running" },
+        health: { ok: true, durationMs: 5 },
+        healthSamples: [{ ok: true, durationMs: 5 }],
+        healthSummary: { count: 1, failureCount: 0 }
+      },
       measurements: {}
     };
     attachEvidenceLedger(record);
@@ -2993,6 +3000,23 @@ function evidenceLedgerGatingCheck() {
     applyEvidenceLedgerGating(failedRecord);
     assertEqual(failedRecord.status, "FAIL", "failed required ledger entry gates pass");
 
+    const missingMetricsRecord = {
+      ...record,
+      status: "PASS",
+      incompleteReason: undefined,
+      incompleteEvidence: undefined,
+      phases: []
+    };
+    delete missingMetricsRecord.finalMetrics;
+    attachEvidenceLedger(missingMetricsRecord);
+    applyEvidenceLedgerGating(missingMetricsRecord);
+    assertEqual(missingMetricsRecord.status, "INCOMPLETE", "absent final metrics gate pass as incomplete");
+    assertEqual(
+      missingMetricsRecord.evidenceLedger.entries.find((entry) => entry.id === "collector:final-metrics")?.status,
+      "missing",
+      "absent final metrics ledger status"
+    );
+
     const failedMetricsRecord = {
       ...record,
       status: "PASS",
@@ -3018,6 +3042,26 @@ function evidenceLedgerGatingCheck() {
       "failed",
       "failed final metrics ledger status"
     );
+
+    const incompleteSummaryRecord = {
+      ...record,
+      status: "PASS",
+      incompleteReason: undefined,
+      incompleteEvidence: undefined,
+      phases: [],
+      finalMetrics: {
+        error: null,
+        service: { gatewayState: "running" },
+        health: null,
+        healthSamples: [],
+        healthSummary: { count: 1 }
+      }
+    };
+    const incompleteSummaryHealth = buildHealthMeasurement(incompleteSummaryRecord);
+    assertEqual(incompleteSummaryHealth.final.ok, null, "count-only final health summary is unknown");
+    attachEvidenceLedger(incompleteSummaryRecord);
+    applyEvidenceLedgerGating(incompleteSummaryRecord);
+    assertEqual(incompleteSummaryRecord.status, "INCOMPLETE", "count-only final health summary gates pass");
 
     const failedPhaseRecord = {
       ...record,
@@ -3282,6 +3326,24 @@ async function webPayloadContractCheck(tmp) {
     }).ok,
     false,
     "negative threshold rejected"
+  );
+  assertEqual(
+    safeParseRelease({ ...payload, releaseDate: null }).ok,
+    false,
+    "null release date rejected"
+  );
+  assertEqual(
+    safeParseRelease({ ...payload, releaseDate: 0 }).ok,
+    false,
+    "numeric release date rejected"
+  );
+  assertEqual(
+    safeParseRelease({
+      ...payload,
+      runs: [{ ...payload.runs[0], startedAt: null }]
+    }).ok,
+    false,
+    "null run date rejected"
   );
 
   await writeFile(inputPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -76,6 +76,7 @@ import { isMissingOcmResource } from "./ocm/missing-resource.mjs";
 import { assertSafeScenarioCommand, assertSingleTopLevelShellCommand } from "./safety.mjs";
 import { resolveTarget } from "./targets.mjs";
 import {
+  commandResultFailureReason,
   commandResultFailed,
   commandResultPassed,
   measurementScopeForPhase,
@@ -3473,6 +3474,15 @@ function commandResultContractCheck() {
       commandResultFailed({ evidenceStatus: "failed", status: 0 }),
       true,
       "failed evidence overrides zero command status"
+    );
+    assertEqual(
+      commandResultFailureReason({
+        evidenceStatus: "failed",
+        evidenceReason: "snapshot payload was incomplete",
+        status: 0
+      }),
+      "command evidence failed: snapshot payload was incomplete",
+      "failed evidence reason overrides zero command exit"
     );
     assertEqual(
       commandResultPassed({ evidenceStatus: "missing", status: 0 }),

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3078,6 +3078,26 @@ function evidenceLedgerGatingCheck() {
     applyEvidenceLedgerGating(incompleteSummaryRecord);
     assertEqual(incompleteSummaryRecord.status, "INCOMPLETE", "count-only final health summary gates pass");
 
+    const malformedSamplesRecord = {
+      ...record,
+      status: "PASS",
+      incompleteReason: undefined,
+      incompleteEvidence: undefined,
+      phases: [],
+      finalMetrics: {
+        error: null,
+        service: { gatewayState: "running" },
+        health: null,
+        healthSamples: [{}],
+        healthSummary: null
+      }
+    };
+    const malformedSamplesHealth = buildHealthMeasurement(malformedSamplesRecord);
+    assertEqual(malformedSamplesHealth.final.ok, null, "malformed final health samples are unknown");
+    attachEvidenceLedger(malformedSamplesRecord);
+    applyEvidenceLedgerGating(malformedSamplesRecord);
+    assertEqual(malformedSamplesRecord.status, "INCOMPLETE", "malformed final health samples gate pass");
+
     const failedPhaseRecord = {
       ...record,
       status: "FAIL",
@@ -3379,7 +3399,9 @@ async function webPayloadContractCheck(tmp) {
   if (result.status !== 0) {
     throw new Error(result.stderr.trim() || result.stdout.trim() || `publish exited ${result.status}`);
   }
+  const receipt = JSON.parse(result.stdout);
   const published = JSON.parse(await readFile(join(outDir, `${payload.ver}.json`), "utf8"));
+  assertEqual(receipt.releaseDate, "2026-07-12T00:00:00.000Z", "publish receipt uses canonical release date");
   assertEqual(published.releaseDate, "2026-07-12T00:00:00.000Z", "publish writes canonical release date");
   assertEqual(published.runs[0].startedAt, "2026-07-12T01:02:03.000Z", "publish writes canonical run date");
   return {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -16,7 +16,11 @@ import { summarizeCpuProfiles } from "./collectors/node-profiles.mjs";
 import { summarizeHeapProfiles } from "./collectors/heap.mjs";
 import { collectEnvMetrics } from "./metrics.mjs";
 import { compactEvaluatedTimelineEvidence, evaluateRecord } from "./evaluator.mjs";
-import { buildHealthMeasurement, healthTotalFailures } from "./health.mjs";
+import {
+  buildHealthMeasurement,
+  healthTotalFailures,
+  healthTotalFailuresComplete
+} from "./health.mjs";
 import { evaluateWorkflowCase } from "../support/channel-conformance/evaluator.mjs";
 import { assertValidObservationSet } from "../support/channel-conformance/observation-schema.mjs";
 import { planWorkflowCases } from "../support/channel-conformance/planner.mjs";
@@ -3033,6 +3037,8 @@ function evidenceLedgerGatingCheck() {
     const health = buildHealthMeasurement(failedMetricsRecord);
     assertEqual(health.final.ok, null, "failed final metrics health is unknown");
     assertEqual(health.final.failureCount, null, "failed final metrics do not report zero failures");
+    assertEqual(healthTotalFailures(health), 0, "missing final metrics retain known health failure lower bound");
+    assertEqual(healthTotalFailuresComplete(health), false, "missing final metrics mark health total incomplete");
     attachEvidenceLedger(failedMetricsRecord);
     applyEvidenceLedgerGating(failedMetricsRecord);
     assertEqual(failedMetricsRecord.status, "INCOMPLETE", "failed final metrics gate pass as incomplete");
@@ -3097,6 +3103,22 @@ function evidenceLedgerGatingCheck() {
     attachEvidenceLedger(malformedSamplesRecord);
     applyEvidenceLedgerGating(malformedSamplesRecord);
     assertEqual(malformedSamplesRecord.status, "INCOMPLETE", "malformed final health samples gate pass");
+
+    const knownFailureRecord = {
+      ...failedMetricsRecord,
+      phases: [{
+        id: "post-ready",
+        healthScope: "post-ready",
+        commands: [],
+        results: [],
+        metrics: {
+          healthSamples: [{ ok: false, durationMs: 5 }]
+        }
+      }]
+    };
+    const knownFailureHealth = buildHealthMeasurement(knownFailureRecord);
+    assertEqual(healthTotalFailures(knownFailureHealth), 1, "missing final metrics retain observed health failures");
+    assertEqual(healthTotalFailuresComplete(knownFailureHealth), false, "observed lower bound remains incomplete");
 
     const failedPhaseRecord = {
       ...record,

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3123,6 +3123,34 @@ function evidenceLedgerGatingCheck() {
     assertEqual(healthKnownFailures(knownFailureHealth), 1, "missing final metrics retain observed health failures");
     assertEqual(healthTotalFailuresComplete(knownFailureHealth), false, "observed lower bound remains incomplete");
 
+    const incompleteServiceFailureRecord = {
+      ...record,
+      status: "PASS",
+      phases: [],
+      finalMetrics: {
+        error: null,
+        service: { gatewayState: " " },
+        health: { ok: false, durationMs: 5 },
+        healthSamples: [{ ok: false, durationMs: 5 }],
+        healthSummary: { count: 1, failureCount: 1 }
+      }
+    };
+    const incompleteServiceHealth = buildHealthMeasurement(incompleteServiceFailureRecord);
+    assertEqual(incompleteServiceHealth.final.ok, null, "malformed service state keeps final health indeterminate");
+    assertEqual(incompleteServiceHealth.final.failureCount, 1, "malformed service state retains observed final failure");
+    evaluateRecord(incompleteServiceFailureRecord, { thresholds: { finalHealthFailures: 0 } });
+    assertEqual(
+      incompleteServiceFailureRecord.violations.some((violation) => violation.metric === "finalHealthFailures"),
+      true,
+      "observed final failure remains a threshold violation"
+    );
+    attachEvidenceLedger(incompleteServiceFailureRecord);
+    assertEqual(
+      incompleteServiceFailureRecord.evidenceLedger.entries.find((entry) => entry.id === "collector:final-metrics")?.status,
+      "missing",
+      "blank final gateway state is incomplete evidence"
+    );
+
     const failedPhaseRecord = {
       ...record,
       status: "FAIL",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3043,6 +3043,21 @@ function evidenceLedgerGatingCheck() {
       "failed final metrics ledger status"
     );
 
+    const emptyErrorMetricsRecord = {
+      ...record,
+      status: "PASS",
+      incompleteReason: undefined,
+      incompleteEvidence: undefined,
+      phases: [],
+      finalMetrics: {
+        ...record.finalMetrics,
+        error: ""
+      }
+    };
+    attachEvidenceLedger(emptyErrorMetricsRecord);
+    applyEvidenceLedgerGating(emptyErrorMetricsRecord);
+    assertEqual(emptyErrorMetricsRecord.status, "INCOMPLETE", "empty final metrics error gates pass");
+
     const incompleteSummaryRecord = {
       ...record,
       status: "PASS",
@@ -3336,6 +3351,16 @@ async function webPayloadContractCheck(tmp) {
     safeParseRelease({ ...payload, releaseDate: 0 }).ok,
     false,
     "numeric release date rejected"
+  );
+  assertEqual(
+    safeParseRelease({ ...payload, releaseDate: "2026-02-30" }).ok,
+    false,
+    "invalid calendar release date rejected"
+  );
+  assertEqual(
+    safeParseRelease({ ...payload, releaseDate: "0" }).ok,
+    false,
+    "numeric string release date rejected"
   );
   assertEqual(
     safeParseRelease({

--- a/src/web-payload-contract.mjs
+++ b/src/web-payload-contract.mjs
@@ -33,63 +33,67 @@ export const stateEnum = z.enum(["pass", "fail", "block"]);
 export const findingKind = z.enum(["fail", "warn", "info"]);
 export const proveState = z.enum(["pass", "fail"]);
 
+const finiteNumber = z.number().finite();
+const nonnegativeNumber = finiteNumber.nonnegative();
+const nonnegativeInteger = z.number().int().nonnegative();
+
 /* ─── Per-scenario summary (top-level on a release) ───────────── */
 
-export const scenarioSchema = z.object({
+export const scenarioSchema = z.strictObject({
   id: z.string(),
   /** Public label for the headline metric, e.g. "startup" or "full turn". */
   metric: z.string().optional(),
-  value: z.number().nullable(),
+  value: finiteNumber.nullable(),
   unit: z.string(),
-  threshold: z.number(),
+  threshold: nonnegativeNumber,
   state: stateEnum,
   /** Trailing-window samples; null when no sample. */
-  spark: z.array(z.number()).nullable(),
+  spark: z.array(finiteNumber).nullable(),
   /** Defaults true; set false when higher numbers are better. */
   lowerIsBetter: z.boolean().optional(),
   /** Worst contributing metric, used by scenario tile. */
   worstMetric: z
-    .object({ name: z.string(), value: z.number(), unit: z.string() })
+    .strictObject({ name: z.string(), value: finiteNumber, unit: z.string() })
     .optional(),
 });
 
 /* ─── Per-run details (drill-down on /releases/<ver>) ─────────── */
 
-export const phaseSchema = z.object({
+export const phaseSchema = z.strictObject({
   name: z.string(),
-  elapsedMs: z.number(),
+  elapsedMs: nonnegativeInteger,
   state: stateEnum,
 });
 
-export const metricRowSchema = z.object({
+export const metricRowSchema = z.strictObject({
   name: z.string(),
-  value: z.number().nullable(),
+  value: finiteNumber.nullable(),
   unit: z.string(),
-  threshold: z.number().nullable(),
+  threshold: nonnegativeNumber.nullable(),
   state: stateEnum,
   /** Renders indented (role-scoped child of the previous metric). */
   child: z.boolean().optional(),
 });
 
-export const findingSchema = z.object({
+export const findingSchema = z.strictObject({
   kind: findingKind,
   text: z.string(),
   scenarioId: z.string().optional(),
   metric: z.string().optional(),
 });
 
-export const proveSchema = z.object({
+export const proveSchema = z.strictObject({
   state: proveState,
   text: z.string(),
   scenarioId: z.string().optional(),
 });
 
-export const runScenarioSchema = z.object({
+export const runScenarioSchema = z.strictObject({
   id: z.string(),
   state: stateEnum,
-  sampleCount: z.number(),
+  sampleCount: nonnegativeInteger,
   /** Headline number for this scenario in this run, before unit formatting. */
-  sampleValue: z.number().optional(),
+  sampleValue: finiteNumber.optional(),
   sampleUnit: z.string().optional(),
   phases: z.array(phaseSchema).optional(),
   metrics: z.array(metricRowSchema).optional(),
@@ -97,19 +101,19 @@ export const runScenarioSchema = z.object({
   proves: z.array(proveSchema).optional(),
 });
 
-export const bundleSchema = z.object({
+export const bundleSchema = z.strictObject({
   name: z.string(),
-  bytes: z.number(),
+  bytes: nonnegativeInteger,
   href: z.string(),
 });
 
-export const runSchema = z.object({
+export const runSchema = z.strictObject({
   id: z.string(),
   runtime: z.string(),
   profile: z.string(),
   startedAt: z.coerce.date(),
-  durationMs: z.number(),
-  entryCount: z.number(),
+  durationMs: nonnegativeInteger,
+  entryCount: nonnegativeInteger,
   state: stateEnum,
   host: z.string().optional(),
   command: z.string().optional(),
@@ -120,44 +124,44 @@ export const runSchema = z.object({
 
 /* ─── Headline + comparison (publish-time projections) ────────── */
 
-export const headlineSchema = z.object({
+export const headlineSchema = z.strictObject({
   label: z.string(),
-  value: z.number(),
+  value: finiteNumber,
   unit: z.string(),
   vsVer: z.string().optional(),
-  deltaPct: z.number().optional(),
+  deltaPct: finiteNumber.optional(),
   lowerIsBetter: z.boolean().optional(),
   scenarioId: z.string().optional(),
   metric: z.string().optional(),
 });
 
-export const comparisonRowSchema = z.object({
+export const comparisonRowSchema = z.strictObject({
   scenarioId: z.string(),
   metric: z.string(),
-  before: z.number(),
-  after: z.number(),
+  before: finiteNumber,
+  after: finiteNumber,
   unit: z.string(),
-  deltaPct: z.number(),
+  deltaPct: finiteNumber,
   lowerIsBetter: z.boolean().optional(),
 });
 
-export const comparisonSchema = z.object({
+export const comparisonSchema = z.strictObject({
   vsVer: z.string(),
   rows: z.array(comparisonRowSchema),
 });
 
 /* ─── Root release schema ─────────────────────────────────────── */
 
-export const releaseSchema = z.object({
+export const releaseSchema = z.strictObject({
   ver: z.string(),
   releaseDate: z.coerce.date(),
   date: z.string(),
   sha: z.string(),
   passed: z.boolean(),
   /** Number of runs executed. Kept even when `runs[]` is populated. */
-  runCount: z.number().optional(),
+  runCount: nonnegativeInteger.optional(),
   host: z.string().optional(),
-  coldReadyDeltaPct: z.number().optional(),
+  coldReadyDeltaPct: finiteNumber.optional(),
   scenarios: z.array(scenarioSchema).optional(),
   runtimeTargets: z.array(z.string()).optional(),
   headline: z.array(headlineSchema).optional(),

--- a/src/web-payload-contract.mjs
+++ b/src/web-payload-contract.mjs
@@ -36,6 +36,9 @@ export const proveState = z.enum(["pass", "fail"]);
 const finiteNumber = z.number().finite();
 const nonnegativeNumber = finiteNumber.nonnegative();
 const nonnegativeInteger = z.number().int().nonnegative();
+const dateValue = z
+  .union([z.date(), z.string().trim().min(1)])
+  .pipe(z.coerce.date());
 
 /* ─── Per-scenario summary (top-level on a release) ───────────── */
 
@@ -111,7 +114,7 @@ export const runSchema = z.strictObject({
   id: z.string(),
   runtime: z.string(),
   profile: z.string(),
-  startedAt: z.coerce.date(),
+  startedAt: dateValue,
   durationMs: nonnegativeInteger,
   entryCount: nonnegativeInteger,
   state: stateEnum,
@@ -154,7 +157,7 @@ export const comparisonSchema = z.strictObject({
 
 export const releaseSchema = z.strictObject({
   ver: z.string(),
-  releaseDate: z.coerce.date(),
+  releaseDate: dateValue,
   date: z.string(),
   sha: z.string(),
   passed: z.boolean(),

--- a/src/web-payload-contract.mjs
+++ b/src/web-payload-contract.mjs
@@ -37,8 +37,12 @@ const finiteNumber = z.number().finite();
 const nonnegativeNumber = finiteNumber.nonnegative();
 const nonnegativeInteger = z.number().int().nonnegative();
 const dateValue = z
-  .union([z.date(), z.string().trim().min(1)])
-  .pipe(z.coerce.date());
+  .union([
+    z.date(),
+    z.iso.date(),
+    z.iso.datetime({ offset: true }),
+  ])
+  .transform((value) => value instanceof Date ? value : new Date(value));
 
 /* ─── Per-scenario summary (top-level on a release) ───────────── */
 

--- a/tests/snapshots/publish-dry-existing-json.snap
+++ b/tests/snapshots/publish-dry-existing-json.snap
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "kova.web-payload.v1",
   "ver": "2026.5.26",
-  "releaseDate": "2026-05-28",
+  "releaseDate": "<iso>",
   "sha": "2026.5.26",
   "passed": false,
   "input": {

--- a/tests/snapshots/publish-dry-internal-report.snap
+++ b/tests/snapshots/publish-dry-internal-report.snap
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "kova.web-payload.v1",
   "ver": "2026.4.30-internal",
-  "releaseDate": "2026-04-30",
+  "releaseDate": "<iso>",
   "sha": "local-build",
   "passed": true,
   "input": {


### PR DESCRIPTION
## What Problem This Solves

Kova could accept malformed release payloads, normalize invalid dates into misleading values, and treat incomplete command or final-health evidence as successful proof. That allowed published reports and run ledgers to overstate what a run had actually established.

## Why This Change Was Made

- Enforce the public web payload contract with strict Zod validation and canonical parsed output.
- Reject invalid ISO calendar dates instead of relying on permissive JavaScript date coercion.
- Centralize command-result classification so evidence failures override a zero process exit code everywhere.
- Require complete final service and health evidence for executed runs while retaining observed failure lower bounds.
- Keep publish receipts, report projections, ledgers, and upgrade evidence aligned on the same canonical facts.
- Add focused self-check and snapshot coverage for malformed dates, incomplete metrics, failed evidence, and canonical publication.

## User Impact

Published Kova data now fails closed when release or run evidence is malformed or incomplete. Reports no longer present unknown health as healthy, and failure messages preserve the actual evidence failure instead of rendering contradictory text such as `command exited 0`.

## Evidence

- Base: `4af25719ec891d879c936ee57f4064e2242709ab`
- Head: `08dbc5d36cfe8ea72f1aa0dfab45bf33b2a4ed95`
- `npm run check:full`
  - concurrent self-check isolation: pass
  - self-check: 259/259 pass
  - snapshots: 21/21 pass
  - web payload contract: 1/1 pass
  - release transaction contracts: pass
- Packed release archive smoke in isolated `HOME` and `KOVA_HOME`
  - `setup --ci --json`: pass
  - extracted archive `npm run check`: 259/259 pass
  - SHA-256: `b7e273ca1521ccc609f2a2c1c68582d966072c3b1dc11b89a7cdbc880b18f350`
  - size: 3,457,049 bytes
- High-thinking branch autoreview: clean, no actionable findings
- `git diff --check`: pass

The change is documented under `Unreleased` in `CHANGELOG.md`.
