### PR TITLE
fix(reporting): preserve runtime evidence integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to Kova are documented in this file.
 - Hardened mock-provider and diagnostic process handling to reject non-decimal PID state, migrate active legacy providers safely, reject stale startup metadata, avoid signaling unrelated processes, retain retryable PID state, and preserve colliding diagnostic artifacts.
 - Fixed OpenClaw inventory discovery to recognize canonical JSON5 plugin manifests consistently across platforms while deterministically bounding scans.
 - Isolated concurrent self-check OCM identities, child environments, runtime names, and temp cleanup ownership.
+- Escape runtime-derived Markdown and paste fields without changing JSON report data.
+- Keep RSS and CPU role peaks independently attributed to their actual scenarios.
 - Hardened performance baseline persistence, unstable-group detection, and repeated-work audit isolation.
 - Fixed web reports to reset matrix deltas across missing samples, preserve scenario breach status, render blocked OG verdicts safely, revalidate mutable OG images, and normalize rounded minute durations.
 - Made matrix gates honor scenario-wide policies and validate all seven coverage dimensions only from records that actually executed.

--- a/src/collectors/pre-provider-attribution.mjs
+++ b/src/collectors/pre-provider-attribution.mjs
@@ -1,3 +1,5 @@
+import { markdownInline, markdownTableCodeSpan } from "../reporting/markdown.mjs";
+
 export function buildPreProviderAttribution({
   schemaVersion,
   label,
@@ -117,7 +119,7 @@ export function preProviderMarkdownRows({ title, turns, fieldName }) {
   }
 
   const lines = [
-    `- ${title}:`,
+    `- ${markdownInline(title)}:`,
     "  - Spans are selected by active turn timestamp window; timeline phase is descriptive, not a startup/turn classifier.",
     "",
     "  | turn | pre-provider | known | unattributed | provider | timeline |",
@@ -126,7 +128,7 @@ export function preProviderMarkdownRows({ title, turns, fieldName }) {
   for (const item of attributions) {
     const timeline = item.timelineArtifacts?.[0] ?? (item.timelineAvailable ? "available" : "missing");
     lines.push(
-      `  | ${item.label ?? "turn"} | ${formatMs(item.window?.durationMs)} | ${formatMs(item.knownAttributedMs)} | ${formatMs(item.unattributedMs)} | ${formatMs(item.provider?.totalDurationMs)} | ${timeline} |`
+      `  | ${markdownInline(item.label ?? "turn")} | ${formatMs(item.window?.durationMs)} | ${formatMs(item.knownAttributedMs)} | ${formatMs(item.unattributedMs)} | ${formatMs(item.provider?.totalDurationMs)} | ${markdownInline(timeline)} |`
     );
   }
 
@@ -139,7 +141,7 @@ export function preProviderMarkdownRows({ title, turns, fieldName }) {
     lines.push("  |---|---|---|---:|---:|---:|---:|");
     for (const span of spanRows.slice(0, 12)) {
       lines.push(
-        `  | ${span.turn} | \`${span.name}\` | ${formatPhases(span.phases)} | ${span.count} | ${span.errorCount} | ${formatMs(span.totalClippedDurationMs)} | ${formatMs(span.maxClippedDurationMs)} |`
+        `  | ${markdownInline(span.turn)} | ${markdownTableCodeSpan(span.name)} | ${formatPhases(span.phases)} | ${span.count} | ${span.errorCount} | ${formatMs(span.totalClippedDurationMs)} | ${formatMs(span.maxClippedDurationMs)} |`
       );
     }
   }
@@ -431,7 +433,7 @@ function formatPhases(phases) {
   }
   return phases
     .slice(0, 3)
-    .map((item) => `\`${item.phase}\`${item.count > 1 ? ` x${item.count}` : ""}`)
+    .map((item) => `${markdownTableCodeSpan(item.phase)}${item.count > 1 ? ` x${item.count}` : ""}`)
     .join(", ");
 }
 

--- a/src/reporting/markdown.mjs
+++ b/src/reporting/markdown.mjs
@@ -17,7 +17,10 @@ export function markdownInline(value, fallback = "unknown") {
   const text = normalizeInline(value, fallback);
   return escapeHtml(text)
     .replace(/([\\`*_[\]~|])/g, "\\$1")
-    .replace(/^([#+-]|\d+\.)\s/, "\\$1 ");
+    .replace(/^(#{1,6})(?=\s|$)/, "\\$1")
+    .replace(/^([+-])(?=\s)/, "\\$1")
+    .replace(/^(\d+)([.)])(?=\s)/, "$1\\$2")
+    .replace(/^(-{3,})(?=\s|$)/, "\\$1");
 }
 
 export function markdownCodeSpan(value, fallback = "unknown") {

--- a/src/reporting/markdown.mjs
+++ b/src/reporting/markdown.mjs
@@ -1,4 +1,4 @@
-export function markdownSafeValue(value, fieldName = null) {
+export function markdownSafeValue(value) {
   if (typeof value === "string") {
     return markdownInline(value, "");
   }
@@ -7,10 +7,7 @@ export function markdownSafeValue(value, fieldName = null) {
   }
   if (value && typeof value === "object") {
     return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [
-        fieldName === "resourceByRole" ? markdownInline(key, "") : key,
-        markdownSafeValue(item, key)
-      ])
+      Object.entries(value).map(([key, item]) => [key, markdownSafeValue(item)])
     );
   }
   return value;

--- a/src/reporting/markdown.mjs
+++ b/src/reporting/markdown.mjs
@@ -1,0 +1,77 @@
+export function markdownSafeValue(value, fieldName = null) {
+  if (typeof value === "string") {
+    return markdownInline(value, "");
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => markdownSafeValue(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        fieldName === "resourceByRole" ? markdownInline(key, "") : key,
+        markdownSafeValue(item, key)
+      ])
+    );
+  }
+  return value;
+}
+
+export function markdownInline(value, fallback = "unknown") {
+  const text = normalizeInline(value, fallback);
+  return escapeHtml(text)
+    .replace(/([\\`*_[\]~|])/g, "\\$1")
+    .replace(/^([#+-]|\d+\.)\s/, "\\$1 ");
+}
+
+export function markdownCodeSpan(value, fallback = "unknown") {
+  const text = normalizeInline(value, fallback);
+  const longestRun = longestBacktickRun(text);
+  const delimiter = "`".repeat(Math.max(1, longestRun + 1));
+  const padding = text.startsWith("`") || text.endsWith("`") ? " " : "";
+  return `${delimiter}${padding}${text}${padding}${delimiter}`;
+}
+
+export function markdownTableCodeSpan(value, fallback = "unknown") {
+  return markdownCodeSpan(value, fallback).replace(/(\\*)\|/g, (_match, backslashes) =>
+    `${backslashes}${backslashes}\\|`
+  );
+}
+
+export function markdownFence(value, language = "text") {
+  const text = String(value ?? "")
+    .replace(/\r\n?/g, "\n")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "");
+  const lines = text.split("\n").slice(0, 30);
+  const longestRun = longestBacktickRun(lines.join("\n"));
+  const delimiter = "`".repeat(Math.max(3, longestRun + 1));
+  return [delimiter + language, ...lines, delimiter].join("\n");
+}
+
+function normalizeInline(value, fallback) {
+  const text = String(value ?? "")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text || String(fallback);
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function longestBacktickRun(value) {
+  let longest = 0;
+  let current = 0;
+  for (const character of value) {
+    if (character === "`") {
+      current += 1;
+      longest = Math.max(longest, current);
+    } else {
+      current = 0;
+    }
+  }
+  return longest;
+}

--- a/src/reporting/report.mjs
+++ b/src/reporting/report.mjs
@@ -9,6 +9,7 @@ import {
 } from "../health.mjs";
 import { RECORD_STATUS, findingSeverityForStatus } from "../statuses.mjs";
 import { firstFailedCommand, summarizeFailureReason } from "./failures.mjs";
+import { markdownCodeSpan, markdownFence, markdownInline, markdownSafeValue, markdownTableCodeSpan } from "./markdown.mjs";
 import { summarizeRecords } from "./records.mjs";
 
 export { summarizeRecords } from "./records.mjs";
@@ -16,7 +17,12 @@ export { summarizeRecords } from "./records.mjs";
 const SUMMARY_SCHEMA = "kova.report.summary.v1";
 
 export function renderMarkdownReport(report) {
-  const summary = buildReportSummary(report);
+  // Inline fields render from an escaped clone; code and fenced evidence retain
+  // the raw report so their context-specific formatters preserve exact text.
+  const rawReport = report;
+  const rawSummary = buildReportSummary(report);
+  const summary = markdownSafeValue(rawSummary);
+  report = markdownSafeValue(rawReport);
   const verdictBand = markdownVerdictBand(summary.decision.verdict);
   const platformLine = `${summary.platform?.os ?? "unknown"} ${summary.platform?.release ?? ""} (${summary.platform?.arch ?? "unknown"}) · ${summary.platform?.node ?? "unknown"}`.trim();
   const authMode = summary.run.auth?.requestedMode ?? summary.run.auth?.live?.method ?? "unknown";
@@ -44,10 +50,10 @@ export function renderMarkdownReport(report) {
     "",
     "| Field | Value |",
     "|---|---|",
-    `| Run ID | \`${tableCell(summary.runId)}\` |`,
+    `| Run ID | ${markdownTableCodeSpan(rawSummary.runId)} |`,
     `| Generated | ${tableCell(summary.generatedAt ?? "unknown")} |`,
     `| Mode | ${tableCell(summary.mode ?? "unknown")} |`,
-    `| Target | \`${tableCell(summary.target ?? "unknown")}\` |`,
+    `| Target | ${markdownTableCodeSpan(rawSummary.target ?? "unknown")} |`,
     `| Platform | ${tableCell(platformLine)} |`,
     `| Repeat / parallel | ${tableCell(`${summary.run.repeat ?? "unknown"} / ${summary.run.parallel ?? "unknown"}`)} |`,
     `| Auth | ${tableCell(authLine)} |`,
@@ -65,17 +71,17 @@ export function renderMarkdownReport(report) {
   ];
 
   if (report.gate) {
-    lines.push(...formatGateSection(report.gate));
+    lines.push(...formatGateSection(report.gate, rawReport.gate));
   }
 
   lines.push(...formatFindingsSection(summary.findings));
-  lines.push(...formatPerformanceSummaryTable(summary.groups, summary.performance));
+  lines.push(...formatPerformanceSummaryTable(summary.groups, summary.performance, rawSummary.performance));
   lines.push(...formatSampleSummaryTable(summary.samples));
-  lines.push(...formatResourceRoleSection(report.records));
+  lines.push(...formatResourceRoleSection(report.records, rawReport.records));
   lines.push(...formatChannelWorkflowResourceSection(report.records));
-  lines.push(...formatSelectedSampleDetails(report.records));
+  lines.push(...formatSelectedSampleDetails(report.records, rawReport.records));
   lines.push(...formatArtifactSection(summary.artifacts));
-  lines.push(...formatTargetCleanupSummary(report.targetCleanup));
+  lines.push(...formatTargetCleanupSummary(report.targetCleanup, rawReport.targetCleanup));
 
   return `${lines.join("\n")}\n`;
 }
@@ -186,10 +192,10 @@ function formatChannelCapabilityProofSection(proof) {
   return lines;
 }
 
-function formatPerformanceSummaryTable(groups = [], performance = null) {
+function formatPerformanceSummaryTable(groups = [], performance = null, rawPerformance = null) {
   const lines = ["## Performance Summary", ""];
   lines.push(`- Resource measurement scope: ${performance?.resourceMeasurementScope ?? "unknown"}`);
-  lines.push(`- Resource headline contract: \`${performance?.resourceHeadlineContract ?? "unknown"}\``);
+  lines.push(`- Resource headline contract: ${markdownCodeSpan(rawPerformance?.resourceHeadlineContract ?? "unknown")}`);
   if (groups.length === 0) {
     lines.push("- No aggregate performance groups were recorded.");
     lines.push("");
@@ -259,21 +265,24 @@ function formatSampleSummaryTable(samples = []) {
   return lines;
 }
 
-function formatSelectedSampleDetails(records = []) {
-  const selected = records.filter((record) =>
-    record.status !== "PASS" ||
-    (record.violations?.length ?? 0) > 0 ||
-    (record.measurements?.agentTurns?.length ?? 0) > 0 ||
-    record.measurements?.gatewaySessionPreProviderAttribution?.count > 0 ||
-    record.measurements?.agentCliPreProviderAttribution?.count > 0 ||
-    record.measurements?.officialPluginEvidence?.available === true
-  ).slice(0, 8);
+function formatSelectedSampleDetails(records = [], rawRecords = []) {
+  const selected = records
+    .map((record, index) => ({ record, rawRecord: rawRecords[index] ?? record }))
+    .filter(({ record }) =>
+      record.status !== "PASS" ||
+      (record.violations?.length ?? 0) > 0 ||
+      (record.measurements?.agentTurns?.length ?? 0) > 0 ||
+      record.measurements?.gatewaySessionPreProviderAttribution?.count > 0 ||
+      record.measurements?.agentCliPreProviderAttribution?.count > 0 ||
+      record.measurements?.officialPluginEvidence?.available === true
+    )
+    .slice(0, 8);
   if (selected.length === 0) {
     return [];
   }
 
   const lines = ["## Selected Sample Details", ""];
-  for (const record of selected) {
+  for (const { record, rawRecord } of selected) {
     const sample = record.repeat?.index ?? "?";
     lines.push(`### ${record.scenario ?? record.title} sample ${sample}`);
     lines.push("");
@@ -296,25 +305,28 @@ function formatSelectedSampleDetails(records = []) {
       }
     }
     const failed = firstFailedCommand(record, { includeCleanup: true });
+    const rawFailed = firstFailedCommand(rawRecord, { includeCleanup: true });
     if (failed) {
-      lines.push(`- Failed command: \`${shortCommand(failed.command)}\``);
-      lines.push(`- Failure: ${summarizeFailureReason(failed)}`);
+      lines.push(`- Failed command: ${markdownCodeSpan(shortCommand(rawFailed?.command ?? failed.command))}`);
+      lines.push(`- Failure: ${markdownInline(summarizeFailureReason(rawFailed ?? failed))}`);
     }
-    pushAgentTurnDetails(lines, record);
-    lines.push(...gatewaySessionPreProviderMarkdownRows(record.measurements?.agentTurns ?? []));
-    lines.push(...agentCliPreProviderMarkdownRows(record.measurements?.agentTurns ?? []));
+    pushAgentTurnDetails(lines, record, rawRecord);
+    lines.push(...gatewaySessionPreProviderMarkdownRows(rawRecord.measurements?.agentTurns ?? []));
+    lines.push(...agentCliPreProviderMarkdownRows(rawRecord.measurements?.agentTurns ?? []));
     lines.push("");
   }
   return lines;
 }
 
-function pushAgentTurnDetails(lines, record) {
+function pushAgentTurnDetails(lines, record, rawRecord) {
   const turns = record.measurements?.agentTurns ?? [];
+  const rawTurns = rawRecord.measurements?.agentTurns ?? [];
   if (turns.length === 0) {
     return;
   }
   lines.push("- Agent turns:");
-  for (const turn of turns.slice(0, 4)) {
+  for (const [index, turn] of turns.slice(0, 4).entries()) {
+    const rawTurn = rawTurns[index] ?? turn;
     const providerTiming = turn.providerAfterCommandEnd ? `; provider late ${turn.providerLateByMs} ms` : "";
     lines.push(`  - ${turn.label}: total ${valueMs(turn.totalTurnMs)}; pre-provider ${valueMs(turn.preProviderMs)}; provider ${valueMs(turn.providerFinalMs)}; post-provider ${valueMs(turn.postProviderMs)}; response ${turn.responseOk}${providerTiming}`);
     if (turn.gatewaySession) {
@@ -353,7 +365,9 @@ function pushAgentTurnDetails(lines, record) {
     if (turn.turnDiagnostics) {
       lines.push(`    - active window: metadata scans ${turn.metadataScanCount ?? "unknown"} (${valueMs(turn.metadataScanTotalMs)} total, max ${valueMs(turn.metadataScanMaxMs)}); event-loop samples ${turn.turnDiagnostics.eventLoop?.sampleCount ?? "unknown"} max ${valueMs(turn.eventLoopMaxMs)}`);
     }
-    const breakdown = summarizeAgentTurnBreakdownForMarkdown(turn.phaseBreakdown);
+    const breakdown = markdownSafeValue(
+      summarizeAgentTurnBreakdownForMarkdown(rawTurn.phaseBreakdown)
+    );
     if (breakdown) {
       lines.push(`    - breakdown: ${breakdown}`);
     }
@@ -403,12 +417,12 @@ function formatArtifactSection(artifacts = []) {
   return lines;
 }
 
-function formatTargetCleanupSummary(targetCleanup) {
+function formatTargetCleanupSummary(targetCleanup, rawTargetCleanup = targetCleanup) {
   if (!targetCleanup) {
     return [];
   }
   const lines = ["## Target Cleanup", ""];
-  lines.push(`- Runtime: \`${targetCleanup.runtimeName ?? "unknown"}\``);
+  lines.push(`- Runtime: ${markdownCodeSpan(rawTargetCleanup?.runtimeName ?? "unknown")}`);
   lines.push(`- Result: ${targetCleanup.status ?? "unknown"}`);
   if (targetCleanup.reason) {
     lines.push(`- Reason: ${targetCleanup.reason}`);
@@ -440,10 +454,10 @@ function formatResourceComparison(comparison = {}) {
 }
 
 function tableCell(value) {
-  return String(value ?? "unknown").replaceAll("|", "\\|").replace(/\s+/g, " ").trim();
+  return String(value ?? "unknown").replace(/\s+/g, " ").trim();
 }
 
-function formatResourceRoleSection(records = []) {
+function formatResourceRoleSection(records = [], rawRecords = records) {
   const roles = summarizeResourceRoles(records).slice(0, 8);
   if (roles.length === 0) {
     return [];
@@ -451,12 +465,16 @@ function formatResourceRoleSection(records = []) {
 
   const lines = ["## Resource Roles", ""];
   const identity = records.find((record) => record.measurements?.resourceHeadlineContract)?.measurements;
+  const rawIdentity = rawRecords.find((record) => record.measurements?.resourceHeadlineContract)?.measurements;
   if (identity) {
     lines.push(`- Measurement scope: ${identity.resourceMeasurementScope ?? "unknown"}`);
-    lines.push(`- Headline contract: \`${identity.resourceHeadlineContract}\``);
+    lines.push(`- Headline contract: ${markdownCodeSpan(rawIdentity?.resourceHeadlineContract ?? identity.resourceHeadlineContract)}`);
   }
   for (const role of roles) {
-    lines.push(`- ${role.role}: RSS ${role.peakRssMb ?? "unknown"} MB; CPU ${role.maxCpuPercent ?? "unknown"}%; scenario ${role.scenario}${role.state ? `/${role.state}` : ""}`);
+    lines.push(
+      `- ${role.role}: RSS ${role.peakRssMb ?? "unknown"} MB (${formatResourcePeakSource(role.rssSource)}); ` +
+      `CPU ${role.maxCpuPercent ?? "unknown"}% (${formatResourcePeakSource(role.cpuSource)})`
+    );
   }
   lines.push("");
   return lines;
@@ -465,32 +483,42 @@ function formatResourceRoleSection(records = []) {
 function summarizeResourceRoles(records = []) {
   const byRole = new Map();
   for (const record of records) {
-    for (const role of compactRolePeaks(record.measurements).slice(0, 8)) {
+    for (const role of compactRolePeaks(record.measurements)) {
       const existing = byRole.get(role.role) ?? {
         role: role.role,
         peakRssMb: null,
         maxCpuPercent: null,
-        scenario: record.scenario,
-        state: record.state?.id ?? null
+        rssSource: null,
+        cpuSource: null
       };
       const rss = role.peakRssMb ?? null;
       const cpu = role.maxCpuPercent ?? null;
       if (rss !== null && (existing.peakRssMb === null || rss > existing.peakRssMb)) {
         existing.peakRssMb = rss;
-        existing.scenario = record.scenario;
-        existing.state = record.state?.id ?? null;
+        existing.rssSource = resourcePeakSource(record);
       }
       if (cpu !== null && (existing.maxCpuPercent === null || cpu > existing.maxCpuPercent)) {
         existing.maxCpuPercent = cpu;
+        existing.cpuSource = resourcePeakSource(record);
       }
       byRole.set(role.role, existing);
     }
   }
-  return [...byRole.values()].toSorted((left, right) => {
-    const leftScore = Math.max(left.peakRssMb ?? 0, left.maxCpuPercent ?? 0);
-    const rightScore = Math.max(right.peakRssMb ?? 0, right.maxCpuPercent ?? 0);
-    return rightScore - leftScore;
-  });
+  return interleaveRankedRoles([...byRole.values()]);
+}
+
+function resourcePeakSource(record) {
+  return {
+    scenario: record.scenario ?? "unknown",
+    state: record.state?.id ?? null
+  };
+}
+
+function formatResourcePeakSource(source) {
+  if (!source) {
+    return "source unknown";
+  }
+  return `scenario ${source.scenario}${source.state ? `/${source.state}` : ""}`;
 }
 
 function formatChannelWorkflowResourceSection(records = []) {
@@ -1375,7 +1403,12 @@ function summarizePerformance(performance, baseline) {
 }
 
 export function renderPasteSummary(report) {
+  const rawReport = report;
+  const brief = markdownSafeValue(buildFailureBrief(report));
+  const recommended = markdownSafeValue(buildRecommendedNextScenario(report));
+  report = markdownSafeValue(report);
   const records = report.records ?? [];
+  const rawRecords = rawReport.records ?? [];
   const lines = [
     "Kova OpenClaw Runtime Findings",
     "",
@@ -1410,7 +1443,6 @@ export function renderPasteSummary(report) {
     lines.push("");
   }
 
-  const brief = buildFailureBrief(report);
   if (brief) {
     lines.push("Failure Brief");
     lines.push("");
@@ -1428,7 +1460,6 @@ export function renderPasteSummary(report) {
     lines.push(brief.fixerPrompt);
     lines.push("");
   }
-  const recommended = buildRecommendedNextScenario(report);
   if (recommended) {
     lines.push("Recommended next scenario");
     lines.push("");
@@ -1445,7 +1476,9 @@ export function renderPasteSummary(report) {
   }
 
   for (const record of recordsForPaste) {
+    const rawRecord = rawRecords[records.indexOf(record)] ?? record;
     const failed = firstFailedCommand(record, { includeCleanup: true });
+    const rawFailed = firstFailedCommand(rawRecord, { includeCleanup: true });
     lines.push(`Scenario: ${record.scenario}`);
     lines.push(`Result: ${record.status}`);
     lines.push(`Cleanup: ${record.cleanup ?? "not-run"}`);
@@ -1478,8 +1511,8 @@ export function renderPasteSummary(report) {
         lines.push(`- Failure domain: ${failureDomain}`);
       }
       lines.push(`- Likely area: ${failureDomain === "kova-harness" ? "Kova harness" : record.likelyOwner ?? "OpenClaw"}`);
-      const stderr = failed.stderr?.trim();
-      const stdout = failed.stdout?.trim();
+      const stderr = rawFailed?.stderr?.trim();
+      const stdout = rawFailed?.stdout?.trim();
       if (stderr) {
         lines.push("- stderr:");
         lines.push(fencedSnippet(stderr));
@@ -1725,22 +1758,70 @@ function compactPerformanceMetrics(metrics = {}) {
 
 function compactRolePeaks(measurements) {
   const byRole = new Map();
-  for (const role of measurements?.resourceTopRolesByRss ?? []) {
-    byRole.set(role.role, { ...byRole.get(role.role), ...role });
+  // RSS- and CPU-ranked rows describe independent peaks; never let one list
+  // overwrite the other's metric or rank.
+  for (const [rank, role] of (measurements?.resourceTopRolesByRss ?? []).entries()) {
+    const existing = byRole.get(role.role) ?? { role: role.role };
+    existing.peakRssMb = role.peakRssMb ?? existing.peakRssMb ?? null;
+    existing.maxCpuPercent ??= role.maxCpuPercent ?? null;
+    existing.rssRank = rank;
+    byRole.set(role.role, existing);
   }
-  for (const role of measurements?.resourceTopRolesByCpu ?? []) {
-    byRole.set(role.role, { ...byRole.get(role.role), ...role });
+  for (const [rank, role] of (measurements?.resourceTopRolesByCpu ?? []).entries()) {
+    const existing = byRole.get(role.role) ?? { role: role.role };
+    existing.peakRssMb ??= role.peakRssMb ?? null;
+    existing.maxCpuPercent = role.maxCpuPercent ?? existing.maxCpuPercent ?? null;
+    existing.cpuRank = rank;
+    byRole.set(role.role, existing);
   }
-  if (byRole.size === 0 && measurements?.resourceByRole) {
+  if (measurements?.resourceByRole) {
     for (const [role, summary] of Object.entries(measurements.resourceByRole)) {
-      byRole.set(role, { role, ...summary });
+      const existing = byRole.get(role) ?? { role };
+      existing.peakRssMb ??= summary.peakRssMb ?? null;
+      existing.maxCpuPercent ??= summary.maxCpuPercent ?? null;
+      byRole.set(role, existing);
     }
   }
-  return [...byRole.values()].toSorted((left, right) => {
-    const leftScore = Math.max(left.peakRssMb ?? 0, left.maxCpuPercent ?? 0);
-    const rightScore = Math.max(right.peakRssMb ?? 0, right.maxCpuPercent ?? 0);
-    return rightScore - leftScore;
+  return interleaveRankedRoles([...byRole.values()], {
+    rssRank: (role) => role.rssRank,
+    cpuRank: (role) => role.cpuRank
   });
+}
+
+function interleaveRankedRoles(roles, ranks = {}) {
+  const rssRoles = [...roles].toSorted((left, right) =>
+    compareRankedRole(left, right, ranks.rssRank, "peakRssMb")
+  );
+  const cpuRoles = [...roles].toSorted((left, right) =>
+    compareRankedRole(left, right, ranks.cpuRank, "maxCpuPercent")
+  );
+  const ordered = [];
+  const seen = new Set();
+  for (let rank = 0; rank < roles.length; rank += 1) {
+    appendRankedRole(ordered, seen, rssRoles[rank]);
+    appendRankedRole(ordered, seen, cpuRoles[rank]);
+  }
+  return ordered;
+}
+
+function compareRankedRole(left, right, explicitRank, metric) {
+  if (explicitRank) {
+    const leftRank = explicitRank(left) ?? Number.MAX_SAFE_INTEGER;
+    const rightRank = explicitRank(right) ?? Number.MAX_SAFE_INTEGER;
+    if (leftRank !== rightRank) {
+      return leftRank - rightRank;
+    }
+  }
+  return (right[metric] ?? Number.NEGATIVE_INFINITY) - (left[metric] ?? Number.NEGATIVE_INFINITY) ||
+    String(left.role).localeCompare(String(right.role));
+}
+
+function appendRankedRole(roles, seen, role) {
+  if (!role || seen.has(role.role)) {
+    return;
+  }
+  seen.add(role.role);
+  roles.push(role);
 }
 
 function pushMeasurementBrief(lines, measurements, { compact }) {
@@ -1927,7 +2008,7 @@ function buildFixerPrompt({ report, primaryBlocker, why, measurements, evidence,
   return parts.join(" ");
 }
 
-function formatGateSection(gate) {
+function formatGateSection(gate, rawGate = gate) {
   const lines = [
     "## Release Gate",
     "",
@@ -1980,14 +2061,15 @@ function formatGateSection(gate) {
   if (visibleCards.length > 0) {
     lines.push("### Failure Cards");
     lines.push("");
-    for (const card of visibleCards) {
+    for (const [index, card] of visibleCards.entries()) {
+      const rawCard = (rawGate.cards ?? []).filter((item) => item.severity !== "info")[index] ?? card;
       lines.push(`- ${card.severity.toUpperCase()} ${card.scenario ?? "gate"}${card.state ? `/${card.state}` : ""}: ${card.summary}`);
       lines.push(`  - expected: ${card.expected}`);
       lines.push(`  - actual: ${card.actual}`);
       lines.push(`  - impact: ${card.impact}`);
       lines.push(`  - likely owner: ${card.likelyOwner}`);
       if (card.failedCommand) {
-        lines.push(`  - command: \`${card.failedCommand}\``);
+        lines.push(`  - command: ${markdownCodeSpan(rawCard.failedCommand ?? card.failedCommand)}`);
       }
     }
     lines.push("");
@@ -2000,7 +2082,7 @@ function formatGateSection(gate) {
 }
 
 function fencedSnippet(value) {
-  return ["```text", ...value.split("\n").slice(0, 30), "```"].join("\n");
+  return markdownFence(value);
 }
 
 function shortCommand(command) {

--- a/src/reporting/report.mjs
+++ b/src/reporting/report.mjs
@@ -458,7 +458,7 @@ function tableCell(value) {
 }
 
 function formatResourceRoleSection(records = [], rawRecords = records) {
-  const roles = summarizeResourceRoles(records).slice(0, 8);
+  const roles = summarizeResourceRoles(rawRecords).slice(0, 8);
   if (roles.length === 0) {
     return [];
   }
@@ -472,7 +472,7 @@ function formatResourceRoleSection(records = [], rawRecords = records) {
   }
   for (const role of roles) {
     lines.push(
-      `- ${role.role}: RSS ${role.peakRssMb ?? "unknown"} MB (${formatResourcePeakSource(role.rssSource)}); ` +
+      `- ${markdownInline(role.role)}: RSS ${role.peakRssMb ?? "unknown"} MB (${formatResourcePeakSource(role.rssSource)}); ` +
       `CPU ${role.maxCpuPercent ?? "unknown"}% (${formatResourcePeakSource(role.cpuSource)})`
     );
   }
@@ -518,7 +518,7 @@ function formatResourcePeakSource(source) {
   if (!source) {
     return "source unknown";
   }
-  return `scenario ${source.scenario}${source.state ? `/${source.state}` : ""}`;
+  return `scenario ${markdownInline(source.scenario)}${source.state ? `/${markdownInline(source.state)}` : ""}`;
 }
 
 function formatChannelWorkflowResourceSection(records = []) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19796,6 +19796,31 @@ function resourcePeakProvenanceCheck() {
     assertEqual(roleKeyRendered.match(/worker\\_name/g)?.length, 1, "role array values and map keys share one identity");
     assertEqual(roleKeyRendered.includes("\n## forged"), false, "resource role keys cannot forge headings");
     assertEqual(roleKeyRendered.includes("<script>"), false, "resource role keys cannot inject raw HTML");
+    const distinctRoleRendered = renderMarkdownReport({
+      generatedAt: "2026-05-01T00:00:00.000Z",
+      runId: "self-check-distinct-resource-role-keys",
+      mode: "execution",
+      target: "runtime:stable",
+      platform: { os: "test", release: "test", arch: "test", node: "test" },
+      summary: { total: 1, statuses: { PASS: 1 } },
+      records: [{
+        ...baseRecord,
+        scenario: "distinct-role-keys",
+        measurements: {
+          resourceByRole: {
+            "worker\nname": { peakRssMb: 900, maxCpuPercent: 10 },
+            "worker name": { peakRssMb: 100, maxCpuPercent: 800 }
+          }
+        }
+      }]
+    });
+    assertEqual(
+      distinctRoleRendered.match(/- worker name: RSS/g)?.length,
+      2,
+      "roles remain distinct even when their escaped labels match"
+    );
+    assertEqual(distinctRoleRendered.includes("RSS 900 MB"), true, "first colliding role retains its RSS peak");
+    assertEqual(distinctRoleRendered.includes("CPU 800%"), true, "second colliding role retains its CPU peak");
     return {
       id: "resource-peak-provenance",
       status: "PASS",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19788,7 +19788,10 @@ function resourcePeakProvenanceCheck() {
           resourceTopRolesByRss: [{ role: "worker_name", peakRssMb: 500, maxCpuPercent: 50 }],
           resourceByRole: {
             worker_name: { peakRssMb: 500, maxCpuPercent: 50 },
-            "unsafe\n## forged\n<script>": { peakRssMb: 1, maxCpuPercent: 1 }
+            "unsafe\n## forged\n<script>": { peakRssMb: 4, maxCpuPercent: 4 },
+            "## forged": { peakRssMb: 3, maxCpuPercent: 3 },
+            "1) forged": { peakRssMb: 2, maxCpuPercent: 2 },
+            "---": { peakRssMb: 1, maxCpuPercent: 1 }
           }
         }
       }]
@@ -19796,6 +19799,9 @@ function resourcePeakProvenanceCheck() {
     assertEqual(roleKeyRendered.match(/worker\\_name/g)?.length, 1, "role array values and map keys share one identity");
     assertEqual(roleKeyRendered.includes("\n## forged"), false, "resource role keys cannot forge headings");
     assertEqual(roleKeyRendered.includes("<script>"), false, "resource role keys cannot inject raw HTML");
+    assertEqual(roleKeyRendered.includes("- \\## forged:"), true, "ATX heading role keys stay inline");
+    assertEqual(roleKeyRendered.includes("- 1\\) forged:"), true, "ordered-list role keys stay inline");
+    assertEqual(roleKeyRendered.includes("- \\---:"), true, "thematic-rule role keys stay inline");
     const distinctRoleRendered = renderMarkdownReport({
       generatedAt: "2026-05-01T00:00:00.000Z",
       runId: "self-check-distinct-resource-role-keys",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -124,6 +124,7 @@ import { captureProcessSnapshot, classifyRegistryRolesForProcess, classifySnapsh
 import { captureOpenClawStateSnapshot } from "./collectors/openclaw-state.mjs";
 import { collectStateFixtureAccounting } from "./collectors/state-fixtures.mjs";
 import { buildReportSummary, renderMarkdownReport, renderPasteSummary, renderReportSummary, summarizeRecords } from "./reporting/report.mjs";
+import { markdownFence, markdownTableCodeSpan } from "./reporting/markdown.mjs";
 import { buildRepeatedWorkAudit } from "./audits/repeated-work.mjs";
 import { ENV_COLLECTOR_IDS, resolveCollectionPolicy } from "./collection-policy.mjs";
 import { classifyManifest, selectManifestCandidates } from "./inventory/openclaw.mjs";
@@ -967,6 +968,8 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(await reportPublicationCheck(tmp));
     checks.push(cleanupPublicationReceiptCheck());
     checks.push(markdownFailureCardsCheck());
+    checks.push(markdownRuntimeFieldSafetyCheck());
+    checks.push(resourcePeakProvenanceCheck());
     checks.push(reportRecommendedNextScenarioCheck());
     checks.push(readinessClassificationCheck());
     checks.push(healthReadinessModelCheck());
@@ -9553,7 +9556,7 @@ function agentTurnBreakdownCheck() {
       summary: { statuses: { PASS: 1 } }
     });
     assertEqual(rendered.includes("breakdown:"), true, "markdown includes agent turn breakdown");
-    assertEqual(rendered.includes("models.catalog.* 70ms"), true, "markdown includes source span evidence");
+    assertEqual(rendered.includes("models.catalog.\\* 70ms"), true, "markdown includes source span evidence");
     assertEqual(rendered.includes("Agent turn stats:"), true, "markdown includes agent turn stats");
     assertEqual(
       summarizeAgentTurnBreakdownForMarkdown(normal.breakdown).includes("unknown 15ms"),
@@ -19563,7 +19566,11 @@ function markdownFailureCardsCheck() {
     assertEqual(rendered.includes("gateway readiness exceeded threshold"), true, "finding summary");
     assertEqual(rendered.includes("gateway-runtime"), true, "finding owner");
     assertEqual(rendered.includes("## Resource Roles"), true, "markdown resource roles section");
-    assertEqual(rendered.includes("gateway: RSS 1100 MB; CPU 220%"), true, "markdown resource role summary");
+    assertEqual(
+      rendered.includes("gateway: RSS 1100 MB (scenario gateway-performance); CPU 220% (scenario gateway-performance)"),
+      true,
+      "markdown resource role summary"
+    );
     return {
       id: "markdown-failure-cards",
       status: "PASS",
@@ -19575,6 +19582,231 @@ function markdownFailureCardsCheck() {
       id: "markdown-failure-cards",
       status: "FAIL",
       command: "render synthetic failure Markdown",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function markdownRuntimeFieldSafetyCheck() {
+  try {
+    const attack = "visible\n## forged\n<script>alert(1)</script>\n```text\nbreak";
+    const report = {
+      generatedAt: "2026-05-01T00:00:00.000Z",
+      runId: "unsafe|run",
+      mode: "execution",
+      target: "runtime:unsafe|target",
+      platform: { os: attack, release: attack, arch: attack, node: attack },
+      summary: { total: 1, statuses: { FAIL: 1 } },
+      records: [{
+        scenario: attack,
+        title: attack,
+        status: "FAIL",
+        cleanup: attack,
+        target: "runtime:unsafe|target",
+        likelyOwner: attack,
+        phases: [{
+          id: "unsafe",
+          title: attack,
+          intent: attack,
+          commands: [attack],
+          evidence: [],
+          results: [{
+            command: attack,
+            status: 1,
+            timedOut: false,
+            durationMs: 1,
+            stdout: "",
+            stderr: attack
+          }]
+        }],
+        measurements: {},
+        violations: []
+      }]
+    };
+    const original = JSON.stringify(report);
+    const markdown = renderMarkdownReport(report);
+    const paste = renderPasteSummary(report);
+    const failedCommandIndex = markdown.indexOf("- Failed command:");
+    const markdownInline = markdown.slice(0, failedCommandIndex);
+    assertEqual(failedCommandIndex >= 0, true, "report includes code-formatted failed command");
+    assertEqual(markdown.includes("\n## forged"), false, "report rejects forged headings");
+    assertEqual(markdownInline.includes("<script>"), false, "report inline fields reject raw HTML");
+    assertEqual(markdownInline.includes("&lt;script&gt;"), true, "report retains escaped inline HTML text");
+    assertEqual(markdown.includes("| Run ID | `unsafe\\|run` |"), true, "report table code spans escape pipes");
+    const failureLine = markdown.split("\n").find((line) => line.startsWith("- Failure:"));
+    assertEqual(failureLine?.includes("visible"), true, "report summarizes raw multiline failure output");
+    assertEqual(failureLine?.includes("forged"), false, "report failure summary stays concise");
+    const stderrMarker = "- stderr:\n";
+    const stderrIndex = paste.indexOf(stderrMarker);
+    const pasteInline = paste.slice(0, stderrIndex);
+    const pasteStderr = paste.slice(stderrIndex + stderrMarker.length);
+    assertEqual(stderrIndex >= 0, true, "paste includes fenced stderr");
+    assertEqual(pasteInline.includes("\n## forged"), false, "paste inline fields reject forged headings");
+    assertEqual(pasteInline.includes("<script>"), false, "paste inline fields reject raw HTML");
+    assertEqual(pasteInline.includes("&lt;script&gt;"), true, "paste retains escaped inline HTML text");
+    assertEqual(pasteStderr.startsWith("````text\n"), true, "paste chooses a fence longer than stderr backticks");
+    assertEqual(pasteStderr.includes(attack), true, "paste preserves multiline stderr evidence");
+    assertEqual(pasteStderr.includes("\n````\n"), true, "paste closes the expanded stderr fence");
+    const backtickStress = markdownFence(
+      `${Array.from({ length: 30 }, () => "safe").join("\n")}\n${"` ".repeat(150_000)}`
+    );
+    assertEqual(backtickStress.startsWith("```text\n"), true, "fence sizing ignores omitted log lines");
+    assertEqual(backtickStress.split("\n").length, 32, "fence output remains capped at 30 evidence lines");
+    const tableCode = markdownTableCodeSpan("left\\|right");
+    const pipeIndex = tableCode.indexOf("|");
+    const precedingBackslashes = tableCode.slice(0, pipeIndex).match(/\\+$/)?.[0].length ?? 0;
+    assertEqual(precedingBackslashes, 3, "table code preserves a literal backslash while escaping its pipe");
+    assertEqual(JSON.stringify(report), original, "renderers do not mutate JSON report data");
+    return {
+      id: "markdown-runtime-field-safety",
+      status: "PASS",
+      command: "render hostile runtime-derived Markdown fields",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "markdown-runtime-field-safety",
+      status: "FAIL",
+      command: "render hostile runtime-derived Markdown fields",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function resourcePeakProvenanceCheck() {
+  try {
+    const baseRecord = {
+      title: "Resource peak provenance",
+      status: "PASS",
+      target: "runtime:stable",
+      likelyOwner: "gateway-runtime",
+      phases: [],
+      violations: []
+    };
+    const rendered = renderMarkdownReport({
+      generatedAt: "2026-05-01T00:00:00.000Z",
+      runId: "self-check-resource-peak-provenance",
+      mode: "execution",
+      target: "runtime:stable",
+      platform: { os: "test", release: "test", arch: "test", node: "test" },
+      summary: { total: 2, statuses: { PASS: 2 } },
+      records: [
+        {
+          ...baseRecord,
+          scenario: "rss-heavy",
+          state: { id: "first" },
+          measurements: {
+            resourceTopRolesByRss: [
+              { role: "gateway", peakRssMb: 900, maxCpuPercent: 20 },
+              { role: "agent", peakRssMb: 500, maxCpuPercent: 10 }
+            ],
+            resourceTopRolesByCpu: [
+              { role: "agent", peakRssMb: 100, maxCpuPercent: 80 },
+              { role: "gateway", peakRssMb: 200, maxCpuPercent: 40 }
+            ]
+          }
+        },
+        {
+          ...baseRecord,
+          scenario: "cpu-heavy",
+          state: { id: "second" },
+          measurements: {
+            resourceTopRolesByRss: [{ role: "gateway", peakRssMb: 700, maxCpuPercent: 30 }],
+            resourceTopRolesByCpu: [{ role: "gateway", peakRssMb: 300, maxCpuPercent: 220 }]
+          }
+        }
+      ]
+    });
+    const gateway = "- gateway: RSS 900 MB (scenario rss-heavy/first); CPU 220% (scenario cpu-heavy/second)";
+    const agent = "- agent: RSS 500 MB (scenario rss-heavy/first); CPU 80% (scenario rss-heavy/first)";
+    assertEqual(rendered.includes(gateway), true, "RSS and CPU retain independent peak sources");
+    assertEqual(rendered.includes(agent), true, "ranked lists retain independent metric values");
+    assertEqual(rendered.indexOf(gateway) < rendered.indexOf(agent), true, "RSS rank order is preserved");
+    const cpuOnlyRendered = renderMarkdownReport({
+      generatedAt: "2026-05-01T00:00:00.000Z",
+      runId: "self-check-cpu-only-role",
+      mode: "execution",
+      target: "runtime:stable",
+      platform: { os: "test", release: "test", arch: "test", node: "test" },
+      summary: { total: 1, statuses: { PASS: 1 } },
+      records: [{
+        ...baseRecord,
+        scenario: "split-rankings",
+        measurements: {
+          resourceTopRolesByRss: Array.from({ length: 8 }, (_, index) => ({
+            role: `rss-${index}`,
+            peakRssMb: 800 - index,
+            maxCpuPercent: index
+          })),
+          resourceTopRolesByCpu: [{ role: "cpu-only", peakRssMb: 10, maxCpuPercent: 999 }]
+        }
+      }]
+    });
+    assertEqual(cpuOnlyRendered.includes("- cpu-only: RSS 10 MB"), true, "CPU-only top role survives display limit");
+    const laterPeakRendered = renderMarkdownReport({
+      generatedAt: "2026-05-01T00:00:00.000Z",
+      runId: "self-check-later-global-peak",
+      mode: "execution",
+      target: "runtime:stable",
+      platform: { os: "test", release: "test", arch: "test", node: "test" },
+      summary: { total: 2, statuses: { PASS: 2 } },
+      records: [
+        {
+          ...baseRecord,
+          scenario: "early-roles",
+          measurements: {
+            resourceTopRolesByRss: Array.from({ length: 8 }, (_, index) => ({
+              role: `early-${index}`,
+              peakRssMb: 100 - index,
+              maxCpuPercent: 10 - index
+            }))
+          }
+        },
+        {
+          ...baseRecord,
+          scenario: "late-peak",
+          measurements: {
+            resourceTopRolesByRss: [{ role: "late-hot", peakRssMb: 2000, maxCpuPercent: 1500 }]
+          }
+        }
+      ]
+    });
+    assertEqual(laterPeakRendered.includes("- late-hot: RSS 2000 MB"), true, "later global peak survives display limit");
+    const roleKeyRendered = renderMarkdownReport({
+      generatedAt: "2026-05-01T00:00:00.000Z",
+      runId: "self-check-resource-role-keys",
+      mode: "execution",
+      target: "runtime:stable",
+      platform: { os: "test", release: "test", arch: "test", node: "test" },
+      summary: { total: 1, statuses: { PASS: 1 } },
+      records: [{
+        ...baseRecord,
+        scenario: "role-keys",
+        measurements: {
+          resourceTopRolesByRss: [{ role: "worker_name", peakRssMb: 500, maxCpuPercent: 50 }],
+          resourceByRole: {
+            worker_name: { peakRssMb: 500, maxCpuPercent: 50 },
+            "unsafe\n## forged\n<script>": { peakRssMb: 1, maxCpuPercent: 1 }
+          }
+        }
+      }]
+    });
+    assertEqual(roleKeyRendered.match(/worker\\_name/g)?.length, 1, "role array values and map keys share one identity");
+    assertEqual(roleKeyRendered.includes("\n## forged"), false, "resource role keys cannot forge headings");
+    assertEqual(roleKeyRendered.includes("<script>"), false, "resource role keys cannot inject raw HTML");
+    return {
+      id: "resource-peak-provenance",
+      status: "PASS",
+      command: "render divergent RSS and CPU peak sources",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "resource-peak-provenance",
+      status: "FAIL",
+      command: "render divergent RSS and CPU peak sources",
       durationMs: 0,
       message: error.message
     };


### PR DESCRIPTION
## What Problem This Solves

Kova Markdown and paste reports rendered runtime-derived free-form values without a complete context-aware escaping boundary. Hostile or malformed values could alter Markdown structure, while eager normalization of dynamic resource-role keys could collapse distinct roles before aggregation.

Resource summaries also combined independently ranked RSS and CPU observations into one apparent scenario attribution, which could misstate where each peak occurred.

## Why This Change Was Made

- Add renderer-only helpers for inline text, code spans, table code spans, and fenced evidence.
- Keep JSON report data and multiline command evidence unchanged.
- Aggregate resource roles from raw identities, then escape only their displayed labels.
- Preserve independent RSS and CPU values, ordering, and scenario/state provenance.
- Cover hostile headings, lists, thematic rules, HTML, pipes, backticks, colliding normalized role labels, and divergent peak sources.

## User Impact

Human-readable Kova reports can no longer be structurally spoofed by runtime-derived Markdown values, and resource-role summaries identify the actual source of each RSS and CPU peak. JSON consumers retain the original report data.

## Evidence

- Base: `5615d97927f629ff7e64c0f49d4eac7a5601f07a`
- Head: `c9cb2d20905538fe340fb157f750c1adc8216725`
- `npm run check:full`
  - concurrent self-check isolation passed
  - self-check `264/264`
  - snapshots `21/21`
  - web payload check passed
  - release contract checks passed
- Packed/extracted release smoke:
  - `npm run pack:release`
  - isolated archive install passed
  - installed `kova version` and `kova setup --ci --json` passed
  - installed self-check `264/264`
- Explicit autoreview:
  - `gpt-5.6-sol`, high reasoning
  - no accepted or actionable findings
- `git diff --check` passed
