### PR TITLE
fix(runtime): harden cleanup and retained environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ All notable changes to Kova are documented in this file.
 - Hardened collector evidence integrity across profiles, provider attribution, process sampling, diagnostics, timelines, state fixtures, redaction, and artifact retention.
 - Made report, portable USTAR bundle, retained-artifact, and baseline publication concurrency-safe, rollback-aware, crash-cleaning, and fail-closed on incomplete evidence.
 - Kept installed release self-checks independent of source-only test fixtures.
+- Made cleanup skip active, retained, recent, and unknown-state environments by default, finalized local runtimes after failures, and made failed comparisons exit non-zero in every output format.

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -8,7 +8,7 @@ const BOOLEAN_FLAGS = new Set([
   "keep_env", "retain_on_failure", "profile_on_failure",
   "deep_profile", "node_profile", "heap_snapshot",
   "ascii", "no_color", "no_progress", "reviewed_good", "version",
-  "dry_run", "no_augment",
+  "dry_run", "no_augment", "force",
 ]);
 
 export function parseFlags(argv) {
@@ -100,7 +100,7 @@ Usage:
   kova report compare <baseline-runId|baseline.json> <current-runId|current.json> [--thresholds <json>] [--fixer] [--json|--plain]
   kova report bundle <runId|report.json> [--output-dir <path>] [--json|--plain]
   kova publish <input.json|runId> [--ver <version>] [--release-date <date>] [--sha <sha>] [--report-dir <path>] [--out-dir <path>] [--no-augment] [--dry-run] [--json]
-  kova cleanup envs [--execute] [--json]
+  kova cleanup envs [--older-than-days <n>] [--execute] [--force] [--json]
   kova cleanup artifacts [--older-than-days <n>] [--execute] [--json]
 
 Selectors:

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -32,15 +32,7 @@ async function cleanupEnvs(flags) {
   const olderThanDays = positiveIntegerFlag(flags, "older_than_days", 1);
   const cutoffMs = Date.now() - olderThanDays * DAY_MS;
   const force = flags.force === true;
-  const envList = await runCommand(ocmEnvListJson(), { timeoutMs: 30000 });
-  if (envList.status !== 0) {
-    throw new Error(`failed to list OCM envs: ${envList.stderr.trim() || envList.stdout.trim()}`);
-  }
-
-  const summaries = JSON.parse(envList.stdout);
-  if (!Array.isArray(summaries)) {
-    throw new Error("ocm env list --json returned unexpected data");
-  }
+  const summaries = await loadEnvSummaries();
 
   const serviceInventory = await loadServiceInventory();
   const retentionInventory = await loadRetentionInventory();
@@ -61,10 +53,14 @@ async function cleanupEnvs(flags) {
   // Destructive cleanup must require the literal boolean set by `--execute`.
   if (flags.execute === true) {
     for (const env of candidates) {
-      const { result, precondition, stage } = await destroyCleanupEnv(env.name, { force });
+      const { result, precondition, stage, code } = await destroyCleanupEnv(env.name, {
+        force,
+        cutoffMs
+      });
       results.push({
         env: env.name,
         stage,
+        code,
         precondition,
         command: result.command,
         status: result.status,
@@ -131,19 +127,29 @@ async function cleanupEnvs(flags) {
   }, flags));
 }
 
-async function destroyCleanupEnv(envName, { force }) {
+async function destroyCleanupEnv(envName, { force, cutoffMs }) {
   if (force) {
+    const result = await runCleanupCommand(
+      ocmEnvDestroy(envName, { force: true }),
+      { timeoutMs: 120000 }
+    );
     return {
-      result: await runCleanupCommand(ocmEnvDestroy(envName, { force: true }), { timeoutMs: 120000 }),
+      result,
       precondition: null,
-      stage: "destroy"
+      stage: "destroy",
+      code: cleanupResultCode(result)
     };
   }
 
   const preview = await runCommand(ocmEnvDestroyPreviewJson(envName), { timeoutMs: 30000 });
   const precondition = summarizeCleanupCommand(preview);
   if (preview.status !== 0) {
-    return { result: preview, precondition, stage: "precondition" };
+    return {
+      result: preview,
+      precondition,
+      stage: "precondition",
+      code: cleanupResultCode(preview)
+    };
   }
 
   let previewSummary;
@@ -153,7 +159,8 @@ async function destroyCleanupEnv(envName, { force }) {
     return {
       result: invalidPreconditionResult(preview, `invalid destroy preview JSON: ${error.message}`),
       precondition,
-      stage: "precondition"
+      stage: "precondition",
+      code: "invalid_preview"
     };
   }
 
@@ -162,7 +169,8 @@ async function destroyCleanupEnv(envName, { force }) {
     return {
       result: invalidPreconditionResult(preview, previewError),
       precondition,
-      stage: "precondition"
+      stage: "precondition",
+      code: "unsafe_preview"
     };
   }
 
@@ -171,15 +179,57 @@ async function destroyCleanupEnv(envName, { force }) {
     return {
       result: invalidPreconditionResult(preview, "destroy preview did not return a stateToken"),
       precondition,
-      stage: "precondition"
+      stage: "precondition",
+      code: "invalid_preview"
+    };
+  }
+
+  let fresh;
+  try {
+    fresh = await loadCleanupEnvClassification(envName, cutoffMs);
+  } catch (error) {
+    return {
+      result: invalidPreconditionResult(preview, `failed to refresh cleanup eligibility: ${error.message}`),
+      precondition,
+      stage: "precondition",
+      code: "eligibility_refresh_failed"
+    };
+  }
+  if (!fresh) {
+    return {
+      result: invalidPreconditionResult(preview, "environment no longer appears in OCM inventory"),
+      precondition,
+      stage: "precondition",
+      code: "environment_missing"
+    };
+  }
+  if (!fresh.eligible) {
+    return {
+      result: invalidPreconditionResult(
+        preview,
+        `environment is no longer eligible for cleanup: ${fresh.reasons.join(", ")}`
+      ),
+      precondition,
+      stage: "precondition",
+      code: "eligibility_changed"
     };
   }
 
   const result = await runCleanupCommand(
     ocmEnvDestroy(envName, { json: true, stateToken: stateRevision }),
-    { timeoutMs: 120000 }
+    {
+      timeoutMs: 120000,
+      // partial_apply means teardown began; a retry needs a fresh preview.
+      retryDelaysMs: [0]
+    }
   );
-  return { result, precondition, stage: "destroy" };
+  const code = cleanupResultCode(result);
+  return {
+    result,
+    precondition,
+    stage: code === "partial_apply" ? "partial-apply" : "destroy",
+    code
+  };
 }
 
 function validateDestroyPreview(summary) {
@@ -224,6 +274,45 @@ function invalidPreconditionResult(preview, message) {
     status: 1,
     stderr: [preview.stderr, message].filter(Boolean).join("\n")
   };
+}
+
+async function loadEnvSummaries() {
+  const result = await runCommand(ocmEnvListJson(), { timeoutMs: 30000 });
+  if (result.status !== 0) {
+    throw new Error(`failed to list OCM envs: ${result.stderr.trim() || result.stdout.trim()}`);
+  }
+  const summaries = JSON.parse(result.stdout);
+  if (!Array.isArray(summaries)) {
+    throw new Error("ocm env list --json returned unexpected data");
+  }
+  return summaries;
+}
+
+async function loadCleanupEnvClassification(envName, cutoffMs) {
+  const summaries = await loadEnvSummaries();
+  const summary = summaries.find((candidate) => candidate?.name === envName);
+  if (!summary) return null;
+
+  const serviceInventory = await loadServiceInventory();
+  const retentionInventory = await loadRetentionInventory();
+  return classifyCleanupEnv({
+    summary,
+    service: serviceInventory.byEnv.get(envName),
+    serviceInventoryOk: serviceInventory.ok,
+    retained: retentionInventory.envNames.has(envName),
+    retentionInventoryOk: retentionInventory.ok,
+    cutoffMs,
+    force: false
+  });
+}
+
+function cleanupResultCode(result) {
+  try {
+    const parsed = JSON.parse(result.stdout);
+    return typeof parsed?.code === "string" ? parsed.code : null;
+  } catch {
+    return null;
+  }
 }
 
 async function loadServiceInventory() {

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -42,14 +42,15 @@ async function cleanupEnvs(flags) {
   }
 
   const serviceInventory = await loadServiceInventory();
-  const retainedEnvNames = await loadRetainedEnvNames();
+  const retentionInventory = await loadRetentionInventory();
   const envs = summaries
     .filter((summary) => /^kova-[a-z0-9-]+$/.test(summary?.name))
     .map((summary) => classifyCleanupEnv({
       summary,
       service: serviceInventory.byEnv.get(summary.name),
       serviceInventoryOk: serviceInventory.ok,
-      retained: retainedEnvNames.has(summary.name),
+      retained: retentionInventory.envNames.has(summary.name),
+      retentionInventoryOk: retentionInventory.ok,
       cutoffMs,
       force
     }));
@@ -83,6 +84,10 @@ async function cleanupEnvs(flags) {
       serviceInventory: {
         ok: serviceInventory.ok,
         error: serviceInventory.error
+      },
+      retentionInventory: {
+        ok: retentionInventory.ok,
+        error: retentionInventory.error
       },
       envs,
       candidates: candidates.map((candidate) => candidate.name),
@@ -148,18 +153,23 @@ async function loadServiceInventory() {
   }
 }
 
-async function loadRetainedEnvNames() {
+async function loadRetentionInventory() {
   let entries;
   try {
     entries = await readdir(reportsDir, { withFileTypes: true });
   } catch (error) {
     if (error.code === "ENOENT") {
-      return new Set();
+      return { ok: true, error: null, envNames: new Set() };
     }
-    throw error;
+    return {
+      ok: false,
+      error: `failed to read reports directory: ${error.message}`,
+      envNames: new Set()
+    };
   }
 
   const retained = new Set();
+  const errors = [];
   for (const entry of entries) {
     if (!entry.isFile() || !entry.name.endsWith(".json") || entry.name.endsWith(".summary.json")) {
       continue;
@@ -171,14 +181,26 @@ async function loadRetainedEnvNames() {
           retained.add(record.envName);
         }
       }
-    } catch {
-      // A malformed unrelated report must not make cleanup less conservative.
+    } catch (error) {
+      errors.push(`${entry.name}: ${error.message}`);
     }
   }
-  return retained;
+  return {
+    ok: errors.length === 0,
+    error: errors.length === 0 ? null : `failed to read retention evidence: ${errors.join("; ")}`,
+    envNames: retained
+  };
 }
 
-function classifyCleanupEnv({ summary, service, serviceInventoryOk, retained, cutoffMs, force }) {
+function classifyCleanupEnv({
+  summary,
+  service,
+  serviceInventoryOk,
+  retained,
+  retentionInventoryOk,
+  cutoffMs,
+  force
+}) {
   const timestamp = Date.parse(summary.lastUsedAt ?? summary.createdAt ?? "");
   const ageDays = Number.isFinite(timestamp)
     ? Math.max(0, Math.floor((Date.now() - timestamp) / DAY_MS))
@@ -195,6 +217,7 @@ function classifyCleanupEnv({ summary, service, serviceInventoryOk, retained, cu
   else if (timestamp > cutoffMs) reasons.push("too-recent");
   if (summary.protected === true) reasons.push("protected");
   if (retained) reasons.push("retained-by-run");
+  if (!retentionInventoryOk) reasons.push("unknown-retention-state");
   if (!serviceKnown) reasons.push("unknown-service-state");
   else if (active) reasons.push("active-service");
 

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -59,7 +59,7 @@ async function cleanupEnvs(flags) {
   // Destructive cleanup must require the literal boolean set by `--execute`.
   if (flags.execute === true) {
     for (const env of candidates) {
-      const result = await runCleanupCommand(ocmEnvDestroy(env.name), { timeoutMs: 120000 });
+      const result = await runCleanupCommand(ocmEnvDestroy(env.name, { force }), { timeoutMs: 120000 });
       results.push({
         env: env.name,
         command: result.command,

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -76,6 +76,9 @@ async function cleanupEnvs(flags) {
       });
     }
   }
+  if (flags.execute === true && results.some((result) => result.status !== 0)) {
+    process.exitCode = 1;
+  }
 
   if (flags.json) {
     console.log(JSON.stringify({
@@ -143,10 +146,9 @@ async function destroyCleanupEnv(envName, { force }) {
     return { result: preview, precondition, stage: "precondition" };
   }
 
-  let stateRevision;
+  let previewSummary;
   try {
-    const parsed = JSON.parse(preview.stdout);
-    stateRevision = parsed?.stateToken;
+    previewSummary = JSON.parse(preview.stdout);
   } catch (error) {
     return {
       result: invalidPreconditionResult(preview, `invalid destroy preview JSON: ${error.message}`),
@@ -154,6 +156,17 @@ async function destroyCleanupEnv(envName, { force }) {
       stage: "precondition"
     };
   }
+
+  const previewError = validateDestroyPreview(previewSummary);
+  if (previewError) {
+    return {
+      result: invalidPreconditionResult(preview, previewError),
+      precondition,
+      stage: "precondition"
+    };
+  }
+
+  const stateRevision = previewSummary.stateToken;
   if (typeof stateRevision !== "string" || stateRevision.length === 0) {
     return {
       result: invalidPreconditionResult(preview, "destroy preview did not return a stateToken"),
@@ -167,6 +180,31 @@ async function destroyCleanupEnv(envName, { force }) {
     { timeoutMs: 120000 }
   );
   return { result, precondition, stage: "destroy" };
+}
+
+function validateDestroyPreview(summary) {
+  if (summary == null || typeof summary !== "object" || Array.isArray(summary)) {
+    return "destroy preview did not return an object";
+  }
+  if (
+    typeof summary.serviceInstalled !== "boolean" ||
+    typeof summary.serviceLoaded !== "boolean" ||
+    typeof summary.serviceRunning !== "boolean" ||
+    !Array.isArray(summary.blockers) ||
+    !Array.isArray(summary.steps)
+  ) {
+    return "destroy preview did not return complete service, blocker, and teardown state";
+  }
+  if (summary.blockers.length > 0) {
+    return `destroy preview reported blockers: ${summary.blockers.join(", ")}`;
+  }
+  if (summary.serviceInstalled || summary.serviceLoaded || summary.serviceRunning) {
+    return "destroy preview reported an active service";
+  }
+  if (summary.steps.some((step) => step?.kind === "processes")) {
+    return "destroy preview reported live processes";
+  }
+  return null;
 }
 
 function summarizeCleanupCommand(result) {

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -72,7 +72,11 @@ async function cleanupEnvs(flags) {
       });
     }
   }
-  if (flags.execute === true && results.some((result) => result.status !== 0)) {
+  const inventoryBlocked = !force && (!serviceInventory.ok || !retentionInventory.ok);
+  if (
+    flags.execute === true &&
+    (inventoryBlocked || results.some((result) => result.status !== 0))
+  ) {
     process.exitCode = 1;
   }
 

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -5,6 +5,7 @@ import { runCommand } from "../commands.mjs";
 import { artifactsDir, reportsDir } from "../paths.mjs";
 import {
   ocmEnvDestroy,
+  ocmEnvDestroyPreviewJson,
   ocmEnvListJson,
   ocmServiceStatusAllJson
 } from "../ocm/commands.mjs";
@@ -60,9 +61,11 @@ async function cleanupEnvs(flags) {
   // Destructive cleanup must require the literal boolean set by `--execute`.
   if (flags.execute === true) {
     for (const env of candidates) {
-      const result = await runCleanupCommand(ocmEnvDestroy(env.name, { force }), { timeoutMs: 120000 });
+      const { result, precondition, stage } = await destroyCleanupEnv(env.name, { force });
       results.push({
         env: env.name,
+        stage,
+        precondition,
         command: result.command,
         status: result.status,
         durationMs: result.durationMs,
@@ -123,6 +126,66 @@ async function cleanupEnvs(flags) {
     force,
     olderThanDays
   }, flags));
+}
+
+async function destroyCleanupEnv(envName, { force }) {
+  if (force) {
+    return {
+      result: await runCleanupCommand(ocmEnvDestroy(envName, { force: true }), { timeoutMs: 120000 }),
+      precondition: null,
+      stage: "destroy"
+    };
+  }
+
+  const preview = await runCommand(ocmEnvDestroyPreviewJson(envName), { timeoutMs: 30000 });
+  const precondition = summarizeCleanupCommand(preview);
+  if (preview.status !== 0) {
+    return { result: preview, precondition, stage: "precondition" };
+  }
+
+  let stateRevision;
+  try {
+    const parsed = JSON.parse(preview.stdout);
+    stateRevision = parsed?.stateToken;
+  } catch (error) {
+    return {
+      result: invalidPreconditionResult(preview, `invalid destroy preview JSON: ${error.message}`),
+      precondition,
+      stage: "precondition"
+    };
+  }
+  if (typeof stateRevision !== "string" || stateRevision.length === 0) {
+    return {
+      result: invalidPreconditionResult(preview, "destroy preview did not return a stateToken"),
+      precondition,
+      stage: "precondition"
+    };
+  }
+
+  const result = await runCleanupCommand(
+    ocmEnvDestroy(envName, { json: true, stateToken: stateRevision }),
+    { timeoutMs: 120000 }
+  );
+  return { result, precondition, stage: "destroy" };
+}
+
+function summarizeCleanupCommand(result) {
+  return {
+    command: result.command,
+    status: result.status,
+    durationMs: result.durationMs,
+    timedOut: result.timedOut,
+    stdout: result.stdout,
+    stderr: result.stderr
+  };
+}
+
+function invalidPreconditionResult(preview, message) {
+  return {
+    ...preview,
+    status: 1,
+    stderr: [preview.stderr, message].filter(Boolean).join("\n")
+  };
 }
 
 async function loadServiceInventory() {

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -89,7 +89,8 @@ async function cleanupEnvs(flags) {
         ok: retentionInventory.ok,
         error: retentionInventory.error
       },
-      envs,
+      envs: envs.map((env) => env.name),
+      classifications: envs,
       candidates: candidates.map((candidate) => candidate.name),
       results
     }, null, 2));

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -221,7 +221,7 @@ async function destroyCleanupEnv(envName, { force, cutoffMs }) {
   }
 
   const result = await runCleanupCommand(
-    ocmEnvDestroy(envName, { json: true, stateToken: stateRevision }),
+    ocmEnvDestroy(envName, { json: true, stateRevision }),
     {
       timeoutMs: 120000,
       // partial_apply means teardown began; a retry needs a fresh preview.

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -302,7 +302,40 @@ async function loadEnvSummaries() {
   if (!Array.isArray(summaries)) {
     throw new Error("ocm env list --json returned unexpected data");
   }
+  const names = new Set();
+  for (const summary of summaries) {
+    const error = validateEnvSummary(summary);
+    if (error) {
+      throw new Error(`ocm env list --json returned unexpected data: ${error}`);
+    }
+    if (names.has(summary.name)) {
+      throw new Error(`ocm env list --json returned duplicate env: ${summary.name}`);
+    }
+    names.add(summary.name);
+  }
   return summaries;
+}
+
+function validateEnvSummary(summary) {
+  if (summary === null || typeof summary !== "object" || Array.isArray(summary)) {
+    return "invalid environment record";
+  }
+  if (typeof summary.name !== "string" || summary.name.length === 0) {
+    return "environment record is missing name";
+  }
+  if (typeof summary.protected !== "boolean") {
+    return `environment ${summary.name} is missing protected state`;
+  }
+  if (typeof summary.createdAt !== "string" || !Number.isFinite(Date.parse(summary.createdAt))) {
+    return `environment ${summary.name} has invalid createdAt`;
+  }
+  if (
+    summary.lastUsedAt !== null &&
+    (typeof summary.lastUsedAt !== "string" || !Number.isFinite(Date.parse(summary.lastUsedAt)))
+  ) {
+    return `environment ${summary.name} has invalid lastUsedAt`;
+  }
+  return null;
 }
 
 async function loadCleanupEnvClassification(envName, cutoffMs) {

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -238,6 +238,7 @@ async function destroyCleanupEnv(envName, { force, cutoffMs }) {
 }
 
 function validateDestroyPreview(summary) {
+  const allowedStepKinds = new Set(["service", "processes", "worktree", "env", "snapshots"]);
   if (summary == null || typeof summary !== "object" || Array.isArray(summary)) {
     return "destroy preview did not return an object";
   }
@@ -245,8 +246,19 @@ function validateDestroyPreview(summary) {
     typeof summary.serviceInstalled !== "boolean" ||
     typeof summary.serviceLoaded !== "boolean" ||
     typeof summary.serviceRunning !== "boolean" ||
+    !Number.isSafeInteger(summary.processCount) ||
+    summary.processCount < 0 ||
     !Array.isArray(summary.blockers) ||
-    !Array.isArray(summary.steps)
+    !summary.blockers.every((blocker) => typeof blocker === "string") ||
+    !Array.isArray(summary.steps) ||
+    !summary.steps.every((step) =>
+      step !== null &&
+      typeof step === "object" &&
+      !Array.isArray(step) &&
+      allowedStepKinds.has(step.kind) &&
+      typeof step.description === "string" &&
+      step.description.length > 0
+    )
   ) {
     return "destroy preview did not return complete service, blocker, and teardown state";
   }
@@ -256,7 +268,7 @@ function validateDestroyPreview(summary) {
   if (summary.serviceLoaded || summary.serviceRunning) {
     return "destroy preview reported an active service";
   }
-  if (summary.steps.some((step) => step?.kind === "processes")) {
+  if (summary.processCount > 0 || summary.steps.some((step) => step.kind === "processes")) {
     return "destroy preview reported live processes";
   }
   return null;
@@ -335,10 +347,19 @@ async function loadServiceInventory() {
     if (!Array.isArray(parsed?.services)) {
       throw new Error("services array missing");
     }
+    const byEnv = new Map();
+    for (const service of parsed.services) {
+      const error = validateServiceInventoryRecord(service);
+      if (error) throw new Error(error);
+      if (byEnv.has(service.envName)) {
+        throw new Error(`duplicate service envName: ${service.envName}`);
+      }
+      byEnv.set(service.envName, service);
+    }
     return {
       ok: true,
       error: null,
-      byEnv: new Map(parsed.services.map((service) => [service.envName, service]))
+      byEnv
     };
   } catch (error) {
     return {
@@ -347,6 +368,34 @@ async function loadServiceInventory() {
       byEnv: new Map()
     };
   }
+}
+
+function validateServiceInventoryRecord(service) {
+  if (service === null || typeof service !== "object" || Array.isArray(service)) {
+    return "services array contains an invalid record";
+  }
+  if (typeof service.envName !== "string" || service.envName.length === 0) {
+    return "service record is missing envName";
+  }
+  if (
+    typeof service.installed !== "boolean" ||
+    typeof service.desiredRunning !== "boolean" ||
+    typeof service.running !== "boolean" ||
+    typeof service.gatewayState !== "string" ||
+    service.gatewayState.length === 0
+  ) {
+    return `service record for ${service.envName} is incomplete`;
+  }
+  if (
+    service.childPid !== null &&
+    (!Number.isSafeInteger(service.childPid) || service.childPid <= 0)
+  ) {
+    return `service record for ${service.envName} has invalid childPid`;
+  }
+  if (service.issue !== undefined && service.issue !== null && typeof service.issue !== "string") {
+    return `service record for ${service.envName} has invalid issue`;
+  }
+  return null;
 }
 
 async function loadRetentionInventory() {

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -206,7 +206,7 @@ function classifyCleanupEnv({
   const ageDays = Number.isFinite(timestamp)
     ? Math.max(0, Math.floor((Date.now() - timestamp) / DAY_MS))
     : null;
-  const serviceKnown = serviceInventoryOk && service !== undefined;
+  const serviceKnown = serviceInventoryOk && service !== undefined && service.issue == null;
   const active = serviceKnown && (
     service.running === true ||
     service.desiredRunning === true ||

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -198,7 +198,7 @@ function validateDestroyPreview(summary) {
   if (summary.blockers.length > 0) {
     return `destroy preview reported blockers: ${summary.blockers.join(", ")}`;
   }
-  if (summary.serviceInstalled || summary.serviceLoaded || summary.serviceRunning) {
+  if (summary.serviceLoaded || summary.serviceRunning) {
     return "destroy preview reported an active service";
   }
   if (summary.steps.some((step) => step?.kind === "processes")) {

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -130,14 +130,19 @@ async function cleanupEnvs(flags) {
 async function destroyCleanupEnv(envName, { force, cutoffMs }) {
   if (force) {
     const result = await runCleanupCommand(
-      ocmEnvDestroy(envName, { force: true }),
-      { timeoutMs: 120000 }
+      ocmEnvDestroy(envName, { force: true, json: true }),
+      {
+        timeoutMs: 120000,
+        // Force bypasses blockers, but it does not make partial teardown retry-safe.
+        retryDelaysMs: [0]
+      }
     );
+    const code = cleanupResultCode(result);
     return {
       result,
       precondition: null,
-      stage: "destroy",
-      code: cleanupResultCode(result)
+      stage: code === "partial_apply" ? "partial-apply" : "destroy",
+      code
     };
   }
 

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -372,8 +372,22 @@ async function loadRetentionInventory() {
     }
     try {
       const report = JSON.parse(await readFile(join(reportsDir, entry.name), "utf8"));
-      for (const record of report.records ?? []) {
-        if (record?.cleanup === "retained" && typeof record.envName === "string") {
+      if (
+        report === null ||
+        typeof report !== "object" ||
+        Array.isArray(report) ||
+        !Array.isArray(report.records)
+      ) {
+        throw new Error("records array missing");
+      }
+      for (const record of report.records) {
+        if (record === null || typeof record !== "object" || Array.isArray(record)) {
+          throw new Error("records array contains an invalid record");
+        }
+        if (record.cleanup === "retained") {
+          if (typeof record.envName !== "string" || record.envName.length === 0) {
+            throw new Error("retained record is missing envName");
+          }
           retained.add(record.envName);
         }
       }

--- a/src/commands/cleanup.mjs
+++ b/src/commands/cleanup.mjs
@@ -1,11 +1,17 @@
-import { readdir, rm, stat } from "node:fs/promises";
+import { readFile, readdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { runCleanupCommand } from "../cleanup.mjs";
 import { runCommand } from "../commands.mjs";
-import { artifactsDir } from "../paths.mjs";
-import { ocmEnvDestroy, ocmEnvListJson } from "../ocm/commands.mjs";
+import { artifactsDir, reportsDir } from "../paths.mjs";
+import {
+  ocmEnvDestroy,
+  ocmEnvListJson,
+  ocmServiceStatusAllJson
+} from "../ocm/commands.mjs";
 import { positiveIntegerFlag } from "../run/options.mjs";
 import { renderCleanupEnvs, renderCleanupArtifacts } from "../reporting/render-cleanup.mjs";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 export async function runCleanupCliCommand(flags) {
   const [subcommand] = flags._;
@@ -22,6 +28,9 @@ export async function runCleanupCliCommand(flags) {
 }
 
 async function cleanupEnvs(flags) {
+  const olderThanDays = positiveIntegerFlag(flags, "older_than_days", 1);
+  const cutoffMs = Date.now() - olderThanDays * DAY_MS;
+  const force = flags.force === true;
   const envList = await runCommand(ocmEnvListJson(), { timeoutMs: 30000 });
   if (envList.status !== 0) {
     throw new Error(`failed to list OCM envs: ${envList.stderr.trim() || envList.stdout.trim()}`);
@@ -32,14 +41,35 @@ async function cleanupEnvs(flags) {
     throw new Error("ocm env list --json returned unexpected data");
   }
 
+  const serviceInventory = await loadServiceInventory();
+  const retainedEnvNames = await loadRetainedEnvNames();
   const envs = summaries
-    .map((summary) => summary.name)
-    .filter((name) => /^kova-[a-z0-9-]+$/.test(name));
+    .filter((summary) => /^kova-[a-z0-9-]+$/.test(summary?.name))
+    .map((summary) => classifyCleanupEnv({
+      summary,
+      service: serviceInventory.byEnv.get(summary.name),
+      serviceInventoryOk: serviceInventory.ok,
+      retained: retainedEnvNames.has(summary.name),
+      cutoffMs,
+      force
+    }));
+  const candidates = envs.filter((env) => env.eligible);
   const results = [];
 
+  // Destructive cleanup must require the literal boolean set by `--execute`.
   if (flags.execute === true) {
-    for (const env of envs) {
-      results.push(await runCleanupCommand(ocmEnvDestroy(env), { timeoutMs: 120000 }));
+    for (const env of candidates) {
+      const result = await runCleanupCommand(ocmEnvDestroy(env.name), { timeoutMs: 120000 });
+      results.push({
+        env: env.name,
+        command: result.command,
+        status: result.status,
+        durationMs: result.durationMs,
+        timedOut: result.timedOut,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        attempts: result.attempts ?? []
+      });
     }
   }
 
@@ -48,43 +78,152 @@ async function cleanupEnvs(flags) {
       schemaVersion: "kova.cleanup.envs.v1",
       generatedAt: new Date().toISOString(),
       execute: flags.execute === true,
+      force,
+      olderThanDays,
+      serviceInventory: {
+        ok: serviceInventory.ok,
+        error: serviceInventory.error
+      },
       envs,
-      results: results.map((result) => ({
-        command: result.command,
-        status: result.status,
-        durationMs: result.durationMs,
-        timedOut: result.timedOut,
-        attempts: result.attempts ?? []
-      }))
+      candidates: candidates.map((candidate) => candidate.name),
+      results
     }, null, 2));
     return;
   }
 
   if (flags.plain === true) {
     if (envs.length === 0) {
-      console.log("No stale Kova envs found.");
+      console.log("No Kova envs found.");
       return;
     }
-    if (!flags.execute) {
-      console.log("Stale Kova envs:");
+    if (flags.execute !== true) {
+      console.log(`Kova env cleanup plan (older than ${olderThanDays} day(s)):`);
       for (const env of envs) {
-        console.log(`- ${env}`);
+        console.log(`- ${env.eligible ? "REMOVE" : "SKIP"} ${env.name}: ${env.reasons.join(", ") || "eligible"}`);
       }
-      console.log("Run with --execute to destroy them.");
+      console.log("Run with --execute to destroy eligible envs; add --force to override safeguards.");
       return;
     }
     for (const result of results) {
-      console.log(`${result.status === 0 ? "PASS" : "FAIL"} ${result.command}`);
+      console.log(`${result.status === 0 ? "PASS" : "FAIL"} ${result.env}: ${result.command}`);
     }
     return;
   }
 
-  console.log(renderCleanupEnvs({ envs, results, execute: flags.execute === true }, flags));
+  console.log(renderCleanupEnvs({
+    envs,
+    results,
+    execute: flags.execute === true,
+    force,
+    olderThanDays
+  }, flags));
+}
+
+async function loadServiceInventory() {
+  const result = await runCommand(ocmServiceStatusAllJson(), { timeoutMs: 30000 });
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      error: result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`,
+      byEnv: new Map()
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout);
+    if (!Array.isArray(parsed?.services)) {
+      throw new Error("services array missing");
+    }
+    return {
+      ok: true,
+      error: null,
+      byEnv: new Map(parsed.services.map((service) => [service.envName, service]))
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `invalid service status JSON: ${error.message}`,
+      byEnv: new Map()
+    };
+  }
+}
+
+async function loadRetainedEnvNames() {
+  let entries;
+  try {
+    entries = await readdir(reportsDir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return new Set();
+    }
+    throw error;
+  }
+
+  const retained = new Set();
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json") || entry.name.endsWith(".summary.json")) {
+      continue;
+    }
+    try {
+      const report = JSON.parse(await readFile(join(reportsDir, entry.name), "utf8"));
+      for (const record of report.records ?? []) {
+        if (record?.cleanup === "retained" && typeof record.envName === "string") {
+          retained.add(record.envName);
+        }
+      }
+    } catch {
+      // A malformed unrelated report must not make cleanup less conservative.
+    }
+  }
+  return retained;
+}
+
+function classifyCleanupEnv({ summary, service, serviceInventoryOk, retained, cutoffMs, force }) {
+  const timestamp = Date.parse(summary.lastUsedAt ?? summary.createdAt ?? "");
+  const ageDays = Number.isFinite(timestamp)
+    ? Math.max(0, Math.floor((Date.now() - timestamp) / DAY_MS))
+    : null;
+  const serviceKnown = serviceInventoryOk && service !== undefined;
+  const active = serviceKnown && (
+    service.running === true ||
+    service.desiredRunning === true ||
+    service.childPid != null ||
+    !["stopped", "not-installed"].includes(service.gatewayState)
+  );
+  const reasons = [];
+  if (!Number.isFinite(timestamp)) reasons.push("unknown-age");
+  else if (timestamp > cutoffMs) reasons.push("too-recent");
+  if (summary.protected === true) reasons.push("protected");
+  if (retained) reasons.push("retained-by-run");
+  if (!serviceKnown) reasons.push("unknown-service-state");
+  else if (active) reasons.push("active-service");
+
+  return {
+    name: summary.name,
+    eligible: force || reasons.length === 0,
+    forced: force && reasons.length > 0,
+    reasons,
+    ageDays,
+    createdAt: summary.createdAt ?? null,
+    lastUsedAt: summary.lastUsedAt ?? null,
+    protected: summary.protected === true,
+    retained,
+    service: serviceKnown
+      ? {
+        installed: service.installed === true,
+        desiredRunning: service.desiredRunning === true,
+        running: service.running === true,
+        gatewayState: service.gatewayState ?? null,
+        childPid: service.childPid ?? null,
+        issue: service.issue ?? null
+      }
+      : null
+  };
 }
 
 async function cleanupArtifacts(flags) {
   const olderThanDays = positiveIntegerFlag(flags, "older_than_days", 7);
-  const cutoffMs = Date.now() - olderThanDays * 24 * 60 * 60 * 1000;
+  const cutoffMs = Date.now() - olderThanDays * DAY_MS;
   const candidates = [];
 
   let entries = [];
@@ -109,7 +248,7 @@ async function cleanupArtifacts(flags) {
       name: entry.name,
       path,
       mtime: info.mtime.toISOString(),
-      ageDays: Math.max(0, Math.floor((Date.now() - info.mtimeMs) / (24 * 60 * 60 * 1000)))
+      ageDays: Math.max(0, Math.floor((Date.now() - info.mtimeMs) / DAY_MS))
     });
   }
 

--- a/src/commands/matrix-run.mjs
+++ b/src/commands/matrix-run.mjs
@@ -8,7 +8,7 @@ import {
   summarizePerformanceReceipt,
   validateBaselineExecutionFlags
 } from "../run/options.mjs";
-import { cleanupTargetRuntimeIfNeeded } from "../run/target-cleanup.mjs";
+import { runWithTargetRuntimeCleanup } from "../run/target-cleanup.mjs";
 import { evaluateGate, preflightGateRun } from "../matrix/gate.mjs";
 import { resolveMatrixPlan, validateMatrixScenarioRuns } from "../matrix/plan-resolution.mjs";
 import { profileSummary } from "../matrix/profile.mjs";
@@ -93,16 +93,16 @@ export async function runMatrixRun(flags) {
     });
   };
 
-  const records = await runEntries({
+  const { records, targetCleanup } = await runWithTargetRuntimeCleanup(targetPlan, {
+    execute: flags.execute === true,
+    timeoutMs: positiveIntegerFlag(flags, "timeout_ms", 120000),
+    retainOnError: flags.keep_env === true || flags.retain_on_failure === true
+  }, () => runEntries({
     entries,
     runEntry,
     execute: flags.execute === true,
     controls
-  });
-  const targetCleanup = await cleanupTargetRuntimeIfNeeded(targetPlan, records, {
-    execute: flags.execute === true,
-    timeoutMs: positiveIntegerFlag(flags, "timeout_ms", 120000)
-  });
+  }));
   const performance = buildPerformanceSummary(records, {
     repeat: controls.repeat,
     parallel: controls.parallel,

--- a/src/commands/matrix-run.mjs
+++ b/src/commands/matrix-run.mjs
@@ -64,7 +64,7 @@ export async function runMatrixRun(flags) {
     target: targetSelector,
     profile: profile.id,
   });
-  const runEntry = async (entry) => {
+  const runEntry = async (entry, onRecord) => {
     const context = buildRunContext({
       flags,
       registry,
@@ -89,7 +89,8 @@ export async function runMatrixRun(flags) {
       context,
       repeat: controls.repeat,
       progress,
-      skipReason: entry.skipReason
+      skipReason: entry.skipReason,
+      onRecord
     });
   };
 
@@ -97,9 +98,9 @@ export async function runMatrixRun(flags) {
     execute: flags.execute === true,
     timeoutMs: positiveIntegerFlag(flags, "timeout_ms", 120000),
     retainOnError: flags.keep_env === true || flags.retain_on_failure === true
-  }, () => runEntries({
+  }, (onRecord) => runEntries({
     entries,
-    runEntry,
+    runEntry: (entry) => runEntry(entry, onRecord),
     execute: flags.execute === true,
     controls
   }));

--- a/src/commands/report.mjs
+++ b/src/commands/report.mjs
@@ -103,6 +103,9 @@ async function compareReportsCommand(baselinePath, currentPath, flags) {
   const current = await readReport(currentPath);
   const thresholds = flags.thresholds ? JSON.parse(await readFile(resolveUserPath(flags.thresholds), "utf8")) : null;
   const comparison = compareReports(baseline, current, { thresholds });
+  if (!comparison.ok) {
+    process.exitCode = 1;
+  }
 
   if (flags.json) {
     console.log(JSON.stringify(comparison, null, 2));
@@ -113,9 +116,6 @@ async function compareReportsCommand(baselinePath, currentPath, flags) {
     console.log(flags.fixer ? renderCompareFixerSummary(comparison) : renderCompareSummary(comparison));
   } else {
     console.log(renderCompareAssessment(comparison, flags));
-  }
-  if (!comparison.ok) {
-    process.exitCode = 1;
   }
 }
 

--- a/src/commands/run.mjs
+++ b/src/commands/run.mjs
@@ -78,10 +78,16 @@ export async function runScenarioCommand(flags) {
     execute: context.execute,
     timeoutMs: context.timeoutMs,
     retainOnError: context.keepEnv || context.retainOnFailure
-  }, async () => {
+  }, async (onRecord) => {
     const runRecords = [];
     for (const scenario of scenarios) {
-      runRecords.push(...await runScenarioRepeats({ scenario, context, repeat, progress }));
+      runRecords.push(...await runScenarioRepeats({
+        scenario,
+        context,
+        repeat,
+        progress,
+        onRecord
+      }));
     }
     return runRecords;
   });

--- a/src/commands/run.mjs
+++ b/src/commands/run.mjs
@@ -7,7 +7,7 @@ import {
   summarizePerformanceReceipt,
   validateBaselineExecutionFlags
 } from "../run/options.mjs";
-import { cleanupTargetRuntimeIfNeeded } from "../run/target-cleanup.mjs";
+import { runWithTargetRuntimeCleanup } from "../run/target-cleanup.mjs";
 import {
   loadBaselineStore,
   resolveBaselinePath,
@@ -67,7 +67,6 @@ export async function runScenarioCommand(flags) {
     controls: { networkFrontage },
     timeoutMs: resolveRunTimeout(scenarios, flags)
   });
-  const records = [];
   const progress = createRunProgress({ flags, mode: context.execute ? "execution" : "dry-run" });
   progress.runStart({
     scenarioCount: scenarios.length * repeat,
@@ -75,12 +74,16 @@ export async function runScenarioCommand(flags) {
     target: targetSelector,
   });
 
-  for (const scenario of scenarios) {
-    records.push(...await runScenarioRepeats({ scenario, context, repeat, progress }));
-  }
-  const targetCleanup = await cleanupTargetRuntimeIfNeeded(targetPlan, records, {
+  const { records, targetCleanup } = await runWithTargetRuntimeCleanup(targetPlan, {
     execute: context.execute,
-    timeoutMs: context.timeoutMs
+    timeoutMs: context.timeoutMs,
+    retainOnError: context.keepEnv || context.retainOnFailure
+  }, async () => {
+    const runRecords = [];
+    for (const scenario of scenarios) {
+      runRecords.push(...await runScenarioRepeats({ scenario, context, repeat, progress }));
+    }
+    return runRecords;
   });
   const performance = buildPerformanceSummary(records, { repeat, regressionThresholds });
 

--- a/src/ocm/commands.mjs
+++ b/src/ocm/commands.mjs
@@ -19,12 +19,12 @@ export function ocmTargetSelector(targetPlan, commandKind = "start") {
 }
 
 export function ocmEnvDestroy(envName, options = {}) {
-  if (options.force === true && options.stateToken !== undefined) {
+  if (options.force === true && options.stateRevision !== undefined) {
     throw new Error("ocm env destroy cannot combine force with a state token");
   }
   if (
-    options.stateToken !== undefined &&
-    (typeof options.stateToken !== "string" || options.stateToken.length === 0)
+    options.stateRevision !== undefined &&
+    (typeof options.stateRevision !== "string" || options.stateRevision.length === 0)
   ) {
     throw new Error("ocm env destroy state token must be a non-empty string");
   }
@@ -32,8 +32,8 @@ export function ocmEnvDestroy(envName, options = {}) {
   if (options.json === true) args.push("--json");
   args.push("--yes");
   if (options.force === true) args.push("--force");
-  if (options.stateToken !== undefined) {
-    args.push("--if-state-token", quoteShell(options.stateToken));
+  if (options.stateRevision !== undefined) {
+    args.push("--if-state-token", quoteShell(options.stateRevision));
   }
   return args.join(" ");
 }

--- a/src/ocm/commands.mjs
+++ b/src/ocm/commands.mjs
@@ -42,6 +42,10 @@ export function ocmEnvDestroyPreviewJson(envName) {
   return `ocm env destroy ${quoteShell(envName)} --json`;
 }
 
+export function ocmEnvProtect(envName, protectedValue) {
+  return `ocm env protect ${quoteShell(envName)} ${protectedValue ? "on" : "off"} --json`;
+}
+
 export function ocmEnvExec(envName, args) {
   return `ocm env exec ${quoteShell(envName)} -- ${quoteArgs(args)}`;
 }

--- a/src/ocm/commands.mjs
+++ b/src/ocm/commands.mjs
@@ -49,6 +49,10 @@ export function ocmServiceStatusJson(envName) {
   return `ocm service status ${quoteShell(envName)} --json`;
 }
 
+export function ocmServiceStatusAllJson() {
+  return "ocm service status --all --json";
+}
+
 export function ocmEnvListJson() {
   return "ocm env list --json";
 }

--- a/src/ocm/commands.mjs
+++ b/src/ocm/commands.mjs
@@ -19,7 +19,27 @@ export function ocmTargetSelector(targetPlan, commandKind = "start") {
 }
 
 export function ocmEnvDestroy(envName, options = {}) {
-  return `ocm env destroy ${quoteShell(envName)} --yes${options.force === true ? " --force" : ""}`;
+  if (options.force === true && options.stateToken !== undefined) {
+    throw new Error("ocm env destroy cannot combine force with a state token");
+  }
+  if (
+    options.stateToken !== undefined &&
+    (typeof options.stateToken !== "string" || options.stateToken.length === 0)
+  ) {
+    throw new Error("ocm env destroy state token must be a non-empty string");
+  }
+  const args = ["ocm env destroy", quoteShell(envName)];
+  if (options.json === true) args.push("--json");
+  args.push("--yes");
+  if (options.force === true) args.push("--force");
+  if (options.stateToken !== undefined) {
+    args.push("--if-state-token", quoteShell(options.stateToken));
+  }
+  return args.join(" ");
+}
+
+export function ocmEnvDestroyPreviewJson(envName) {
+  return `ocm env destroy ${quoteShell(envName)} --json`;
 }
 
 export function ocmEnvExec(envName, args) {

--- a/src/ocm/commands.mjs
+++ b/src/ocm/commands.mjs
@@ -18,8 +18,8 @@ export function ocmTargetSelector(targetPlan, commandKind = "start") {
   throw new Error(`unsupported OCM target kind: ${targetPlan.kind}`);
 }
 
-export function ocmEnvDestroy(envName) {
-  return `ocm env destroy ${quoteShell(envName)} --yes`;
+export function ocmEnvDestroy(envName, options = {}) {
+  return `ocm env destroy ${quoteShell(envName)} --yes${options.force === true ? " --force" : ""}`;
 }
 
 export function ocmEnvExec(envName, args) {

--- a/src/reporting/render-cleanup.mjs
+++ b/src/reporting/render-cleanup.mjs
@@ -5,7 +5,7 @@ import {
   renderTable, repeat, withMargin,
 } from "../ui/index.mjs";
 
-export function renderCleanupEnvs({ envs, results, execute }, flags = {}, env = process.env, stream = process.stdout) {
+export function renderCleanupEnvs({ envs, results, execute, force = false, olderThanDays = 1 }, flags = {}, env = process.env, stream = process.stdout) {
   const ui = makeUi(flags, env, stream);
   const sections = [];
   const verdict = deriveEnvsVerdict({ envs, results, execute });
@@ -13,7 +13,7 @@ export function renderCleanupEnvs({ envs, results, execute }, flags = {}, env = 
     surface: "cleanup envs",
     verdict: verdict.label,
     headline: buildEnvsHeadline({ envs, results, execute }),
-    meta: execute ? "mode: execute" : "mode: dry-run",
+    meta: `older-than: ${olderThanDays}d ${ui.g.sep} mode: ${execute ? "execute" : "dry-run"}${force ? ` ${ui.g.sep} forced` : ""}`,
     ui,
   }));
   sections.push("");
@@ -87,7 +87,7 @@ function deriveArtifactsVerdict({ candidates, results, execute }) {
 
 function buildEnvsHeadline({ envs, results, execute }) {
   const eligible = eligibleEnvCount(envs);
-  if (!execute) return envs.length === 0 ? "nothing to do" : `${eligible} would be removed`;
+  if (!execute) return envs.length === 0 ? "nothing to do" : `${eligible} would be removed · ${envs.length - eligible} skipped`;
   const removed = results.filter((r) => r.status === 0).length;
   const failed = results.filter((r) => r.status !== 0).length;
   const missing = missingEnvResultCount(envs, results);
@@ -123,7 +123,7 @@ function renderEnvsKpi({ envs, results, execute }, ui) {
     ? results.filter((r) => r.status !== 0).length + missingEnvResultCount(envs, results)
     : 0;
   return kpiStrip([
-    { label: "Stale envs", value: String(envs.length), hint: "matched", tone: "neutral" },
+    { label: "Kova envs", value: String(envs.length), hint: `${envs.length - eligible} skipped`, tone: "neutral" },
     {
       label: execute ? "Removed" : "Would remove",
       value: execute ? String(removed) : String(eligible),
@@ -154,15 +154,23 @@ function renderArtifactsKpi({ candidates, results, execute }, ui) {
 function renderEnvsTable({ envs, results, execute }, ui) {
   const { c, g } = ui;
   const lines = [ruleSection("envs", ui.width, ui)];
-  const byEnv = new Map(results.map((r) => [extractEnvFromCommand(r.command), r]));
-  const rows = envs.map((env) => {
+  const byEnv = new Map(results.map((r) => [r.env ?? extractEnvFromCommand(r.command), r]));
+  const rows = envs.map((item) => {
+    const env = typeof item === "string" ? item : item.name;
+    const eligible = typeof item === "string" || item.eligible;
     const result = byEnv.get(env);
     let status;
-    if (!execute) status = c.dim("DRY-RUN");
+    if (!eligible) status = c.dim("SKIP");
+    else if (!execute) status = c.dim("DRY-RUN");
     else if (!result) status = c.dim("SKIP");
     else if (result.status === 0) status = c.ok("REMOVED");
     else status = c.err("FAILED");
-    const note = result?.timedOut ? c.warn("timed out") : (result?.durationMs != null ? c.dim(`${result.durationMs}ms`) : c.dim("—"));
+    const detail = typeof item === "string" ? null : item.reasons.join(", ");
+    const note = detail
+      ? c.dim(detail)
+      : result?.timedOut
+        ? c.warn("timed out")
+        : (result?.durationMs != null ? c.dim(`${result.durationMs}ms`) : c.dim("eligible"));
     return { status, env: c.bold(env), note };
   });
   lines.push(indentBlock(renderTable({

--- a/src/reporting/render-help.mjs
+++ b/src/reporting/render-help.mjs
@@ -205,12 +205,13 @@ const COMMANDS = [
     id: "cleanup", title: "kova cleanup",
     blurb: "Remove stale Kova-owned envs and run artifact dirs.",
     usage: [
-      "kova cleanup envs [--execute] [--json|--plain]",
+      "kova cleanup envs [--older-than-days <n>] [--execute] [--force] [--json|--plain]",
       "kova cleanup artifacts [--older-than-days <n>] [--execute] [--json|--plain]",
     ],
     flags: [
       ["--execute", "actually destroy/remove (default dry-run)"],
-      ["--older-than-days <n>", "artifacts only (default 7)"],
+      ["--older-than-days <n>", "minimum env/artifact age (defaults: envs 1, artifacts 7)"],
+      ["--force", "envs only: override age, retained, active, and unknown-state safeguards"],
       ["--json|--plain", "machine output / plain text"],
     ],
     examples: [

--- a/src/run/engine.mjs
+++ b/src/run/engine.mjs
@@ -2,7 +2,14 @@ import { buildDryRunRecord, buildSkippedRecord, executeScenario } from "../runne
 import { isNonPassingExecutionStatus } from "../statuses.mjs";
 import { positiveIntegerValue } from "./options.mjs";
 
-export async function runScenarioRepeats({ scenario, context, repeat, progress, skipReason = null }) {
+export async function runScenarioRepeats({
+  scenario,
+  context,
+  repeat,
+  progress,
+  skipReason = null,
+  onRecord
+}) {
   const total = positiveIntegerValue(repeat, "repeat");
   const records = [];
   for (let index = 1; index <= total; index += 1) {
@@ -17,6 +24,8 @@ export async function runScenarioRepeats({ scenario, context, repeat, progress, 
 
     if (skipReason) {
       const record = buildSkippedRecord(scenario, iterationContext, skipReason);
+      records.push(record);
+      onRecord?.(record);
       progress?.scenarioEnd?.({
         scenarioId: scenario.id,
         stateId: context.state?.id,
@@ -24,7 +33,6 @@ export async function runScenarioRepeats({ scenario, context, repeat, progress, 
         status: record.status,
         skipReason
       });
-      records.push(record);
       continue;
     }
 
@@ -37,6 +45,8 @@ export async function runScenarioRepeats({ scenario, context, repeat, progress, 
     const record = iterationContext.execute
       ? await executeScenario(scenario, iterationContext)
       : buildDryRunRecord(scenario, iterationContext);
+    records.push(record);
+    onRecord?.(record);
     progress?.scenarioEnd?.({
       scenarioId: scenario.id,
       stateId: context.state?.id,
@@ -44,7 +54,6 @@ export async function runScenarioRepeats({ scenario, context, repeat, progress, 
       status: record.status,
       skipReason: record.skipReason
     });
-    records.push(record);
   }
   return records;
 }

--- a/src/run/target-cleanup.mjs
+++ b/src/run/target-cleanup.mjs
@@ -71,12 +71,32 @@ export async function runWithTargetRuntimeCleanup(targetPlan, options, run) {
     if (primaryError === null) {
       throw cleanupError;
     }
+    throw new AggregateError(
+      [primaryError, cleanupError],
+      `${primaryError.message}; target runtime cleanup also failed: ${cleanupError.message}`,
+      { cause: primaryError }
+    );
   }
 
   if (primaryError !== null) {
+    if (targetCleanup?.status === "remove-failed") {
+      const cleanupError = targetRuntimeCleanupError(targetCleanup);
+      throw new AggregateError(
+        [primaryError, cleanupError],
+        `${primaryError.message}; target runtime cleanup also failed: ${cleanupError.message}`,
+        { cause: primaryError }
+      );
+    }
     throw primaryError;
   }
   return { records, targetCleanup };
+}
+
+function targetRuntimeCleanupError(targetCleanup) {
+  const detail = targetCleanup.result?.stderr?.trim() ||
+    targetCleanup.result?.stdout?.trim() ||
+    `exit ${targetCleanup.result?.status ?? "unknown"}`;
+  return new Error(detail);
 }
 
 function classifyTargetRuntimeCleanup(result, runtimeName) {

--- a/src/run/target-cleanup.mjs
+++ b/src/run/target-cleanup.mjs
@@ -8,11 +8,20 @@ export async function cleanupTargetRuntimeIfNeeded(targetPlan, records, options)
   }
 
   const command = ocmRuntimeRemoveJson(targetPlan.runtimeName);
-  if (!options.execute) {
+  if (options.execute !== true) {
     return {
       status: "planned",
       runtimeName: targetPlan.runtimeName,
       command
+    };
+  }
+
+  if (options.retainOnError === true) {
+    return {
+      status: "retained",
+      runtimeName: targetPlan.runtimeName,
+      command,
+      reason: "run failed and env retention was requested"
     };
   }
 
@@ -41,6 +50,33 @@ export async function cleanupTargetRuntimeIfNeeded(targetPlan, records, options)
       attempts: result.attempts ?? []
     }
   };
+}
+
+export async function runWithTargetRuntimeCleanup(targetPlan, options, run) {
+  let records = [];
+  let primaryError = null;
+  try {
+    records = await run();
+  } catch (error) {
+    primaryError = error;
+  }
+
+  let targetCleanup = null;
+  try {
+    targetCleanup = await cleanupTargetRuntimeIfNeeded(targetPlan, records, {
+      ...options,
+      retainOnError: primaryError !== null && options.retainOnError === true
+    });
+  } catch (cleanupError) {
+    if (primaryError === null) {
+      throw cleanupError;
+    }
+  }
+
+  if (primaryError !== null) {
+    throw primaryError;
+  }
+  return { records, targetCleanup };
 }
 
 function classifyTargetRuntimeCleanup(result, runtimeName) {

--- a/src/run/target-cleanup.mjs
+++ b/src/run/target-cleanup.mjs
@@ -56,7 +56,7 @@ export async function runWithTargetRuntimeCleanup(targetPlan, options, run) {
   let records = [];
   let primaryError = null;
   try {
-    records = await run();
+    records = await run((record) => records.push(record));
   } catch (error) {
     primaryError = error;
   }

--- a/src/run/teardown.mjs
+++ b/src/run/teardown.mjs
@@ -1,7 +1,8 @@
 import { buildAuthCleanupPhase } from "../auth.mjs";
 import { runCleanupCommand } from "../cleanup.mjs";
+import { runCommand } from "../commands.mjs";
 import { isMissingOcmResource } from "../ocm/missing-resource.mjs";
-import { ocmEnvDestroy } from "../ocm/commands.mjs";
+import { ocmEnvDestroy, ocmEnvProtect } from "../ocm/commands.mjs";
 import { stopNetworkFrontage } from "../network-frontage.mjs";
 import { executeAuthPhase } from "./auth-phase.mjs";
 import {
@@ -31,6 +32,11 @@ export async function teardownScenario(record, scenario, context, envName, artif
 
   const retainEnv = shouldRetainEnv(context, record);
   if (retainEnv) {
+    const protection = await runGuardedTeardownStages([{
+      id: "retention-protection",
+      run: () => protectRetainedEnv(record, context, envName)
+    }], options);
+    errors.push(...protection.errors);
     record.cleanup = "retained";
     record.retainedReason = context.keepEnv ? "keep-env" : "failure";
   }
@@ -135,6 +141,17 @@ async function cleanupEnv(record, context, envName) {
   record.cleanupResult = cleanup;
   if (record.cleanup === "destroy-failed") {
     blockPassingRecord(record);
+  }
+}
+
+async function protectRetainedEnv(record, context, envName) {
+  const result = await runCommand(ocmEnvProtect(envName, true), {
+    timeoutMs: context.timeoutMs
+  });
+  record.retentionProtectionResult = result;
+  if (result.status !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`;
+    throw new Error(`failed to protect retained env ${envName}: ${detail}`);
   }
 }
 

--- a/src/run/teardown.mjs
+++ b/src/run/teardown.mjs
@@ -32,11 +32,9 @@ export async function teardownScenario(record, scenario, context, envName, artif
 
   const retainEnv = shouldRetainEnv(context, record);
   if (retainEnv) {
-    const protection = await runGuardedTeardownStages([{
-      id: "retention-protection",
-      run: () => protectRetainedEnv(record, context, envName)
-    }], options);
-    errors.push(...protection.errors);
+    // The OCM protection is the destruction fence. Do not emit a retained
+    // record when that fence could not be established.
+    await protectRetainedEnv(record, context, envName);
     record.cleanup = "retained";
     record.retainedReason = context.keepEnv ? "keep-env" : "failure";
   }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19250,7 +19250,11 @@ JSON
     ;;
   env:destroy:*)
     if [ "$4" = "--json" ] && [ -z "$5" ]; then
-      printf '{"stateToken":"v1:%s"}\\n' "$3"
+      if [ "$KOVA_PREVIEW_ACTIVE" = "1" ]; then
+        printf '{"stateToken":"v1:%s","serviceInstalled":true,"serviceLoaded":true,"serviceRunning":true,"blockers":[],"steps":[{"kind":"service"},{"kind":"processes"}]}\\n' "$3"
+      else
+        printf '{"stateToken":"v1:%s","serviceInstalled":false,"serviceLoaded":false,"serviceRunning":false,"blockers":[],"steps":[]}\\n' "$3"
+      fi
       exit 0
     fi
     if [ "$KOVA_TOKEN_MISMATCH" = "1" ]; then
@@ -19311,7 +19315,7 @@ exit 2
     assertEqual(await fileExists(destroyLog), false, "execute string did not destroy envs");
 
     const stateChanged = await run("--execute", { KOVA_TOKEN_MISMATCH: "1" });
-    assertEqual(stateChanged.status, 0, "state-changed cleanup receipt exit");
+    assertEqual(stateChanged.status !== 0, true, "state-changed cleanup receipt exit");
     const stateChangedReceipt = JSON.parse(stateChanged.stdout);
     assertEqual(stateChangedReceipt.results[0]?.status, 1, "state token mismatch blocks destroy");
     assertEqual(stateChangedReceipt.results[0]?.stage, "destroy", "state token mismatch occurs at guarded destroy");
@@ -19321,6 +19325,13 @@ exit 2
       "cleanup applies the preview state token"
     );
     assertEqual(await fileExists(destroyLog), false, "state token mismatch performs no teardown");
+
+    const activePreview = await run("--execute", { KOVA_PREVIEW_ACTIVE: "1" });
+    assertEqual(activePreview.status !== 0, true, "active preview cleanup receipt exit");
+    const activePreviewReceipt = JSON.parse(activePreview.stdout);
+    assertEqual(activePreviewReceipt.results[0]?.status, 1, "active destroy preview blocks destroy");
+    assertEqual(activePreviewReceipt.results[0]?.stage, "precondition", "active preview fails precondition");
+    assertEqual(await fileExists(destroyLog), false, "active preview performs no teardown");
 
     const execute = await run("--execute");
     assertEqual(execute.status, 0, "cleanup safety execute exit");
@@ -19343,7 +19354,7 @@ exit 2
       status: "PASS",
       command: "exercise cleanup env eligibility, execute guard, and force override",
       durationMs: dry.durationMs + unknownRetention.durationMs + falseExecute.durationMs +
-        stateChanged.durationMs + execute.durationMs + forced.durationMs
+        stateChanged.durationMs + activePreview.durationMs + execute.durationMs + forced.durationMs
     };
   } catch (error) {
     return {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -14235,7 +14235,7 @@ async function networkFrontagePartialStartupCleanupInvariantCheck() {
     const teardownSource = await readFile("src/run/teardown.mjs", "utf8");
     const retentionPattern = /id: "network-frontage-cleanup"[\s\S]+const retainEnv = shouldRetainEnv\(context, record\)/;
     assertEqual(retentionPattern.test(teardownSource), true, "retain-on-failure is computed after network frontage cleanup can update status");
-    const protectionPattern = /const retainEnv = shouldRetainEnv\(context, record\);[\s\S]+id: "retention-protection"[\s\S]+protectRetainedEnv\(record, context, envName\)[\s\S]+record\.cleanup = "retained"/;
+    const protectionPattern = /const retainEnv = shouldRetainEnv\(context, record\);[\s\S]+await protectRetainedEnv\(record, context, envName\);[\s\S]+record\.cleanup = "retained"/;
     assertEqual(protectionPattern.test(teardownSource), true, "retained env is protected before retention is published");
     assertEqual(
       ocmEnvProtect("kova-retained", true),
@@ -19404,6 +19404,20 @@ exit 2
     assertEqual((await readFile(destroyLog, "utf8")).trim(), "kova-stale", "partial apply executes once");
     await rm(destroyLog, { force: true });
 
+    const forcedPartialApply = await run("--execute --force", { KOVA_PARTIAL_APPLY: "1" });
+    assertEqual(forcedPartialApply.status !== 0, true, "forced partial apply exits nonzero");
+    const forcedPartialReceipt = JSON.parse(forcedPartialApply.stdout);
+    assertEqual(
+      forcedPartialReceipt.results.every((result) =>
+        result.code === "partial_apply" &&
+        result.stage === "partial-apply" &&
+        result.attempts?.length === 1
+      ),
+      true,
+      "forced partial apply is structured and never retried"
+    );
+    await rm(destroyLog, { force: true });
+
     const execute = await run("--execute");
     assertEqual(execute.status, 0, "cleanup safety execute exit");
     assertEqual((await readFile(destroyLog, "utf8")).trim(), "kova-stale", "default cleanup destroys only eligible env");
@@ -19426,7 +19440,8 @@ exit 2
       command: "exercise cleanup env eligibility, execute guard, and force override",
       durationMs: dry.durationMs + unknownRetention.durationMs + falseExecute.durationMs +
         stateChanged.durationMs + activePreview.durationMs + recentlyUsed.durationMs +
-        newlyRetained.durationMs + partialApply.durationMs + execute.durationMs + forced.durationMs
+        newlyRetained.durationMs + partialApply.durationMs + forcedPartialApply.durationMs +
+        execute.durationMs + forced.durationMs
     };
   } catch (error) {
     return {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19499,16 +19499,6 @@ exit 2
   }
 }
 
-async function fileExists(path) {
-  try {
-    await stat(path);
-    return true;
-  } catch (error) {
-    if (error?.code === "ENOENT") return false;
-    throw error;
-  }
-}
-
 function markdownFailureCardsCheck() {
   try {
     const rendered = renderMarkdownReport({

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19270,6 +19270,10 @@ JSON
     exit 0
     ;;
   service:status:--all)
+    if [ "$KOVA_INVALID_SERVICE_INVENTORY" = "1" ]; then
+      echo '{"services":[{"envName":"kova-stale","gatewayState":"stopped"}]}'
+      exit 0
+    fi
     cat <<'JSON'
 {"services":[
   {"envName":"kova-stale","installed":false,"desiredRunning":false,"running":false,"gatewayState":"stopped","childPid":null},
@@ -19290,10 +19294,14 @@ JSON
       if [ "$KOVA_REVALIDATE_RETAINED" = "1" ]; then
         printf '{"records":[{"envName":"%s","cleanup":"retained"}]}\\n' "$3" > "$KOVA_RETENTION_REPORT"
       fi
+      if [ "$KOVA_PREVIEW_MALFORMED" = "1" ]; then
+        printf '{"stateToken":"v1:%s","serviceInstalled":true,"serviceLoaded":false,"serviceRunning":false,"processCount":0,"blockers":[],"steps":[null]}\\n' "$3"
+        exit 0
+      fi
       if [ "$KOVA_PREVIEW_ACTIVE" = "1" ]; then
-        printf '{"stateToken":"v1:%s","serviceInstalled":true,"serviceLoaded":true,"serviceRunning":true,"blockers":[],"steps":[{"kind":"service"},{"kind":"processes"}]}\\n' "$3"
+        printf '{"stateToken":"v1:%s","serviceInstalled":true,"serviceLoaded":true,"serviceRunning":true,"processCount":1,"blockers":[],"steps":[{"kind":"service","description":"disable service"},{"kind":"processes","description":"terminate processes"}]}\\n' "$3"
       else
-        printf '{"stateToken":"v1:%s","serviceInstalled":true,"serviceLoaded":false,"serviceRunning":false,"blockers":[],"steps":[{"kind":"service"}]}\\n' "$3"
+        printf '{"stateToken":"v1:%s","serviceInstalled":true,"serviceLoaded":false,"serviceRunning":false,"processCount":0,"blockers":[],"steps":[{"kind":"service","description":"disable service"}]}\\n' "$3"
       fi
       exit 0
     fi
@@ -19365,6 +19373,12 @@ exit 2
     assertEqual(invalidShapePlan.candidates.length, 0, "invalid retention shape blocks cleanup");
     await rm(invalidShapeReport);
 
+    const invalidServiceInventory = await run("", { KOVA_INVALID_SERVICE_INVENTORY: "1" });
+    assertEqual(invalidServiceInventory.status, 0, "invalid service inventory dry-run exit");
+    const invalidServicePlan = JSON.parse(invalidServiceInventory.stdout);
+    assertEqual(invalidServicePlan.serviceInventory?.ok, false, "invalid service shape fails inventory");
+    assertEqual(invalidServicePlan.candidates.length, 0, "invalid service shape blocks cleanup");
+
     const falseExecute = await run("--execute=false");
     assertEqual(falseExecute.status, 0, "non-boolean execute exit");
     assertEqual(JSON.parse(falseExecute.stdout).execute, false, "execute string does not authorize cleanup");
@@ -19388,6 +19402,13 @@ exit 2
     assertEqual(activePreviewReceipt.results[0]?.status, 1, "active destroy preview blocks destroy");
     assertEqual(activePreviewReceipt.results[0]?.stage, "precondition", "active preview fails precondition");
     assertEqual(await fileExists(destroyLog), false, "active preview performs no teardown");
+
+    const malformedPreview = await run("--execute", { KOVA_PREVIEW_MALFORMED: "1" });
+    assertEqual(malformedPreview.status !== 0, true, "malformed preview cleanup receipt exit");
+    const malformedPreviewReceipt = JSON.parse(malformedPreview.stdout);
+    assertEqual(malformedPreviewReceipt.results[0]?.code, "unsafe_preview", "malformed preview is unsafe");
+    assertEqual(malformedPreviewReceipt.results[0]?.stage, "precondition", "malformed preview stops before apply");
+    assertEqual(await fileExists(destroyLog), false, "malformed preview performs no teardown");
 
     const recentlyUsed = await run("--execute", { KOVA_REVALIDATE_RECENT: "1" });
     assertEqual(recentlyUsed.status !== 0, true, "recent eligibility refresh exits nonzero");
@@ -19447,9 +19468,12 @@ exit 2
       id: "cleanup-env-safety",
       status: "PASS",
       command: "exercise cleanup env eligibility, execute guard, and force override",
-      durationMs: dry.durationMs + unknownRetention.durationMs + falseExecute.durationMs +
+      durationMs: dry.durationMs + unknownRetention.durationMs +
+        invalidShapeRetention.durationMs + invalidServiceInventory.durationMs +
+        falseExecute.durationMs +
         stateChanged.durationMs + activePreview.durationMs + recentlyUsed.durationMs +
-        newlyRetained.durationMs + partialApply.durationMs + forcedPartialApply.durationMs +
+        malformedPreview.durationMs + newlyRetained.durationMs +
+        partialApply.durationMs + forcedPartialApply.durationMs +
         execute.durationMs + forced.durationMs
     };
   } catch (error) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -943,6 +943,8 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       assertEqual(data.schemaVersion, "kova.cleanup.envs.v1", "cleanup schema");
       assertEqual(data.execute, false, "cleanup execute flag");
       assertArray(data.envs, "cleanup envs");
+      assertEqual(data.envs.every((env) => typeof env === "string"), true, "cleanup v1 envs stay names");
+      assertArray(data.classifications, "cleanup classifications");
     }));
     checks.push(await cleanupEnvSafetyCheck(tmp));
     checks.push(await cleanupArtifactsCheck(tmp));
@@ -19264,11 +19266,12 @@ exit 2
     assertEqual(dry.status, 0, "cleanup safety dry-run exit");
     const plan = JSON.parse(dry.stdout);
     assertEqual(plan.candidates.join(","), "kova-stale", "only inactive stale env eligible");
-    assertEqual(plan.envs.find((item) => item.name === "kova-recent")?.reasons.includes("too-recent"), true, "recent env skipped");
-    assertEqual(plan.envs.find((item) => item.name === "kova-protected")?.reasons.includes("protected"), true, "protected env skipped");
-    assertEqual(plan.envs.find((item) => item.name === "kova-retained")?.reasons.includes("retained-by-run"), true, "retained env skipped");
-    assertEqual(plan.envs.find((item) => item.name === "kova-active")?.reasons.includes("active-service"), true, "active env skipped");
-    assertEqual(plan.envs.find((item) => item.name === "kova-unknown")?.reasons.includes("unknown-service-state"), true, "unknown service env skipped");
+    assertEqual(plan.envs.every((item) => typeof item === "string"), true, "cleanup v1 envs remain names");
+    assertEqual(plan.classifications.find((item) => item.name === "kova-recent")?.reasons.includes("too-recent"), true, "recent env skipped");
+    assertEqual(plan.classifications.find((item) => item.name === "kova-protected")?.reasons.includes("protected"), true, "protected env skipped");
+    assertEqual(plan.classifications.find((item) => item.name === "kova-retained")?.reasons.includes("retained-by-run"), true, "retained env skipped");
+    assertEqual(plan.classifications.find((item) => item.name === "kova-active")?.reasons.includes("active-service"), true, "active env skipped");
+    assertEqual(plan.classifications.find((item) => item.name === "kova-unknown")?.reasons.includes("unknown-service-state"), true, "unknown service env skipped");
 
     const malformedReport = join(reports, "malformed.json");
     await writeFile(malformedReport, "{not-json\n", "utf8");
@@ -19278,7 +19281,7 @@ exit 2
     assertEqual(unknownRetentionPlan.retentionInventory?.ok, false, "malformed report fails retention inventory");
     assertEqual(unknownRetentionPlan.candidates.length, 0, "unknown retention state blocks cleanup");
     assertEqual(
-      unknownRetentionPlan.envs.every((item) => item.reasons.includes("unknown-retention-state")),
+      unknownRetentionPlan.classifications.every((item) => item.reasons.includes("unknown-retention-state")),
       true,
       "unknown retention state is recorded for every env"
     );

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -8432,6 +8432,10 @@ async function localBuildRuntimeExceptionCleanupCheck(tmp) {
 case "$1:$2" in
   runtime:remove)
     printf '%s\\n' "$*" >> "$KOVA_MOCK_REMOVE_LOG"
+    if [ "$KOVA_MOCK_REMOVE_FAIL" = "1" ]; then
+      echo "runtime removal failed" >&2
+      exit 2
+    fi
     echo '{"removed":true}'
     exit 0
     ;;
@@ -8443,6 +8447,7 @@ exit 2
 
   const previousPath = process.env.PATH;
   const previousLog = process.env.KOVA_MOCK_REMOVE_LOG;
+  const previousRemoveFail = process.env.KOVA_MOCK_REMOVE_FAIL;
   process.env.PATH = `${binDir}:${previousPath}`;
   process.env.KOVA_MOCK_REMOVE_LOG = removeLog;
   const targetPlan = {
@@ -8482,6 +8487,28 @@ exit 2
     assertEqual(retainedError?.message, "retained run failure", "retained target preserves original error");
     assertEqual(await fileExists(removeLog), false, "retention flags keep target runtime after exception");
 
+    process.env.KOVA_MOCK_REMOVE_FAIL = "1";
+    let combinedError;
+    try {
+      await runWithTargetRuntimeCleanup(targetPlan, {
+        execute: true,
+        timeoutMs: 30000,
+        retainOnError: false
+      }, async () => {
+        throw new Error("primary run failure");
+      });
+    } catch (error) {
+      combinedError = error;
+    }
+    assertEqual(combinedError instanceof AggregateError, true, "run and cleanup failures are aggregated");
+    assertEqual(
+      combinedError?.message,
+      "primary run failure; target runtime cleanup also failed: runtime removal failed",
+      "combined failure names the primary and cleanup errors"
+    );
+    assertEqual(combinedError?.errors?.[0]?.message, "primary run failure", "aggregate preserves primary error");
+    assertEqual(combinedError?.errors?.[1]?.message, "runtime removal failed", "aggregate exposes cleanup error");
+
     return {
       id: "local-build-runtime-exception-cleanup",
       status: "PASS",
@@ -8502,6 +8529,11 @@ exit 2
       delete process.env.KOVA_MOCK_REMOVE_LOG;
     } else {
       process.env.KOVA_MOCK_REMOVE_LOG = previousLog;
+    }
+    if (previousRemoveFail === undefined) {
+      delete process.env.KOVA_MOCK_REMOVE_FAIL;
+    } else {
+      process.env.KOVA_MOCK_REMOVE_FAIL = previousRemoveFail;
     }
   }
 }
@@ -19238,6 +19270,20 @@ exit 2
     assertEqual(plan.envs.find((item) => item.name === "kova-active")?.reasons.includes("active-service"), true, "active env skipped");
     assertEqual(plan.envs.find((item) => item.name === "kova-unknown")?.reasons.includes("unknown-service-state"), true, "unknown service env skipped");
 
+    const malformedReport = join(reports, "malformed.json");
+    await writeFile(malformedReport, "{not-json\n", "utf8");
+    const unknownRetention = await run("");
+    assertEqual(unknownRetention.status, 0, "unknown retention dry-run exit");
+    const unknownRetentionPlan = JSON.parse(unknownRetention.stdout);
+    assertEqual(unknownRetentionPlan.retentionInventory?.ok, false, "malformed report fails retention inventory");
+    assertEqual(unknownRetentionPlan.candidates.length, 0, "unknown retention state blocks cleanup");
+    assertEqual(
+      unknownRetentionPlan.envs.every((item) => item.reasons.includes("unknown-retention-state")),
+      true,
+      "unknown retention state is recorded for every env"
+    );
+    await rm(malformedReport);
+
     const falseExecute = await run("--execute=false");
     assertEqual(falseExecute.status, 0, "non-boolean execute exit");
     assertEqual(JSON.parse(falseExecute.stdout).execute, false, "execute string does not authorize cleanup");
@@ -19263,7 +19309,7 @@ exit 2
       id: "cleanup-env-safety",
       status: "PASS",
       command: "exercise cleanup env eligibility, execute guard, and force override",
-      durationMs: dry.durationMs + falseExecute.durationMs + execute.durationMs + forced.durationMs
+      durationMs: dry.durationMs + unknownRetention.durationMs + falseExecute.durationMs + execute.durationMs + forced.durationMs
     };
   } catch (error) {
     return {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -943,6 +943,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       assertEqual(data.execute, false, "cleanup execute flag");
       assertArray(data.envs, "cleanup envs");
     }));
+    checks.push(await cleanupEnvSafetyCheck(tmp));
     checks.push(await cleanupArtifactsCheck(tmp));
     checks.push(await mockProviderProcessSafetyCheck(tmp));
     checks.push(await diagnosticArtifactIdentityCheck(tmp));
@@ -19074,6 +19075,122 @@ async function cleanupRetryCheck(tmp) {
       durationMs: result.durationMs,
       message: error.message
     };
+  }
+}
+
+async function cleanupEnvSafetyCheck(tmp) {
+  const home = join(tmp, "cleanup-env-safety-home");
+  const binDir = join(tmp, "cleanup-env-safety-bin");
+  const reports = join(home, "reports");
+  const destroyLog = join(tmp, "cleanup-env-destroy.log");
+  const ocmPath = join(binDir, "ocm");
+  const old = "2020-01-01T00:00:00Z";
+  const recent = new Date().toISOString();
+  await mkdir(reports, { recursive: true });
+  await mkdir(binDir, { recursive: true });
+  await writeFile(join(reports, "retained.json"), `${JSON.stringify({
+    records: [{ envName: "kova-retained", cleanup: "retained" }]
+  })}\n`, "utf8");
+  await writeFile(ocmPath, `#!/bin/sh
+case "$1:$2:$3" in
+  env:list:--json)
+    cat <<'JSON'
+[
+  {"name":"kova-stale","createdAt":"${old}","lastUsedAt":null,"protected":false},
+  {"name":"kova-recent","createdAt":"${recent}","lastUsedAt":"${recent}","protected":false},
+  {"name":"kova-protected","createdAt":"${old}","lastUsedAt":null,"protected":true},
+  {"name":"kova-retained","createdAt":"${old}","lastUsedAt":null,"protected":false},
+  {"name":"kova-active","createdAt":"${old}","lastUsedAt":null,"protected":false},
+  {"name":"kova-unknown","createdAt":"${old}","lastUsedAt":null,"protected":false},
+  {"name":"durable-user-env","createdAt":"${old}","lastUsedAt":null,"protected":false}
+]
+JSON
+    exit 0
+    ;;
+  service:status:--all)
+    cat <<'JSON'
+{"services":[
+  {"envName":"kova-stale","installed":false,"desiredRunning":false,"running":false,"gatewayState":"stopped","childPid":null},
+  {"envName":"kova-recent","installed":false,"desiredRunning":false,"running":false,"gatewayState":"stopped","childPid":null},
+  {"envName":"kova-protected","installed":false,"desiredRunning":false,"running":false,"gatewayState":"stopped","childPid":null},
+  {"envName":"kova-retained","installed":false,"desiredRunning":false,"running":false,"gatewayState":"stopped","childPid":null},
+  {"envName":"kova-active","installed":true,"desiredRunning":true,"running":true,"gatewayState":"healthy","childPid":123}
+]}
+JSON
+    exit 0
+    ;;
+  env:destroy:*)
+    printf '%s\\n' "$3" >> "$KOVA_DESTROY_LOG"
+    echo '{"destroyed":true}'
+    exit 0
+    ;;
+esac
+echo "unhandled mock ocm command: $*" >&2
+exit 2
+`, "utf8");
+  await chmod(ocmPath, 0o755);
+
+  const env = {
+    PATH: `${binDir}:${process.env.PATH}`,
+    KOVA_HOME: home,
+    KOVA_DESTROY_LOG: destroyLog
+  };
+  const run = (args) => runCommand(`node bin/kova.mjs cleanup envs ${args} --json`, {
+    env,
+    timeoutMs: 30000,
+    maxOutputChars: 1000000
+  });
+
+  try {
+    const dry = await run("");
+    assertEqual(dry.status, 0, "cleanup safety dry-run exit");
+    const plan = JSON.parse(dry.stdout);
+    assertEqual(plan.candidates.join(","), "kova-stale", "only inactive stale env eligible");
+    assertEqual(plan.envs.find((item) => item.name === "kova-recent")?.reasons.includes("too-recent"), true, "recent env skipped");
+    assertEqual(plan.envs.find((item) => item.name === "kova-protected")?.reasons.includes("protected"), true, "protected env skipped");
+    assertEqual(plan.envs.find((item) => item.name === "kova-retained")?.reasons.includes("retained-by-run"), true, "retained env skipped");
+    assertEqual(plan.envs.find((item) => item.name === "kova-active")?.reasons.includes("active-service"), true, "active env skipped");
+    assertEqual(plan.envs.find((item) => item.name === "kova-unknown")?.reasons.includes("unknown-service-state"), true, "unknown service env skipped");
+
+    const falseExecute = await run("--execute=false");
+    assertEqual(falseExecute.status, 0, "non-boolean execute exit");
+    assertEqual(JSON.parse(falseExecute.stdout).execute, false, "execute string does not authorize cleanup");
+    assertEqual(await fileExists(destroyLog), false, "execute string did not destroy envs");
+
+    const execute = await run("--execute");
+    assertEqual(execute.status, 0, "cleanup safety execute exit");
+    assertEqual((await readFile(destroyLog, "utf8")).trim(), "kova-stale", "default cleanup destroys only eligible env");
+
+    await rm(destroyLog, { force: true });
+    const forced = await run("--execute --force");
+    assertEqual(forced.status, 0, "forced cleanup exit");
+    assertEqual(JSON.parse(forced.stdout).candidates.length, 6, "force overrides cleanup safeguards");
+    assertEqual((await readFile(destroyLog, "utf8")).trim().split("\n").length, 6, "force destroys every Kova env");
+
+    return {
+      id: "cleanup-env-safety",
+      status: "PASS",
+      command: "exercise cleanup env eligibility, execute guard, and force override",
+      durationMs: dry.durationMs + falseExecute.durationMs + execute.durationMs + forced.durationMs
+    };
+  } catch (error) {
+    return {
+      id: "cleanup-env-safety",
+      status: "FAIL",
+      command: "exercise cleanup env eligibility, execute guard, and force override",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function fileExists(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
   }
 }
 

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -173,6 +173,7 @@ import {
 import {
   ocmAt,
   ocmEnvDestroy,
+  ocmEnvDestroyPreviewJson,
   ocmEnvExec,
   ocmEnvExecShell,
   ocmLogs,
@@ -1848,6 +1849,12 @@ function ocmCommandBuildersCheck() {
     assertEqual(ocmServiceStatusJson("Team Env"), "ocm service status 'Team Env' --json", "quoted service status");
     assertEqual(ocmLogs("Team Env", { tail: 25, raw: true }), "ocm logs 'Team Env' --tail '25' --raw", "quoted logs");
     assertEqual(ocmEnvDestroy("Team Env"), "ocm env destroy 'Team Env' --yes", "quoted env destroy");
+    assertEqual(ocmEnvDestroyPreviewJson("Team Env"), "ocm env destroy 'Team Env' --json", "quoted env destroy preview");
+    assertEqual(
+      ocmEnvDestroy("Team Env", { json: true, stateToken: "v1:r1" }),
+      "ocm env destroy 'Team Env' --json --yes --if-state-token 'v1:r1'",
+      "quoted guarded env destroy"
+    );
     assertEqual(ocmAt("Team Env", ["status"]), "ocm @'Team Env' -- 'status'", "quoted at command");
     assertEqual(
       ocmEnvExec("Team Env", ["node", "support/script.mjs", "--name", "O'Hara"]),
@@ -19242,6 +19249,14 @@ JSON
     exit 0
     ;;
   env:destroy:*)
+    if [ "$4" = "--json" ] && [ -z "$5" ]; then
+      printf '{"stateToken":"v1:%s"}\\n' "$3"
+      exit 0
+    fi
+    if [ "$KOVA_TOKEN_MISMATCH" = "1" ]; then
+      printf '{"code":"state_changed","removed":false,"stateToken":"v1:changed"}\\n'
+      exit 1
+    fi
     printf '%s\\n' "$3" >> "$KOVA_DESTROY_LOG"
     echo '{"destroyed":true}'
     exit 0
@@ -19257,8 +19272,8 @@ exit 2
     KOVA_HOME: home,
     KOVA_DESTROY_LOG: destroyLog
   };
-  const run = (args) => runCommand(`node bin/kova.mjs cleanup envs ${args} --json`, {
-    env,
+  const run = (args, envOverrides = {}) => runCommand(`node bin/kova.mjs cleanup envs ${args} --json`, {
+    env: { ...env, ...envOverrides },
     timeoutMs: 30000,
     maxOutputChars: 1000000
   });
@@ -19295,6 +19310,18 @@ exit 2
     assertEqual(JSON.parse(falseExecute.stdout).execute, false, "execute string does not authorize cleanup");
     assertEqual(await fileExists(destroyLog), false, "execute string did not destroy envs");
 
+    const stateChanged = await run("--execute", { KOVA_TOKEN_MISMATCH: "1" });
+    assertEqual(stateChanged.status, 0, "state-changed cleanup receipt exit");
+    const stateChangedReceipt = JSON.parse(stateChanged.stdout);
+    assertEqual(stateChangedReceipt.results[0]?.status, 1, "state token mismatch blocks destroy");
+    assertEqual(stateChangedReceipt.results[0]?.stage, "destroy", "state token mismatch occurs at guarded destroy");
+    assertEqual(
+      stateChangedReceipt.results[0]?.command.includes("--if-state-token 'v1:kova-stale'"),
+      true,
+      "cleanup applies the preview state token"
+    );
+    assertEqual(await fileExists(destroyLog), false, "state token mismatch performs no teardown");
+
     const execute = await run("--execute");
     assertEqual(execute.status, 0, "cleanup safety execute exit");
     assertEqual((await readFile(destroyLog, "utf8")).trim(), "kova-stale", "default cleanup destroys only eligible env");
@@ -19315,7 +19342,8 @@ exit 2
       id: "cleanup-env-safety",
       status: "PASS",
       command: "exercise cleanup env eligibility, execute guard, and force override",
-      durationMs: dry.durationMs + unknownRetention.durationMs + falseExecute.durationMs + execute.durationMs + forced.durationMs
+      durationMs: dry.durationMs + unknownRetention.durationMs + falseExecute.durationMs +
+        stateChanged.durationMs + execute.durationMs + forced.durationMs
     };
   } catch (error) {
     return {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -67,6 +67,7 @@ import { runEntries } from "./run/engine.mjs";
 import { executeStateLifecycleSteps } from "./run/state-lifecycle.mjs";
 import { executeTargetSetup } from "./run/target-setup.mjs";
 import { runGuardedTeardownStages } from "./run/teardown.mjs";
+import { runWithTargetRuntimeCleanup } from "./run/target-cleanup.mjs";
 import { loadProcessRoles } from "./registries/process-roles.mjs";
 import { validateProfileShape } from "./registries/profiles.mjs";
 import { validateScenarioShape } from "./registries/scenarios.mjs";
@@ -1089,6 +1090,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     ));
     checks.push(await localBuildRuntimeCleanupCheck(tmp));
     checks.push(await localBuildRuntimeAlreadyAbsentCleanupCheck(tmp));
+    checks.push(await localBuildRuntimeExceptionCleanupCheck(tmp));
     checks.push(await localBuildProfileEnvCheck(tmp, scope));
     checks.push(await localBuildParallelSingleFlightCheck(tmp));
     checks.push(defaultGatewayResourceRoleCheck());
@@ -8417,6 +8419,89 @@ exit 2
       durationMs: result.durationMs,
       message: error.message
     };
+  }
+}
+
+async function localBuildRuntimeExceptionCleanupCheck(tmp) {
+  const binDir = join(tmp, "mock-bin-runtime-exception");
+  const removeLog = join(tmp, "mock-runtime-exception-remove.log");
+  const ocmPath = join(binDir, "ocm");
+  await mkdir(binDir, { recursive: true });
+  await writeFile(ocmPath, `#!/bin/sh
+case "$1:$2" in
+  runtime:remove)
+    printf '%s\\n' "$*" >> "$KOVA_MOCK_REMOVE_LOG"
+    echo '{"removed":true}'
+    exit 0
+    ;;
+esac
+echo "unhandled mock ocm command: $*" >&2
+exit 2
+`, "utf8");
+  await chmod(ocmPath, 0o755);
+
+  const previousPath = process.env.PATH;
+  const previousLog = process.env.KOVA_MOCK_REMOVE_LOG;
+  process.env.PATH = `${binDir}:${previousPath}`;
+  process.env.KOVA_MOCK_REMOVE_LOG = removeLog;
+  const targetPlan = {
+    kind: "local-build",
+    runtimeName: "kova-local-exception"
+  };
+
+  try {
+    let original;
+    try {
+      await runWithTargetRuntimeCleanup(targetPlan, {
+        execute: true,
+        timeoutMs: 30000,
+        retainOnError: false
+      }, async () => {
+        throw new Error("original run failure");
+      });
+    } catch (error) {
+      original = error;
+    }
+    assertEqual(original?.message, "original run failure", "target cleanup preserves original error");
+    assertEqual((await readFile(removeLog, "utf8")).trim().split("\n").length, 1, "target runtime removed exactly once");
+
+    await rm(removeLog, { force: true });
+    let retainedError;
+    try {
+      await runWithTargetRuntimeCleanup(targetPlan, {
+        execute: true,
+        timeoutMs: 30000,
+        retainOnError: true
+      }, async () => {
+        throw new Error("retained run failure");
+      });
+    } catch (error) {
+      retainedError = error;
+    }
+    assertEqual(retainedError?.message, "retained run failure", "retained target preserves original error");
+    assertEqual(await fileExists(removeLog), false, "retention flags keep target runtime after exception");
+
+    return {
+      id: "local-build-runtime-exception-cleanup",
+      status: "PASS",
+      command: "exercise exception-safe target runtime cleanup",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "local-build-runtime-exception-cleanup",
+      status: "FAIL",
+      command: "exercise exception-safe target runtime cleanup",
+      durationMs: 0,
+      message: error.message
+    };
+  } finally {
+    process.env.PATH = previousPath;
+    if (previousLog === undefined) {
+      delete process.env.KOVA_MOCK_REMOVE_LOG;
+    } else {
+      process.env.KOVA_MOCK_REMOVE_LOG = previousLog;
+    }
   }
 }
 

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1099,6 +1099,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(compareMetricOrderingCheck());
     checks.push(compareGatewayRssDedupeCheck());
     checks.push(resourceContractCompareCheck());
+    checks.push(await reportCompareExitStatusCheck());
     checks.push(fixtureAccountingRenderCheck());
 
     const receiptCheck = await jsonCommandCheck(
@@ -20849,6 +20850,51 @@ function zeroLogMetrics() {
     eventLoopDelayMentions: 0,
     v8DiagnosticMentions: 0
   };
+}
+
+async function reportCompareExitStatusCheck() {
+  const modes = [
+    { name: "dashboard", flag: "" },
+    { name: "plain", flag: "--plain" },
+    { name: "fixer", flag: "--fixer" },
+    { name: "json", flag: "--json" }
+  ];
+  let durationMs = 0;
+  try {
+    for (const mode of modes) {
+      const command = [
+        "node bin/kova.mjs report compare",
+        "tests/fixtures/reports/pass.json",
+        "tests/fixtures/reports/fail.json",
+        mode.flag
+      ].filter(Boolean).join(" ");
+      const result = await runCommand(command, {
+        timeoutMs: 30000,
+        maxOutputChars: 1000000
+      });
+      durationMs += result.durationMs;
+      assertEqual(result.status, 1, `${mode.name} failed comparison exit`);
+      if (mode.name === "json") {
+        assertEqual(JSON.parse(result.stdout).ok, false, "JSON failed comparison body");
+      } else {
+        assertEqual(result.stdout.trim().length > 0, true, `${mode.name} failed comparison body`);
+      }
+    }
+    return {
+      id: "report-compare-exit-status",
+      status: "PASS",
+      command: "verify failed comparison exits across render formats",
+      durationMs
+    };
+  } catch (error) {
+    return {
+      id: "report-compare-exit-status",
+      status: "FAIL",
+      command: "verify failed comparison exits across render formats",
+      durationMs,
+      message: error.message
+    };
+  }
 }
 
 async function reportRunIdReferenceCheck(tmp) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -8496,6 +8496,26 @@ exit 2
     assertEqual(retainedError?.message, "retained run failure", "retained target preserves original error");
     assertEqual(await fileExists(removeLog), false, "retention flags keep target runtime after exception");
 
+    let partialRetainedError;
+    try {
+      await runWithTargetRuntimeCleanup(targetPlan, {
+        execute: true,
+        timeoutMs: 30000,
+        retainOnError: false
+      }, async (onRecord) => {
+        onRecord({ cleanup: "retained" });
+        throw new Error("failure after retained record");
+      });
+    } catch (error) {
+      partialRetainedError = error;
+    }
+    assertEqual(
+      partialRetainedError?.message,
+      "failure after retained record",
+      "partial retained record preserves original error"
+    );
+    assertEqual(await fileExists(removeLog), false, "partial retained record keeps target runtime");
+
     process.env.KOVA_MOCK_REMOVE_FAIL = "1";
     let combinedError;
     try {
@@ -19253,7 +19273,7 @@ JSON
       if [ "$KOVA_PREVIEW_ACTIVE" = "1" ]; then
         printf '{"stateToken":"v1:%s","serviceInstalled":true,"serviceLoaded":true,"serviceRunning":true,"blockers":[],"steps":[{"kind":"service"},{"kind":"processes"}]}\\n' "$3"
       else
-        printf '{"stateToken":"v1:%s","serviceInstalled":false,"serviceLoaded":false,"serviceRunning":false,"blockers":[],"steps":[]}\\n' "$3"
+        printf '{"stateToken":"v1:%s","serviceInstalled":true,"serviceLoaded":false,"serviceRunning":false,"blockers":[],"steps":[{"kind":"service"}]}\\n' "$3"
       fi
       exit 0
     fi

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19251,6 +19251,10 @@ async function cleanupEnvSafetyCheck(tmp) {
   await writeFile(ocmPath, `#!/bin/sh
 case "$1:$2:$3" in
   env:list:--json)
+    if [ "$KOVA_INVALID_ENV_INVENTORY" = "1" ]; then
+      echo '[{"name":"kova-stale","createdAt":"${old}","lastUsedAt":null}]'
+      exit 0
+    fi
     stale_last_used=null
     if [ -n "$KOVA_RECENT_MARKER" ] && [ -f "$KOVA_RECENT_MARKER" ]; then
       stale_last_used='"${recent}"'
@@ -19379,6 +19383,14 @@ exit 2
     assertEqual(invalidServicePlan.serviceInventory?.ok, false, "invalid service shape fails inventory");
     assertEqual(invalidServicePlan.candidates.length, 0, "invalid service shape blocks cleanup");
 
+    const invalidEnvInventory = await run("", { KOVA_INVALID_ENV_INVENTORY: "1" });
+    assertEqual(invalidEnvInventory.status !== 0, true, "invalid env inventory exits nonzero");
+    assertEqual(
+      `${invalidEnvInventory.stdout}\n${invalidEnvInventory.stderr}`.includes("missing protected state"),
+      true,
+      "invalid env protection state is rejected"
+    );
+
     const falseExecute = await run("--execute=false");
     assertEqual(falseExecute.status, 0, "non-boolean execute exit");
     assertEqual(JSON.parse(falseExecute.stdout).execute, false, "execute string does not authorize cleanup");
@@ -19470,7 +19482,7 @@ exit 2
       command: "exercise cleanup env eligibility, execute guard, and force override",
       durationMs: dry.durationMs + unknownRetention.durationMs +
         invalidShapeRetention.durationMs + invalidServiceInventory.durationMs +
-        falseExecute.durationMs +
+        invalidEnvInventory.durationMs + falseExecute.durationMs +
         stateChanged.durationMs + activePreview.durationMs + recentlyUsed.durationMs +
         malformedPreview.durationMs + newlyRetained.durationMs +
         partialApply.durationMs + forcedPartialApply.durationMs +

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1852,7 +1852,7 @@ function ocmCommandBuildersCheck() {
     assertEqual(ocmEnvDestroy("Team Env"), "ocm env destroy 'Team Env' --yes", "quoted env destroy");
     assertEqual(ocmEnvDestroyPreviewJson("Team Env"), "ocm env destroy 'Team Env' --json", "quoted env destroy preview");
     assertEqual(
-      ocmEnvDestroy("Team Env", { json: true, stateToken: "v1:r1" }),
+      ocmEnvDestroy("Team Env", { json: true, stateRevision: "v1:r1" }),
       "ocm env destroy 'Team Env' --json --yes --if-state-token 'v1:r1'",
       "quoted guarded env destroy"
     );
@@ -19310,7 +19310,7 @@ JSON
       exit 0
     fi
     if [ "$KOVA_TOKEN_MISMATCH" = "1" ]; then
-      printf '{"code":"state_changed","removed":false,"stateToken":"v1:changed"}\\n'
+      printf '{"code":"state_changed","removed":false,"stateToken":"test-token-placeholder"}\\n'
       exit 1
     fi
     if [ "$KOVA_PARTIAL_APPLY" = "1" ]; then

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19250,7 +19250,13 @@ exit 2
     await rm(destroyLog, { force: true });
     const forced = await run("--execute --force");
     assertEqual(forced.status, 0, "forced cleanup exit");
-    assertEqual(JSON.parse(forced.stdout).candidates.length, 6, "force overrides cleanup safeguards");
+    const forcedReceipt = JSON.parse(forced.stdout);
+    assertEqual(forcedReceipt.candidates.length, 6, "force overrides cleanup safeguards");
+    assertEqual(
+      forcedReceipt.results.every((result) => result.command.endsWith("--yes --force")),
+      true,
+      "force is forwarded to OCM destroy"
+    );
     assertEqual((await readFile(destroyLog, "utf8")).trim().split("\n").length, 6, "force destroys every Kova env");
 
     return {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -176,6 +176,7 @@ import {
   ocmEnvDestroyPreviewJson,
   ocmEnvExec,
   ocmEnvExecShell,
+  ocmEnvProtect,
   ocmLogs,
   ocmRuntimeBuildLocal,
   ocmRuntimeRemoveJson,
@@ -14234,6 +14235,13 @@ async function networkFrontagePartialStartupCleanupInvariantCheck() {
     const teardownSource = await readFile("src/run/teardown.mjs", "utf8");
     const retentionPattern = /id: "network-frontage-cleanup"[\s\S]+const retainEnv = shouldRetainEnv\(context, record\)/;
     assertEqual(retentionPattern.test(teardownSource), true, "retain-on-failure is computed after network frontage cleanup can update status");
+    const protectionPattern = /const retainEnv = shouldRetainEnv\(context, record\);[\s\S]+id: "retention-protection"[\s\S]+protectRetainedEnv\(record, context, envName\)[\s\S]+record\.cleanup = "retained"/;
+    assertEqual(protectionPattern.test(teardownSource), true, "retained env is protected before retention is published");
+    assertEqual(
+      ocmEnvProtect("kova-retained", true),
+      "ocm env protect 'kova-retained' on --json",
+      "retention protection command"
+    );
     let proxyClosed = false;
     let resolveProxyClosed;
     const context = {
@@ -19230,6 +19238,8 @@ async function cleanupEnvSafetyCheck(tmp) {
   const binDir = join(tmp, "cleanup-env-safety-bin");
   const reports = join(home, "reports");
   const destroyLog = join(tmp, "cleanup-env-destroy.log");
+  const recentMarker = join(tmp, "cleanup-env-recent.marker");
+  const retentionReport = join(reports, "late-retained.json");
   const ocmPath = join(binDir, "ocm");
   const old = "2020-01-01T00:00:00Z";
   const recent = new Date().toISOString();
@@ -19241,9 +19251,13 @@ async function cleanupEnvSafetyCheck(tmp) {
   await writeFile(ocmPath, `#!/bin/sh
 case "$1:$2:$3" in
   env:list:--json)
-    cat <<'JSON'
+    stale_last_used=null
+    if [ -n "$KOVA_RECENT_MARKER" ] && [ -f "$KOVA_RECENT_MARKER" ]; then
+      stale_last_used='"${recent}"'
+    fi
+    cat <<JSON
 [
-  {"name":"kova-stale","createdAt":"${old}","lastUsedAt":null,"protected":false},
+  {"name":"kova-stale","createdAt":"${old}","lastUsedAt":$stale_last_used,"protected":false},
   {"name":"kova-recent","createdAt":"${recent}","lastUsedAt":"${recent}","protected":false},
   {"name":"kova-protected","createdAt":"${old}","lastUsedAt":null,"protected":true},
   {"name":"kova-retained","createdAt":"${old}","lastUsedAt":null,"protected":false},
@@ -19270,6 +19284,12 @@ JSON
     ;;
   env:destroy:*)
     if [ "$4" = "--json" ] && [ -z "$5" ]; then
+      if [ "$KOVA_REVALIDATE_RECENT" = "1" ]; then
+        : > "$KOVA_RECENT_MARKER"
+      fi
+      if [ "$KOVA_REVALIDATE_RETAINED" = "1" ]; then
+        printf '{"records":[{"envName":"%s","cleanup":"retained"}]}\\n' "$3" > "$KOVA_RETENTION_REPORT"
+      fi
       if [ "$KOVA_PREVIEW_ACTIVE" = "1" ]; then
         printf '{"stateToken":"v1:%s","serviceInstalled":true,"serviceLoaded":true,"serviceRunning":true,"blockers":[],"steps":[{"kind":"service"},{"kind":"processes"}]}\\n' "$3"
       else
@@ -19279,6 +19299,11 @@ JSON
     fi
     if [ "$KOVA_TOKEN_MISMATCH" = "1" ]; then
       printf '{"code":"state_changed","removed":false,"stateToken":"v1:changed"}\\n'
+      exit 1
+    fi
+    if [ "$KOVA_PARTIAL_APPLY" = "1" ]; then
+      printf '%s\\n' "$3" >> "$KOVA_DESTROY_LOG"
+      printf '{"code":"partial_apply","removed":false,"serviceUninstalled":true,"processesTerminated":0,"stateToken":"v1:%s"}\\n' "$3"
       exit 1
     fi
     printf '%s\\n' "$3" >> "$KOVA_DESTROY_LOG"
@@ -19294,7 +19319,9 @@ exit 2
   const env = {
     PATH: `${binDir}:${process.env.PATH}`,
     KOVA_HOME: home,
-    KOVA_DESTROY_LOG: destroyLog
+    KOVA_DESTROY_LOG: destroyLog,
+    KOVA_RECENT_MARKER: recentMarker,
+    KOVA_RETENTION_REPORT: retentionReport
   };
   const run = (args, envOverrides = {}) => runCommand(`node bin/kova.mjs cleanup envs ${args} --json`, {
     env: { ...env, ...envOverrides },
@@ -19353,6 +19380,30 @@ exit 2
     assertEqual(activePreviewReceipt.results[0]?.stage, "precondition", "active preview fails precondition");
     assertEqual(await fileExists(destroyLog), false, "active preview performs no teardown");
 
+    const recentlyUsed = await run("--execute", { KOVA_REVALIDATE_RECENT: "1" });
+    assertEqual(recentlyUsed.status !== 0, true, "recent eligibility refresh exits nonzero");
+    const recentlyUsedReceipt = JSON.parse(recentlyUsed.stdout);
+    assertEqual(recentlyUsedReceipt.results[0]?.code, "eligibility_changed", "recent env fails refreshed eligibility");
+    assertEqual(recentlyUsedReceipt.results[0]?.stage, "precondition", "recent env stops before guarded destroy");
+    assertEqual(await fileExists(destroyLog), false, "recent eligibility refresh performs no teardown");
+    await rm(recentMarker, { force: true });
+
+    const newlyRetained = await run("--execute", { KOVA_REVALIDATE_RETAINED: "1" });
+    assertEqual(newlyRetained.status !== 0, true, "retention refresh exits nonzero");
+    const newlyRetainedReceipt = JSON.parse(newlyRetained.stdout);
+    assertEqual(newlyRetainedReceipt.results[0]?.code, "eligibility_changed", "new retention fails refreshed eligibility");
+    assertEqual(await fileExists(destroyLog), false, "retention refresh performs no teardown");
+    await rm(retentionReport, { force: true });
+
+    const partialApply = await run("--execute", { KOVA_PARTIAL_APPLY: "1" });
+    assertEqual(partialApply.status !== 0, true, "partial apply exits nonzero");
+    const partialApplyReceipt = JSON.parse(partialApply.stdout);
+    assertEqual(partialApplyReceipt.results[0]?.code, "partial_apply", "partial apply code preserved");
+    assertEqual(partialApplyReceipt.results[0]?.stage, "partial-apply", "partial apply has distinct stage");
+    assertEqual(partialApplyReceipt.results[0]?.attempts?.length, 1, "partial apply is not retried");
+    assertEqual((await readFile(destroyLog, "utf8")).trim(), "kova-stale", "partial apply executes once");
+    await rm(destroyLog, { force: true });
+
     const execute = await run("--execute");
     assertEqual(execute.status, 0, "cleanup safety execute exit");
     assertEqual((await readFile(destroyLog, "utf8")).trim(), "kova-stale", "default cleanup destroys only eligible env");
@@ -19374,7 +19425,8 @@ exit 2
       status: "PASS",
       command: "exercise cleanup env eligibility, execute guard, and force override",
       durationMs: dry.durationMs + unknownRetention.durationMs + falseExecute.durationMs +
-        stateChanged.durationMs + activePreview.durationMs + execute.durationMs + forced.durationMs
+        stateChanged.durationMs + activePreview.durationMs + recentlyUsed.durationMs +
+        newlyRetained.durationMs + partialApply.durationMs + execute.durationMs + forced.durationMs
     };
   } catch (error) {
     return {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19356,6 +19356,15 @@ exit 2
     );
     await rm(malformedReport);
 
+    const invalidShapeReport = join(reports, "invalid-shape.json");
+    await writeFile(invalidShapeReport, '{"records":"retained"}\n', "utf8");
+    const invalidShapeRetention = await run("");
+    assertEqual(invalidShapeRetention.status, 0, "invalid retention shape dry-run exit");
+    const invalidShapePlan = JSON.parse(invalidShapeRetention.stdout);
+    assertEqual(invalidShapePlan.retentionInventory?.ok, false, "invalid report shape fails retention inventory");
+    assertEqual(invalidShapePlan.candidates.length, 0, "invalid retention shape blocks cleanup");
+    await rm(invalidShapeReport);
+
     const falseExecute = await run("--execute=false");
     assertEqual(falseExecute.status, 0, "non-boolean execute exit");
     assertEqual(JSON.parse(falseExecute.stdout).execute, false, "execute string does not authorize cleanup");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19366,6 +19366,10 @@ exit 2
       true,
       "unknown retention state is recorded for every env"
     );
+    const unknownRetentionExecute = await run("--execute");
+    assertEqual(unknownRetentionExecute.status !== 0, true, "unknown retention execute exits nonzero");
+    assertEqual(JSON.parse(unknownRetentionExecute.stdout).results.length, 0, "unknown retention executes no destroys");
+    assertEqual(await fileExists(destroyLog), false, "unknown retention execute performs no teardown");
     await rm(malformedReport);
 
     const invalidShapeReport = join(reports, "invalid-shape.json");
@@ -19382,6 +19386,20 @@ exit 2
     const invalidServicePlan = JSON.parse(invalidServiceInventory.stdout);
     assertEqual(invalidServicePlan.serviceInventory?.ok, false, "invalid service shape fails inventory");
     assertEqual(invalidServicePlan.candidates.length, 0, "invalid service shape blocks cleanup");
+    const invalidServiceExecute = await run("--execute", { KOVA_INVALID_SERVICE_INVENTORY: "1" });
+    assertEqual(invalidServiceExecute.status !== 0, true, "invalid service execute exits nonzero");
+    assertEqual(JSON.parse(invalidServiceExecute.stdout).results.length, 0, "invalid service executes no destroys");
+    assertEqual(await fileExists(destroyLog), false, "invalid service execute performs no teardown");
+    const forcedInvalidService = await run("--execute --force", {
+      KOVA_INVALID_SERVICE_INVENTORY: "1"
+    });
+    assertEqual(forcedInvalidService.status, 0, "force overrides invalid service inventory");
+    assertEqual(
+      JSON.parse(forcedInvalidService.stdout).results.length,
+      7,
+      "forced invalid service inventory destroys every Kova env"
+    );
+    await rm(destroyLog, { force: true });
 
     const invalidEnvInventory = await run("", { KOVA_INVALID_ENV_INVENTORY: "1" });
     assertEqual(invalidEnvInventory.status !== 0, true, "invalid env inventory exits nonzero");
@@ -19481,8 +19499,9 @@ exit 2
       status: "PASS",
       command: "exercise cleanup env eligibility, execute guard, and force override",
       durationMs: dry.durationMs + unknownRetention.durationMs +
-        invalidShapeRetention.durationMs + invalidServiceInventory.durationMs +
-        invalidEnvInventory.durationMs + falseExecute.durationMs +
+        unknownRetentionExecute.durationMs + invalidShapeRetention.durationMs +
+        invalidServiceInventory.durationMs + invalidServiceExecute.durationMs +
+        forcedInvalidService.durationMs + invalidEnvInventory.durationMs + falseExecute.durationMs +
         stateChanged.durationMs + activePreview.durationMs + recentlyUsed.durationMs +
         malformedPreview.durationMs + newlyRetained.durationMs +
         partialApply.durationMs + forcedPartialApply.durationMs +

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1103,7 +1103,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(compareMetricOrderingCheck());
     checks.push(compareGatewayRssDedupeCheck());
     checks.push(resourceContractCompareCheck());
-    checks.push(await reportCompareExitStatusCheck());
+    checks.push(await reportCompareExitStatusCheck(tmp));
     checks.push(fixtureAccountingRenderCheck());
 
     const receiptCheck = await jsonCommandCheck(
@@ -21071,7 +21071,7 @@ function zeroLogMetrics() {
   };
 }
 
-async function reportCompareExitStatusCheck() {
+async function reportCompareExitStatusCheck(tmp) {
   const modes = [
     { name: "dashboard", flag: "" },
     { name: "plain", flag: "--plain" },
@@ -21080,11 +21080,39 @@ async function reportCompareExitStatusCheck() {
   ];
   let durationMs = 0;
   try {
+    const fixtureDir = join(tmp, "report-compare-exit-status");
+    const baselinePath = join(fixtureDir, "baseline.json");
+    const currentPath = join(fixtureDir, "current.json");
+    const platform = {
+      os: process.platform,
+      arch: process.arch,
+      release: "self-check",
+      node: process.version
+    };
+    await mkdir(fixtureDir, { recursive: true });
+    await writeFile(
+      baselinePath,
+      `${JSON.stringify(syntheticPerformanceReport({
+        runId: "report-compare-exit-baseline",
+        platform,
+        target: "runtime:stable",
+        records: [syntheticPerformanceRecord(1, { peakRssMb: 400 })]
+      }), null, 2)}\n`
+    );
+    await writeFile(
+      currentPath,
+      `${JSON.stringify(syntheticPerformanceReport({
+        runId: "report-compare-exit-current",
+        platform,
+        target: "runtime:stable",
+        records: [syntheticPerformanceRecord(1, { peakRssMb: 900 })]
+      }), null, 2)}\n`
+    );
     for (const mode of modes) {
       const command = [
         "node bin/kova.mjs report compare",
-        "tests/fixtures/reports/pass.json",
-        "tests/fixtures/reports/fail.json",
+        quoteShell(baselinePath),
+        quoteShell(currentPath),
         mode.flag
       ].filter(Boolean).join(" ");
       const result = await runCommand(command, {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19221,6 +19221,7 @@ case "$1:$2:$3" in
   {"name":"kova-protected","createdAt":"${old}","lastUsedAt":null,"protected":true},
   {"name":"kova-retained","createdAt":"${old}","lastUsedAt":null,"protected":false},
   {"name":"kova-active","createdAt":"${old}","lastUsedAt":null,"protected":false},
+  {"name":"kova-issue","createdAt":"${old}","lastUsedAt":null,"protected":false},
   {"name":"kova-unknown","createdAt":"${old}","lastUsedAt":null,"protected":false},
   {"name":"durable-user-env","createdAt":"${old}","lastUsedAt":null,"protected":false}
 ]
@@ -19234,7 +19235,8 @@ JSON
   {"envName":"kova-recent","installed":false,"desiredRunning":false,"running":false,"gatewayState":"stopped","childPid":null},
   {"envName":"kova-protected","installed":false,"desiredRunning":false,"running":false,"gatewayState":"stopped","childPid":null},
   {"envName":"kova-retained","installed":false,"desiredRunning":false,"running":false,"gatewayState":"stopped","childPid":null},
-  {"envName":"kova-active","installed":true,"desiredRunning":true,"running":true,"gatewayState":"healthy","childPid":123}
+  {"envName":"kova-active","installed":true,"desiredRunning":true,"running":true,"gatewayState":"healthy","childPid":123},
+  {"envName":"kova-issue","installed":false,"desiredRunning":false,"running":false,"gatewayState":"stopped","childPid":null,"issue":"status incomplete"}
 ]}
 JSON
     exit 0
@@ -19271,6 +19273,7 @@ exit 2
     assertEqual(plan.classifications.find((item) => item.name === "kova-protected")?.reasons.includes("protected"), true, "protected env skipped");
     assertEqual(plan.classifications.find((item) => item.name === "kova-retained")?.reasons.includes("retained-by-run"), true, "retained env skipped");
     assertEqual(plan.classifications.find((item) => item.name === "kova-active")?.reasons.includes("active-service"), true, "active env skipped");
+    assertEqual(plan.classifications.find((item) => item.name === "kova-issue")?.reasons.includes("unknown-service-state"), true, "service issue env skipped");
     assertEqual(plan.classifications.find((item) => item.name === "kova-unknown")?.reasons.includes("unknown-service-state"), true, "unknown service env skipped");
 
     const malformedReport = join(reports, "malformed.json");
@@ -19300,13 +19303,13 @@ exit 2
     const forced = await run("--execute --force");
     assertEqual(forced.status, 0, "forced cleanup exit");
     const forcedReceipt = JSON.parse(forced.stdout);
-    assertEqual(forcedReceipt.candidates.length, 6, "force overrides cleanup safeguards");
+    assertEqual(forcedReceipt.candidates.length, 7, "force overrides cleanup safeguards");
     assertEqual(
       forcedReceipt.results.every((result) => result.command.endsWith("--yes --force")),
       true,
       "force is forwarded to OCM destroy"
     );
-    assertEqual((await readFile(destroyLog, "utf8")).trim().split("\n").length, 6, "force destroys every Kova env");
+    assertEqual((await readFile(destroyLog, "utf8")).trim().split("\n").length, 7, "force destroys every Kova env");
 
     return {
       id: "cleanup-env-safety",


### PR DESCRIPTION
## What Problem This Solves

Kova cleanup and local-build finalization could destroy environments from stale or incomplete safety evidence, report blocked cleanup as successful, lose retained-run receipts after a later failure, or leave a local runtime behind when execution threw. Failed report comparisons could also exit successfully in dashboard mode.

## Why This Change Was Made

- Make environment cleanup dry-run by default and require a literal `--execute` for destruction.
- Protect recent, active, retained, protected, and unknown-state environments unless the operator explicitly uses `--force`.
- Validate environment, service, retention, and OCM destroy-preview evidence before acting.
- Bind non-forced destruction to the previewed OCM state revision and revalidate eligibility immediately before apply.
- Treat stale state, unsafe previews, partial apply, invalid inventories, and failed destroy commands as failed execution without unsafe retries.
- Protect retained environments before recording retained receipts, and preserve partially produced retained records when later execution fails.
- Finalize local-build runtimes after primary errors and aggregate primary and cleanup failures.
- Propagate failed comparison exit status across dashboard, plain, fixer, and JSON output.

This stack was rebased onto the publication hardening merged in https://github.com/openclaw/Kova/pull/55. Its canonical file-lock, exact report-bundle binding, publish implementation, and snapshots remain unchanged.

## User Impact

Cleanup automation now fails closed and returns a nonzero status when required safety evidence is unavailable. Destructive cleanup is guarded against state changes between preview and apply, partial teardown is surfaced without retry, retained failure environments remain inspectable, and local runtime cleanup runs even after execution errors.

## Evidence

- Base: `35c4dea542e7fd1c032a334d403361ed9befef57`
- Head: `a77a1cd5220f37e30301eb696dd996498a11fed2`
- `npm run check:full`
  - concurrent self-check isolation: pass
  - self-check: 262/262 pass
  - snapshots: 21/21 pass
  - web payload contract: 1/1 pass
  - release transaction contracts: pass
- Packed release archive smoke in isolated `HOME` and `KOVA_HOME`
  - `setup --ci --json`: pass
  - extracted archive `npm run check`: 262/262 pass
  - SHA-256: `2d715ce0a21e3e56059fbe4d78b93472e0dfbc5308e4253a6e4a6244cccb7c3a`
  - size: 3,463,305 bytes
- Explicit `gpt-5.6-sol` high-thinking branch autoreview: clean, no actionable findings after fixing the inventory-blocked execute status finding
- `git diff --check origin/main...HEAD`: pass
- Publish implementation and snapshots diff: empty

The change is documented under `Unreleased` in `CHANGELOG.md`.