### PR TITLE
fix(ui): make terminal rendering width-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Made terminal reports width-safe for Unicode, narrow layouts, wrapped shell hints, duration rollover, and strict numeric samples.
 - Hardened command execution with bounded streaming redaction, POSIX process-group cleanup, strict optional-log matching, and direct scenario command validation.
 - Hardened artifact confidentiality by redacting credential-bearing logs before persistence and containing OpenClaw state collection against symlink escapes and hostile filesystem inputs.
 - Hardened mock-provider and diagnostic process handling to reject non-decimal PID state, migrate active legacy providers safely, reject stale startup metadata, avoid signaling unrelated processes, retain retryable PID state, and preserve colliding diagnostic artifacts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "@shakkernerd/kova",
       "version": "0.1.0",
       "dependencies": {
+        "cli-truncate": "^6.1.1",
         "json5": "2.2.3",
         "mock-ai-provider": "0.1.2",
+        "string-width": "^8.2.2",
         "tar-stream": "3.2.0",
         "unicode-case-folding": "1.1.1",
+        "wrap-ansi": "^10.0.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -19,6 +22,30 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/b4a": {
@@ -115,6 +142,22 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.1.1.tgz",
+      "integrity": "sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^9.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -129,6 +172,33 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -154,6 +224,22 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
+      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
@@ -163,6 +249,37 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/tar-stream": {
@@ -200,6 +317,23 @@
       "resolved": "https://registry.npmjs.org/unicode-case-folding/-/unicode-case-folding-1.1.1.tgz",
       "integrity": "sha512-ZAYziAnMTBisO2dT5tyGvBFMNsIfonOS/BZTd3UZaKWtXMOZqK8s8HRUCrlKxGCTeCxCuCjS/6HW+4a6G+rbzw==",
       "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,13 @@
     "node": ">=22"
   },
   "dependencies": {
+    "cli-truncate": "^6.1.1",
     "json5": "2.2.3",
     "mock-ai-provider": "0.1.2",
+    "string-width": "^8.2.2",
     "tar-stream": "3.2.0",
     "unicode-case-folding": "1.1.1",
+    "wrap-ansi": "^10.0.0",
     "zod": "^4.4.3"
   }
 }

--- a/src/reporting/render-assessment.mjs
+++ b/src/reporting/render-assessment.mjs
@@ -64,7 +64,7 @@ export function renderAssessment(report, flags = {}, env = process.env, stream =
   const summary = buildReportSummary(report);
   const scenarios = aggregateScenarios(report, summary.findings);
   const isFull = !!flags.full;
-  return withMargin(renderFromSummary({ summary, scenarios, isFull }, ui), ui.leftPad);
+  return withMargin(renderFromSummary({ summary, scenarios, isFull }, ui), ui.leftPad, ui.width);
 }
 
 // Exposed for tests and downstream callers.

--- a/src/reporting/render-bundle.mjs
+++ b/src/reporting/render-bundle.mjs
@@ -30,7 +30,7 @@ export function renderBundleReceipt(receipt, flags = {}, env = process.env, stre
   for (const [label, value] of rows) {
     if (!value) continue;
     const head = `  ${c.dim(padEndPlain(label, labelCol))}  `;
-    const avail = Math.max(20, ui.width - visualWidth(head));
+    const avail = Math.max(1, ui.width - visualWidth(head));
     const wrapped = wrap(String(value), avail);
     sections.push(head + c.met(wrapped[0] ?? ""));
     for (const cont of wrapped.slice(1)) {
@@ -44,7 +44,7 @@ export function renderBundleReceipt(receipt, flags = {}, env = process.env, stre
   sections.push(`  ${c.dim(g.arrow)} kova report ${displayPath(receipt.outputPath) ?? ""}`);
   if (receipt.runId) sections.push(`  ${c.dim(g.arrow)} kova report ${receipt.runId}`);
 
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 function formatBytes(n) {

--- a/src/reporting/render-cleanup.mjs
+++ b/src/reporting/render-cleanup.mjs
@@ -29,7 +29,7 @@ export function renderCleanupEnvs({ envs, results, execute, force = false, older
     kind: "envs",
     verdict
   }));
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 export function renderCleanupArtifacts({ candidates, results, execute, artifactsDir, olderThanDays }, flags = {}, env = process.env, stream = process.stdout) {
@@ -58,7 +58,7 @@ export function renderCleanupArtifacts({ candidates, results, execute, artifacts
     artifactsDir,
     verdict
   }));
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 function deriveEnvsVerdict({ envs, results, execute }) {
@@ -179,7 +179,7 @@ function renderEnvsTable({ envs, results, execute }, ui) {
       { key: "env",    header: c.dim("env"),    align: "left", minWidth: 24 },
       { key: "note",   header: c.dim("detail"), align: "left", minWidth: 10 },
     ],
-    rows, gap: 2,
+    rows, gap: 2, maxWidth: Math.max(1, ui.width - 2),
   }), 2));
   return lines.join("\n");
 }
@@ -204,7 +204,7 @@ function renderArtifactsTable({ candidates, results, execute }, ui) {
       { key: "name",   header: c.dim("artifact dir"), align: "left", minWidth: 32 },
       { key: "note",   header: c.dim("detail"), align: "left", minWidth: 10 },
     ],
-    rows, gap: 2,
+    rows, gap: 2, maxWidth: Math.max(1, ui.width - 2),
   }), 2));
   return lines.join("\n");
 }

--- a/src/reporting/render-compare.mjs
+++ b/src/reporting/render-compare.mjs
@@ -37,7 +37,7 @@ const TOP_SKIPPED_RESOURCE_METRICS = 6;
 
 export function renderCompareAssessment(comparison, flags = {}, env = process.env, stream = process.stdout) {
   const ui = makeUi(flags, env, stream);
-  return withMargin(renderCompareFromComparison(comparison, ui, { full: !!flags.full }), ui.leftPad);
+  return withMargin(renderCompareFromComparison(comparison, ui, { full: !!flags.full }), ui.leftPad, ui.width);
 }
 
 export function renderCompareFromComparison(comparison, ui, opts = {}) {

--- a/src/reporting/render-error.mjs
+++ b/src/reporting/render-error.mjs
@@ -104,7 +104,7 @@ export function renderError(error, flags = {}, env = process.env, stream = proce
       }
     }
   }
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 function nearestCommand(input) {

--- a/src/reporting/render-help.mjs
+++ b/src/reporting/render-help.mjs
@@ -244,7 +244,7 @@ const NOTES = [
 export function renderHelp(commandId, flags = {}, env = process.env, stream = process.stdout) {
   const ui = makeUi(flags, env, stream);
   const cmd = commandId ? COMMANDS.find((c) => c.id === commandId) : null;
-  return withMargin(cmd ? renderCommandHelp(cmd, ui) : renderTopLevelHelp(ui), ui.leftPad);
+  return withMargin(cmd ? renderCommandHelp(cmd, ui) : renderTopLevelHelp(ui), ui.leftPad, ui.width);
 }
 
 function renderTopLevelHelp(ui) {

--- a/src/reporting/render-inventory.mjs
+++ b/src/reporting/render-inventory.mjs
@@ -22,7 +22,7 @@ export function renderInventoryPlan(plan, flags = {}, env = process.env, stream 
 
   sections.push("");
   sections.push(renderFooter(plan, ui));
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 function renderBand(plan, ui) {
@@ -93,7 +93,7 @@ function renderWarnings(plan, ui, flags) {
 
   const lines = [ruleSection(heading, ui.width, ui)];
   for (const w of top) {
-    const wrapped = wrap(String(w.message ?? ""), Math.max(20, ui.width - 6));
+    const wrapped = wrap(String(w.message ?? ""), Math.max(1, ui.width - 6));
     lines.push(`  ${c.warn(g.warn)} ${c.dim(wrapped[0] ?? "")}`);
     for (const cont of wrapped.slice(1)) lines.push("    " + c.dim(cont));
   }

--- a/src/reporting/render-matrix-plan.mjs
+++ b/src/reporting/render-matrix-plan.mjs
@@ -19,7 +19,7 @@ export function renderMatrixPlan(planJson, flags = {}, env = process.env, stream
 
   sections.push("");
   sections.push(renderNext(planJson, ui));
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 function renderBand(planJson, ui) {
@@ -90,7 +90,7 @@ function renderEntries(planJson, ui) {
     ],
     rows,
     gap: 2,
-    maxWidth: ui.width ? Math.max(40, ui.width - 2) : null,
+    maxWidth: ui.width ? Math.max(1, ui.width - 2) : null,
   });
   lines.push(indentBlock(table, 2));
 

--- a/src/reporting/render-plan.mjs
+++ b/src/reporting/render-plan.mjs
@@ -26,7 +26,7 @@ export function renderPlan(planJson, flags = {}, env = process.env, stream = pro
 
   sections.push("");
   sections.push(renderNext(planJson, ui));
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 function renderBand(planJson, ui) {
@@ -116,7 +116,7 @@ function renderChannelWorkflowCoverage(planJson, ui) {
     ],
     rows,
     gap: 2,
-    maxWidth: ui.width ? Math.max(40, ui.width - 2) : null
+    maxWidth: ui.width ? Math.max(1, ui.width - 2) : null
   });
   return [
     ruleSection("channel user flows", ui.width, ui),
@@ -149,7 +149,7 @@ function renderScenarioList(planJson, ui) {
     ],
     rows,
     gap: 2,
-    maxWidth: ui.width ? Math.max(40, ui.width - 2) : null,
+    maxWidth: ui.width ? Math.max(1, ui.width - 2) : null,
   });
   lines.push(indentBlock(table, 2));
 

--- a/src/reporting/render-run-receipt.mjs
+++ b/src/reporting/render-run-receipt.mjs
@@ -30,7 +30,7 @@ export function renderRunReceipt({ report, reportPath, jsonPath, summaryPath }, 
 
   sections.push("");
   sections.push(renderNext({ report, reportPath, jsonPath }, ui));
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 export function renderMatrixRunReceipt({ report, reportPath, jsonPath, summaryPath, bundlePath, retainedGateArtifacts }, flags = {}, env = process.env, stream = process.stdout) {
@@ -54,7 +54,7 @@ export function renderMatrixRunReceipt({ report, reportPath, jsonPath, summaryPa
 
   sections.push("");
   sections.push(renderNext({ report, reportPath, jsonPath, bundlePath }, ui));
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 function renderBand(report, ui, { kind }) {

--- a/src/reporting/render-run-receipt.mjs
+++ b/src/reporting/render-run-receipt.mjs
@@ -7,7 +7,7 @@
 
 import {
   makeUi, ruleSection, renderKovaHeader, kpiStrip,
-  scenariosRollup, withMargin,
+  scenariosRollup, visualWidth, withMargin, wrap,
 } from "../ui/index.mjs";
 import { aggregateScenarios } from "./scenario-aggregate.mjs";
 import { displayPath } from "../paths.mjs";
@@ -201,16 +201,27 @@ function renderScenarios(report, ui, opts = {}) {
 
 function renderArtifacts({ reportPath, jsonPath, summaryPath, bundlePath, retainedGateArtifacts }, ui) {
   const { c, g } = ui;
-  const rel = (p) => displayPath(p);
   const lines = [ruleSection("artifacts", ui.width, ui)];
-  if (reportPath)   lines.push(`  ${c.head(g.diamond)} ${c.dim("markdown   ")} ${rel(reportPath)}`);
-  if (jsonPath)     lines.push(`  ${c.head(g.diamond)} ${c.dim("json       ")} ${rel(jsonPath)}`);
-  if (summaryPath)  lines.push(`  ${c.head(g.diamond)} ${c.dim("summary    ")} ${rel(summaryPath)}`);
-  if (bundlePath)   lines.push(`  ${c.head(g.diamond)} ${c.dim("bundle     ")} ${rel(bundlePath)}`);
+  if (reportPath) lines.push(renderArtifactPath("markdown", reportPath, c.head(g.diamond), ui));
+  if (jsonPath) lines.push(renderArtifactPath("json", jsonPath, c.head(g.diamond), ui));
+  if (summaryPath) lines.push(renderArtifactPath("summary", summaryPath, c.head(g.diamond), ui));
+  if (bundlePath) lines.push(renderArtifactPath("bundle", bundlePath, c.head(g.diamond), ui));
   if (retainedGateArtifacts?.outputDir) {
-    lines.push(`  ${c.warn(g.warn)} ${c.dim("retained   ")} ${rel(retainedGateArtifacts.outputDir)}`);
+    lines.push(renderArtifactPath("retained", retainedGateArtifacts.outputDir, c.warn(g.warn), ui));
   }
   return lines.join("\n");
+}
+
+function renderArtifactPath(label, path, glyph, ui) {
+  const labelCell = String(label).padEnd(11);
+  const prefix = `  ${glyph} ${ui.c.dim(labelCell)} `;
+  const available = Math.max(1, ui.width - visualWidth(prefix));
+  const pathLines = wrap(displayPath(path), available);
+  const continuation = " ".repeat(visualWidth(prefix));
+  return [
+    prefix + (pathLines[0] ?? ""),
+    ...pathLines.slice(1).map((line) => continuation + line),
+  ].join("\n");
 }
 
 function renderNext({ report, reportPath, jsonPath, bundlePath }, ui) {

--- a/src/reporting/render-selfcheck.mjs
+++ b/src/reporting/render-selfcheck.mjs
@@ -78,7 +78,7 @@ export function renderSelfCheckReceipt(result, flags = {}, env = process.env, st
 
   sections.push("");
   sections.push(renderFooter(result, ui));
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 function deriveVerdict(result) {
@@ -112,7 +112,7 @@ function renderFailures(failed, ui) {
       { key: "id",     header: c.dim("check"),  align: "left", minWidth: 22 },
       { key: "detail", header: c.dim("detail"), align: "left", minWidth: 24 },
     ],
-    rows, gap: 2,
+    rows, gap: 2, maxWidth: Math.max(1, ui.width - 2),
   }), 2));
   return lines.join("\n");
 }

--- a/src/reporting/render-setup.mjs
+++ b/src/reporting/render-setup.mjs
@@ -32,7 +32,7 @@ export function renderSetup(result, flags = {}, env = process.env, stream = proc
     sections.push("");
     sections.push(renderNext(result.nextCommands, ui));
   }
-  return withMargin(sections.join("\n"), ui.leftPad);
+  return withMargin(sections.join("\n"), ui.leftPad, ui.width);
 }
 
 function deriveVerdict(result) {
@@ -95,7 +95,7 @@ function renderChecks(result, ui) {
       { key: "id",     header: c.dim("check"),  align: "left", minWidth: 22 },
       { key: "detail", header: c.dim("detail"), align: "left", minWidth: 24 },
     ],
-    rows, gap: 2,
+    rows, gap: 2, maxWidth: Math.max(1, ui.width - 2),
   }), 2));
   return lines.join("\n");
 }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -402,7 +402,9 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       assertEqual(visualWidth("👨‍👩‍👧‍👦"), 2, "emoji grapheme width");
       assertEqual(truncateText("👨‍👩‍👧‍👦 family", 3), "👨‍👩‍👧‍👦…", "truncate preserves grapheme");
       assertEqual(wrap("界界界", 4).every((line) => visualWidth(line) <= 4), true, "wrap respects cell width");
-      assertEqual(wrap("界", 1), ["…"], "wrap replaces graphemes wider than the line");
+      const narrowWideGrapheme = wrap("界", 1);
+      assertEqual(narrowWideGrapheme.length, 1, "wide grapheme wrap line count");
+      assertEqual(narrowWideGrapheme[0], "…", "wrap replaces graphemes wider than the line");
 
       assertEqual(formatDuration(59_950), "1m", "duration carries seconds into minutes");
       assertEqual(formatDuration(3_599_600), "1h 00m", "duration carries minutes into hours");

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -172,6 +172,22 @@ import {
   writeReportOutputs
 } from "./run/report-output.mjs";
 import {
+  badge,
+  card,
+  detectCapabilities,
+  formatDuration,
+  makeUi,
+  renderKovaHeader,
+  renderTable,
+  resolveWidth,
+  scenarioRule,
+  summarizeSamples,
+  truncate as truncateText,
+  visualWidth,
+  withMargin,
+  wrap,
+} from "./ui/index.mjs";
+import {
   ocmAt,
   ocmEnvDestroy,
   ocmEnvDestroyPreviewJson,
@@ -375,6 +391,136 @@ async function runScopedSelfCheck(flags, scope, workspace) {
         rejected = /must be true or false/.test(error.message);
       }
       assertEqual(rejected, true, "invalid boolean value rejected");
+    }));
+    checks.push(await inlineCheck("terminal-ui-contracts", () => {
+      const samples = summarizeSamples([null, "", false, 0, 2, Number.NaN]);
+      assertEqual(samples.n, 2, "sample summary accepts finite numbers only");
+      assertEqual(samples.mean, 1, "sample summary preserves numeric zero");
+
+      assertEqual(visualWidth("e\u0301"), 1, "combining grapheme width");
+      assertEqual(visualWidth("界"), 2, "fullwidth cell width");
+      assertEqual(visualWidth("👨‍👩‍👧‍👦"), 2, "emoji grapheme width");
+      assertEqual(truncateText("👨‍👩‍👧‍👦 family", 3), "👨‍👩‍👧‍👦…", "truncate preserves grapheme");
+      assertEqual(wrap("界界界", 4).every((line) => visualWidth(line) <= 4), true, "wrap respects cell width");
+      assertEqual(wrap("界", 1), ["…"], "wrap replaces graphemes wider than the line");
+
+      assertEqual(formatDuration(59_950), "1m", "duration carries seconds into minutes");
+      assertEqual(formatDuration(3_599_600), "1h 00m", "duration carries minutes into hours");
+      assertEqual(resolveWidth(24).width, 24, "resolved width never exceeds narrow terminal");
+      assertEqual(resolveWidth(24, { width: 80 }).width, 24, "explicit width cannot exceed terminal");
+
+      assertEqual(detectCapabilities({ NO_COLOR: "" }, {}).noColor, false, "empty NO_COLOR is disabled");
+      assertEqual(detectCapabilities({ NO_COLOR: "0" }, {}).noColor, true, "non-empty NO_COLOR is enabled");
+
+      const ui = makeUi(
+        { color: "never" },
+        { LANG: "en_US.UTF-8" },
+        { isTTY: false, columns: 24 },
+      );
+      const header = renderKovaHeader({
+        surface: "report",
+        verdict: "OK",
+        headline: "a deliberately long headline with fullwidth 界 text",
+        meta: "target runtime:stable",
+        ui,
+      });
+      assertEqual(
+        header.split("\n").every((line) => visualWidth(line) <= ui.width),
+        true,
+        "header wraps within terminal width",
+      );
+      const command = withMargin(
+        "  → node bin/kova.mjs run --profile-on-failure --json",
+        0,
+        39,
+      );
+      assertEqual(
+        command.split("\n").every((line) => visualWidth(line) <= 39),
+        true,
+        "command continuations stay within terminal width",
+      );
+      assertEqual(command.includes("\\\n"), true, "wrapped commands use shell continuations");
+      assertEqual(
+        Array.from({ length: 11 }, (_, index) => index + 1).every((width) => (
+          withMargin("  → node bin/kova.mjs run --json", 0, width)
+            .split("\n")
+            .every((line) => visualWidth(line) <= width)
+        )),
+        true,
+        "sub-structural command hints never exceed terminal width",
+      );
+      assertEqual(
+        [12, 13, 14, 15].every((width) => (
+          withMargin("  → printf '%s' 'quoted value'", 0, width)
+            .split("\n")
+            .every((line) => visualWidth(line) <= width)
+        )),
+        true,
+        "quoted commands never bypass narrow width constraints",
+      );
+      const colorUi = makeUi(
+        { color: "always" },
+        { LANG: "en_US.UTF-8" },
+        { isTTY: true, columns: 39 },
+      );
+      const coloredCommand = withMargin(
+        `  ${colorUi.c.dim(colorUi.g.arrow)} node bin/kova.mjs run --profile-on-failure --json`,
+        0,
+        39,
+      );
+      assertEqual(coloredCommand.includes("\\\n"), true, "colorized command arrows preserve shell wrapping");
+      assertEqual(
+        withMargin("  → printf '%s' 'quoted value'", 0, 24).includes("eval "),
+        true,
+        "quoted commands use an exact shell expression",
+      );
+      const centeredExpression = withMargin("  → printf '%s' 'quoted value'", 4, 24);
+      assertEqual(
+        centeredExpression.includes("\\\n'"),
+        true,
+        "centered shell chunks stay adjacent across continuations",
+      );
+      assertEqual(
+        centeredExpression.split("\n").every((line) => visualWidth(line) <= 28),
+        true,
+        "centered commands include margin within terminal width",
+      );
+      const compactTable = renderTable({
+        columns: [
+          { key: "status", header: "status", align: "left", minWidth: 8 },
+          { key: "name", header: "artifact dir", align: "left", minWidth: 24 },
+          { key: "note", header: "detail", align: "left", minWidth: 10 },
+        ],
+        rows: [{ status: "REMOVED", name: "long-artifact-name", note: "done" }],
+        gap: 2,
+        maxWidth: 40,
+      });
+      assertEqual(
+        compactTable.split("\n").every((line) => visualWidth(line) <= 40),
+        true,
+        "tables compact when structural columns do not fit",
+      );
+      assertEqual(
+        scenarioRule({
+          id: "a-very-long-scenario-identifier-that-cannot-fit-inline",
+          verdict: "PASS",
+          samples: 12,
+          ui: colorUi,
+        }).split("\n").every((line) => visualWidth(line) <= 39),
+        true,
+        "scenario rules stack metadata before overflow",
+      );
+      assertEqual(
+        card({
+          title: "a card title much wider than its frame",
+          lines: ["body"],
+          width: 24,
+          ui: colorUi,
+        }).split("\n").every((line) => visualWidth(line) <= 24),
+        true,
+        "card titles stay within their frame",
+      );
+      assertEqual(badge("OK", "OK", { color: true }).includes("\u001b[42;30m"), true, "OK badge uses success tone");
     }));
     checks.push(await inlineCheck("external-plugin-fixture-manifests", async () => {
       for (const [dir, expectedId] of [
@@ -2833,15 +2979,16 @@ function fixtureAccountingRenderCheck() {
       findings: []
     };
     const rendered = renderAssessment(report, { full: true, color: "never" }, process.env, process.stdout);
+    const normalizedRendered = rendered.replace(/\s+/g, " ");
     assertEqual(rendered.includes("Fixture Accounting"), true, "fixture accounting section rendered");
     assertEqual(rendered.includes("sessions:"), true, "session accounting line rendered");
-    assertEqual(rendered.includes("store[80] source"), true, "source session store summarized");
-    assertEqual(rendered.includes("store[80] canonical"), true, "canonical session store summarized");
-    assertEqual(rendered.includes("store[80] legacy"), true, "legacy session store summarized");
+    assertEqual(normalizedRendered.includes("store[80] source"), true, "source session store summarized");
+    assertEqual(normalizedRendered.includes("store[80] canonical"), true, "canonical session store summarized");
+    assertEqual(normalizedRendered.includes("store[80] legacy"), true, "legacy session store summarized");
     assertEqual(rendered.includes("memory:"), true, "memory accounting line rendered");
-    assertEqual(rendered.includes("items[1200] source"), true, "source memory summarized");
-    assertEqual(rendered.includes("items[1200] canonical"), true, "canonical memory summarized");
-    assertEqual(rendered.includes("items[1200] legacy"), true, "legacy memory summarized");
+    assertEqual(normalizedRendered.includes("items[1200] source"), true, "source memory summarized");
+    assertEqual(normalizedRendered.includes("items[1200] canonical"), true, "canonical memory summarized");
+    assertEqual(normalizedRendered.includes("items[1200] legacy"), true, "legacy memory summarized");
     assertEqual(rendered.includes("sessionId"), false, "fixture payload keys not dumped");
     return {
       id: "fixture-accounting-render",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -512,6 +512,33 @@ async function runScopedSelfCheck(flags, scope, workspace) {
         true,
         "scenario rules stack metadata before overflow",
       );
+      const longArtifactReceipt = renderRunReceipt({
+        report: {
+          mode: "dry-run",
+          runId: "kova-terminal-width-check",
+          summary: { total: 0, statuses: {} },
+          records: [],
+        },
+        reportPath: `/outside/${"deep/".repeat(20)}report.md`,
+      }, { color: "never" }, process.env, { isTTY: false, columns: 80 });
+      const artifactLines = longArtifactReceipt.split("\n");
+      const artifactLabelIndex = artifactLines.findIndex((line) => line.includes("◆ markdown"));
+      assertEqual(artifactLabelIndex >= 0, true, "artifact receipt includes markdown label");
+      assertEqual(
+        artifactLines[artifactLabelIndex].includes("/outside/"),
+        true,
+        "artifact path begins beside its label",
+      );
+      assertEqual(
+        artifactLines[artifactLabelIndex + 1].startsWith(" ".repeat(16)),
+        true,
+        "artifact path continuations use a hanging indent",
+      );
+      assertEqual(
+        artifactLines.every((line) => visualWidth(line) <= 80),
+        true,
+        "artifact receipt stays within terminal width",
+      );
       assertEqual(
         card({
           title: "a card title much wider than its frame",

--- a/src/ui/badges.mjs
+++ b/src/ui/badges.mjs
@@ -6,6 +6,13 @@ import { makeColor } from "./color.mjs";
 const KIND_TO_BG = {
   SHIP: "ok",
   PASS: "ok",
+  OK: "ok",
+  READY: "ok",
+  GREEN: "ok",
+  CLEAN: "ok",
+  CLEANED: "ok",
+  DONE: "ok",
+  IMPROVED: "ok",
   DO_NOT_SHIP: "err",
   FAIL: "err",
   PARTIAL: "warn",

--- a/src/ui/confidence.mjs
+++ b/src/ui/confidence.mjs
@@ -20,8 +20,7 @@ export const CONFIDENCE_BUCKETS = ["single-sample", "stable", "moderate", "noisy
 //   - p95 is null when n < 2; the renderer should pick the column variant.
 export function summarizeSamples(values) {
   const xs = (values ?? [])
-    .map((v) => Number(v))
-    .filter((v) => Number.isFinite(v));
+    .filter((value) => typeof value === "number" && Number.isFinite(value));
   const n = xs.length;
   if (n === 0) {
     return { n: 0, mean: null, median: null, stdev: null, p95: null, min: null, max: null, cv: null };
@@ -62,8 +61,8 @@ export function classifyConfidence({ n, cv } = {}) {
 // Returns the percentage of the threshold still unused. Negative when
 // the threshold is breached. Null when inputs are missing.
 export function headroomPercent({ value, threshold, direction = "lower-better" } = {}) {
-  const v = Number(value);
-  const t = Number(threshold);
+  const v = typeof value === "number" ? value : Number.NaN;
+  const t = typeof threshold === "number" ? threshold : Number.NaN;
   if (!Number.isFinite(v) || !Number.isFinite(t) || t === 0) return null;
   const raw = direction === "lower-better" ? (t - v) / t : (v - t) / t;
   return raw * 100;

--- a/src/ui/findings-block.mjs
+++ b/src/ui/findings-block.mjs
@@ -25,7 +25,7 @@ export function findingsBlock({ findings, compare = false, ui, limit = null, ind
   if (!findings || findings.length === 0) return "";
   const c = ui.c;
   const g = ui.g;
-  const width = Math.max(20, (ui.width ?? 80) - indent);
+  const width = Math.max(1, (ui.width ?? 80) - indent);
   const top = limit ? findings.slice(0, limit) : findings;
 
   const lines = [];
@@ -62,11 +62,11 @@ export function findingsBlock({ findings, compare = false, ui, limit = null, ind
 
     const scope = formatScope(f);
     const evidence = (f.evidence ?? []).slice(0, 2).map(tightenSummary).join("; ");
-    const detail = [scope, evidence].filter(Boolean).join("  ");
+    const detail = [scope, evidence].filter(Boolean).join(" ");
     if (detail) {
-      const indent = 6;
-      const wrapped = wrap(detail, Math.max(20, width - indent));
-      for (const w of wrapped) lines.push(repeat(" ", indent) + c.dim(w));
+      const detailIndent = Math.min(6, Math.max(0, width - 1));
+      const wrapped = wrap(detail, Math.max(1, width - detailIndent));
+      for (const w of wrapped) lines.push(repeat(" ", detailIndent) + c.dim(w));
     }
   }
 
@@ -170,12 +170,12 @@ function commaNum(n) {
 // The owner suffix is glued to the last line when it fits there; otherwise
 // it gets its own continuation line.
 function wrapSummaryWithOwner(summary, ownerSuffix, available) {
-  const min = Math.max(20, available);
-  if (!ownerSuffix) return wrap(summary, min);
+  const width = Math.max(1, available);
+  if (!ownerSuffix) return wrap(summary, width);
 
-  const lines = wrap(summary, min);
+  const lines = wrap(summary, width);
   const last = lines[lines.length - 1];
-  if (visualWidth(last) + visualWidth(ownerSuffix) <= min) {
+  if (visualWidth(last) + visualWidth(ownerSuffix) <= width) {
     lines[lines.length - 1] = last + ownerSuffix;
   } else {
     lines.push(ownerSuffix.replace(/^\s+/, ""));

--- a/src/ui/format.mjs
+++ b/src/ui/format.mjs
@@ -28,12 +28,13 @@ export function formatDuration(ms) {
   if (n < 1) return `${n.toFixed(2)} ms`;
   if (n < 1000) return `${Math.round(n)} ms`;
   const s = n / 1000;
-  if (s < 60) return `${s.toFixed(s < 10 ? 2 : 1)} s`;
-  const minutes = Math.floor(s / 60);
-  const seconds = Math.round(s - minutes * 60);
+  if (s < 59.95) return `${s.toFixed(s < 10 ? 2 : 1)} s`;
+  const roundedSeconds = Math.round(s);
+  const minutes = Math.floor(roundedSeconds / 60);
+  const seconds = roundedSeconds % 60;
   if (minutes < 60) return seconds === 0 ? `${minutes}m` : `${minutes}m ${String(seconds).padStart(2, "0")}s`;
   const hours = Math.floor(minutes / 60);
-  const rem = minutes - hours * 60;
+  const rem = minutes % 60;
   return `${hours}h ${String(rem).padStart(2, "0")}m`;
 }
 

--- a/src/ui/header.mjs
+++ b/src/ui/header.mjs
@@ -15,7 +15,7 @@
 
 import { heavyBand } from "./layout.mjs";
 import { badge } from "./badges.mjs";
-import { visualWidth, repeat } from "./text.mjs";
+import { visualWidth, repeat, truncate, wrap } from "./text.mjs";
 
 // renderKovaHeader({ surface, verdict, headline, meta, ui }) -> string
 //
@@ -55,20 +55,46 @@ function renderVerdictLine({ verdict, headline, meta, ui }) {
 
   const { c } = ui;
   const badgeText = verdictText ? badge(verdictText, verdictText, ui) : "";
-  const head = headlineText ? c.bold(headlineText) : "";
-  const left = [badgeText, head].filter(Boolean).join("   ");
-  const leftPadded = left ? `   ${left}` : "";
+  const outerIndent = Math.min(3, Math.max(0, ui.width - 1));
+  const prefix = badgeText ? `${repeat(" ", outerIndent)}${badgeText}` : repeat(" ", outerIndent);
+  const headlineIndent = badgeText ? visualWidth(prefix) + 3 : outerIndent;
+  const headlineWidth = Math.max(1, ui.width - headlineIndent);
+  const lines = [];
 
-  if (!metaText) return leftPadded;
-
-  const right = c.dim(metaText);
-  const leftW = visualWidth(leftPadded);
-  const rightW = visualWidth(right);
-  if (leftW === 0) return `   ${right}`;
-  if (leftW + 2 + rightW > ui.width) {
-    const indent = badgeText ? visualWidth(badgeText) + 6 : 3;
-    return `${leftPadded}\n${repeat(" ", indent)}${right}`;
+  const headlineFitsBesideBadge = !badgeText || headlineIndent < ui.width;
+  const headlineLines = headlineText
+    ? wrap(c.bold(headlineText), headlineFitsBesideBadge ? headlineWidth : Math.max(1, ui.width - outerIndent))
+    : [];
+  if (headlineLines.length > 0 && headlineFitsBesideBadge) {
+    lines.push(truncate(`${prefix}${badgeText ? "   " : ""}${headlineLines[0]}`, ui.width));
+    const continuationPrefix = repeat(" ", Math.min(headlineIndent, Math.max(0, ui.width - 1)));
+    for (const line of headlineLines.slice(1)) {
+      lines.push(truncate(continuationPrefix + line, ui.width));
+    }
+  } else {
+    if (badgeText) lines.push(truncate(prefix, ui.width));
+    const continuationPrefix = repeat(" ", outerIndent);
+    for (const line of headlineLines) {
+      lines.push(truncate(continuationPrefix + line, ui.width));
+    }
   }
-  const pad = Math.max(2, ui.width - leftW - rightW);
-  return leftPadded + repeat(" ", pad) + right;
+  if (metaText) {
+    const metaIndent = Math.min(headlineIndent, Math.max(0, ui.width - 1));
+    const metaWidth = Math.max(1, ui.width - metaIndent);
+    const metaLines = wrap(c.dim(metaText), metaWidth);
+    const canShareLastLine = lines.length > 0
+      && metaLines.length === 1
+      && visualWidth(lines.at(-1)) + 2 + visualWidth(metaLines[0]) <= ui.width;
+    if (canShareLastLine) {
+      const pad = ui.width - visualWidth(lines.at(-1)) - visualWidth(metaLines[0]);
+      lines[lines.length - 1] += repeat(" ", pad) + metaLines[0];
+    } else {
+      const continuationPrefix = repeat(" ", metaIndent);
+      for (const line of metaLines) {
+        lines.push(truncate(continuationPrefix + line, ui.width));
+      }
+    }
+  }
+
+  return lines.join("\n");
 }

--- a/src/ui/kpi-strip.mjs
+++ b/src/ui/kpi-strip.mjs
@@ -19,7 +19,7 @@
 
 import { makeColor } from "./color.mjs";
 import { makeGlyphs } from "./glyphs.mjs";
-import { visualWidth, repeat } from "./text.mjs";
+import { visualWidth, repeat, wrap } from "./text.mjs";
 
 const SEP_SPACING = "   ";
 const BAR_WIDE = 10;
@@ -51,7 +51,14 @@ export function kpiStrip(items, ui) {
 
   // Final layout option: stack one per line, full detail.
   return list
-    .map((it) => "  " + renderItem(it, c, g, { includeLabel: true, includeHint: true, barWidth: BAR_WIDE }))
+    .flatMap((it) => {
+      const indent = Math.min(2, Math.max(0, width - 1));
+      const lines = wrap(
+        renderItem(it, c, g, { includeLabel: true, includeHint: true, barWidth: BAR_WIDE }),
+        Math.max(1, width - indent),
+      );
+      return lines.map((line) => repeat(" ", indent) + line);
+    })
     .join("\n");
 }
 

--- a/src/ui/layout.mjs
+++ b/src/ui/layout.mjs
@@ -3,7 +3,7 @@
 
 import { makeColor } from "./color.mjs";
 import { makeGlyphs } from "./glyphs.mjs";
-import { padEnd, visualWidth, repeat } from "./text.mjs";
+import { padEnd, visualWidth, repeat, truncate, wrap } from "./text.mjs";
 
 const SIDE_BY_SIDE_MIN_WIDTH = 120;
 
@@ -15,7 +15,11 @@ const SIDE_BY_SIDE_MIN_WIDTH = 120;
 export function heavyBand({ badgeText = "", status = "", title = "", meta = "", width, ui }) {
   const c = makeColor(ui);
   const g = makeGlyphs(ui);
-  const inner = Math.max(20, width - 2);
+  const frameWidth = positiveWidth(width);
+  if (frameWidth < 4) {
+    return truncate([badgeText, status, title, meta].filter(Boolean).join(" "), frameWidth);
+  }
+  const inner = frameWidth - 2;
 
   const top = c.head(g.tlHeavy + repeat(g.hHeavy, inner) + g.trHeavy);
   const bot = c.head(g.blHeavy + repeat(g.hHeavy, inner) + g.brHeavy);
@@ -32,7 +36,7 @@ export function heavyBand({ badgeText = "", status = "", title = "", meta = "", 
     content = "  " + [badgeText, statusColored, titleColored].filter(Boolean).join("  ");
     if (visualWidth(content) > inner) {
       const plain = "  " + [badgeText, status, title].filter(Boolean).join("  ");
-      content = plain.length > inner ? plain.slice(0, Math.max(0, inner - 1)) + "…" : plain;
+      content = truncate(plain, inner);
     }
   }
   const padded = padEnd(content, inner);
@@ -46,9 +50,11 @@ export function heavyBand({ badgeText = "", status = "", title = "", meta = "", 
 export function ruleSection(label, width, ui) {
   const c = makeColor(ui);
   const g = makeGlyphs(ui);
+  const lineWidth = positiveWidth(width);
+  if (lineWidth === 0) return "";
   const prefix = repeat(g.hLight, 3) + (label ? ` ${label} ` : "");
-  const remaining = Math.max(3, width - visualWidth(prefix));
-  return c.dim(prefix + repeat(g.hLight, remaining));
+  if (visualWidth(prefix) >= lineWidth) return c.dim(truncate(prefix, lineWidth));
+  return c.dim(prefix + repeat(g.hLight, lineWidth - visualWidth(prefix)));
 }
 
 // card({ title, lines, width, ui })
@@ -60,9 +66,17 @@ export function ruleSection(label, width, ui) {
 export function card({ title = "", lines = [], width, ui }) {
   const c = makeColor(ui);
   const g = makeGlyphs(ui);
-  const inner = Math.max(8, width - 2);
+  const frameWidth = positiveWidth(width);
+  if (frameWidth < 4) {
+    return [title, ...lines]
+      .flatMap((line) => wrap(String(line), frameWidth))
+      .join("\n");
+  }
+  const inner = frameWidth - 2;
 
-  const titleSegment = title ? `${g.hLight} ${title} ` : "";
+  const titleBudget = Math.max(0, inner - 3);
+  const titleText = titleBudget > 0 ? truncate(title, titleBudget) : "";
+  const titleSegment = titleText ? `${g.hLight} ${titleText} ` : "";
   const topFill = repeat(g.hLight, Math.max(0, inner - visualWidth(titleSegment)));
   const top = c.dim(g.tlLight + titleSegment + topFill + g.trLight);
   const bot = c.dim(g.blLight + repeat(g.hLight, inner) + g.brLight);
@@ -105,6 +119,11 @@ function colorStatus(c, status) {
   if (upper === "INCOMPLETE" || upper === "PARTIAL" || upper === "REGRESSION") return c.bold(c.warn(upper));
   if (upper === "BLOCKED") return c.bold(c.block(upper));
   return c.bold(upper);
+}
+
+function positiveWidth(width) {
+  const value = Number(width);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
 }
 
 export { SIDE_BY_SIDE_MIN_WIDTH };

--- a/src/ui/metrics-table.mjs
+++ b/src/ui/metrics-table.mjs
@@ -51,7 +51,7 @@ export function metricsTable({ rows, sampleCount = 1, compare = false, ui, gap =
         ? fewSampleColumns(c)
         : singleSampleColumns(c);
   const shaped = rows.map((r) => compare ? shapeCompareRow(r, ui) : shapeRow(r, sampleCount, ui));
-  const maxWidth = ui.width ? Math.max(20, ui.width - indent) : null;
+  const maxWidth = ui.width ? Math.max(1, ui.width - indent) : null;
   return renderTable({ columns: cols, rows: shaped, gap, maxWidth });
 }
 

--- a/src/ui/phases-block.mjs
+++ b/src/ui/phases-block.mjs
@@ -43,6 +43,7 @@ export function phasesBlock({ phases, compare = false, ui } = {}) {
       ],
       rows,
       gap: 2,
+      maxWidth: ui.width,
     });
   }
 
@@ -70,6 +71,7 @@ export function phasesBlock({ phases, compare = false, ui } = {}) {
     ],
     rows,
     gap: 2,
+    maxWidth: ui.width,
   });
 }
 

--- a/src/ui/proves-block.mjs
+++ b/src/ui/proves-block.mjs
@@ -27,7 +27,7 @@ export function provesBlock({ claims, compare = false, ui, indent = 0 } = {}) {
   if (!claims || claims.length === 0) return "";
   const c = ui.c;
   const g = ui.g;
-  const width = Math.max(20, (ui.width ?? 80) - indent);
+  const width = Math.max(1, (ui.width ?? 80) - indent);
 
   const lines = [];
   for (const cl of claims) {
@@ -36,7 +36,7 @@ export function provesBlock({ claims, compare = false, ui, indent = 0 } = {}) {
       const glyph = colorize(c, sev, statusGlyph(g, sev));
       const prefix = `  ${glyph} `;
       const prefixW = 2 + 1 + 1; // 2 margin + 1 glyph + 1 space
-      const wrapped = wrap(cl.claim ?? "", Math.max(20, width - prefixW));
+      const wrapped = wrap(cl.claim ?? "", Math.max(1, width - prefixW));
       wrapped.forEach((line, i) => {
         lines.push((i === 0 ? prefix : repeat(" ", prefixW)) + line);
       });
@@ -54,7 +54,7 @@ export function provesBlock({ claims, compare = false, ui, indent = 0 } = {}) {
         : cl.change === "improved" ? "  (improved)".length : 0;
       const prefix = `  ${transition} `;
       const prefixW = 2 + transitionW + 1;
-      const wrapped = wrap(cl.claim ?? "", Math.max(20, width - prefixW - noteW));
+      const wrapped = wrap(cl.claim ?? "", Math.max(1, width - prefixW - noteW));
       wrapped.forEach((line, i) => {
         const isLast = i === wrapped.length - 1;
         const tail = isLast ? note : "";

--- a/src/ui/scenario-rule.mjs
+++ b/src/ui/scenario-rule.mjs
@@ -9,7 +9,7 @@
 
 import { makeColor } from "./color.mjs";
 import { makeGlyphs } from "./glyphs.mjs";
-import { visualWidth, repeat } from "./text.mjs";
+import { visualWidth, repeat, truncate } from "./text.mjs";
 import { badge } from "./badges.mjs";
 
 // scenarioRule({ id, verdict, samples, ui }) -> string
@@ -32,8 +32,13 @@ export function scenarioRule({ id, verdict = "", samples = null, note = "", ui }
 
   const prefixW = visualWidth(prefix);
   const rightW = visualWidth(right);
+  if (prefixW + rightW + 5 > width) {
+    const lines = [c.dim(truncate(prefix, width))];
+    if (right) lines.push(truncate(right, width));
+    return lines.join("\n");
+  }
   const trailingLen = 3;
-  const fillW = Math.max(3, width - prefixW - rightW - (right ? 2 : 0) - (right ? trailingLen : 0));
+  const fillW = Math.max(0, width - prefixW - rightW - (right ? 2 : 0) - (right ? trailingLen : 0));
   const fill = repeat(g.hLight, fillW);
   const trailing = repeat(g.hLight, trailingLen);
   if (!right) {

--- a/src/ui/scenarios-rollup.mjs
+++ b/src/ui/scenarios-rollup.mjs
@@ -13,9 +13,6 @@
 //     fresh-install          stable   5/5      PASS      —
 //     fresh-install          canary   5/5      FAIL      health.startup over by 1.1 s
 //
-// When `collapseSharedTargets` is true and a scenario has the same
-// verdict across all targets, the target column shows "both" / "all".
-
 import { renderTable } from "./tables.mjs";
 import { badge } from "./badges.mjs";
 import { visualWidth, truncate } from "./text.mjs";
@@ -88,7 +85,7 @@ function formatWorstCell(worst, c, termWidth) {
 
   // Prose note: label in cell, full reason on continuation line.
   const indent = "    ↳ ";
-  const budget = Math.max(40, termWidth - visualWidth(indent));
+  const budget = Math.max(1, termWidth - visualWidth(indent));
   const fit = visualWidth(note) > budget ? truncate(note, budget) : note;
   return { cell: color(label), after: c.dim(indent + fit) };
 }

--- a/src/ui/tables.mjs
+++ b/src/ui/tables.mjs
@@ -25,6 +25,14 @@ import { padEnd, padStart, visualWidth, truncate, wrap } from "./text.mjs";
 // below the row, untouched by column alignment. Use it for a full-width
 // dim continuation line (e.g. a long reason that won't fit in any cell).
 export function renderTable({ columns, rows, gap = 2, maxWidth = null }) {
+  const structuralWidth = columns.reduce(
+    (total, col) => total + Math.max(col.minWidth ?? 0, visualWidth(String(col.header ?? ""))),
+    Math.max(0, columns.length - 1) * gap,
+  );
+  if (typeof maxWidth === "number" && maxWidth > 0 && maxWidth < structuralWidth) {
+    return renderCompactTable(columns, rows, Math.floor(maxWidth));
+  }
+
   const widths = columns.map((col) => {
     const header = col.header ?? "";
     const max = rows.reduce(
@@ -70,6 +78,41 @@ export function renderTable({ columns, rows, gap = 2, maxWidth = null }) {
     }
   }
 
+  return lines.join("\n");
+}
+
+function renderCompactTable(columns, rows, maxWidth) {
+  const lines = [];
+  for (const row of rows) {
+    for (const col of columns) {
+      const raw = row[col.key];
+      const isObj = raw != null && typeof raw === "object" && "text" in raw;
+      const text = String(isObj ? raw.text : (raw ?? ""));
+      if (text.length === 0) continue;
+      const color = isObj && typeof raw.color === "function" ? raw.color : (value) => value;
+      const label = String(col.header ?? col.key ?? "").trim();
+      const prefix = label ? `${label}: ` : "";
+      if (prefix && visualWidth(prefix) >= maxWidth) {
+        lines.push(truncate(label, maxWidth));
+        const valueIndent = " ".repeat(Math.min(2, Math.max(0, maxWidth - 1)));
+        const valueWidth = Math.max(1, maxWidth - visualWidth(valueIndent));
+        for (const line of wrap(text, valueWidth)) {
+          lines.push(truncate(valueIndent + color(line), maxWidth));
+        }
+        continue;
+      }
+      const available = Math.max(1, maxWidth - visualWidth(prefix));
+      const wrapped = wrap(text, available);
+      lines.push(truncate(prefix + color(wrapped[0] ?? ""), maxWidth));
+      const indent = " ".repeat(Math.min(visualWidth(prefix), Math.max(0, maxWidth - 1)));
+      for (const line of wrapped.slice(1)) {
+        lines.push(truncate(indent + color(line), maxWidth));
+      }
+    }
+    if (typeof row.__after === "string" && row.__after.length > 0) {
+      lines.push(...wrap(row.__after, maxWidth));
+    }
+  }
   return lines.join("\n");
 }
 

--- a/src/ui/terminal.mjs
+++ b/src/ui/terminal.mjs
@@ -13,9 +13,11 @@ export function detectCapabilities(env = process.env, stream = process.stdout) {
   const locale = (env.LC_ALL || env.LC_CTYPE || env.LANG || "").toLowerCase();
   const isUtf8 = locale.includes("utf-8") || locale.includes("utf8") || process.platform === "darwin";
   const colorDepthHint = forceColor !== null ? forceColor : (isTTY && !noColor ? 1 : 0);
-  const width = (stream && Number.isFinite(stream.columns) && stream.columns > 0)
-    ? stream.columns
-    : DEFAULT_WIDTH;
+  const streamWidth = stream && Number.isFinite(stream.columns) && stream.columns > 0
+    ? Math.floor(stream.columns)
+    : null;
+  const envWidth = positiveInteger(env.COLUMNS);
+  const width = streamWidth ?? envWidth ?? DEFAULT_WIDTH;
 
   return { isTTY, noColor, forceColor, isCI, isUtf8, colorDepthHint, width };
 }
@@ -30,6 +32,12 @@ function parseForceColor(raw) {
 function isCiEnv(env) {
   if (env.CI && env.CI !== "false" && env.CI !== "0") return true;
   return Boolean(env.GITHUB_ACTIONS || env.GITLAB_CI || env.CIRCLECI || env.BUILDKITE || env.TEAMCITY_VERSION);
+}
+
+function positiveInteger(value) {
+  if (value === undefined || value === null || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
 }
 
 // Resolve UI options from CLI flags + environment.

--- a/src/ui/text.mjs
+++ b/src/ui/text.mjs
@@ -1,14 +1,13 @@
 // ANSI-aware text utilities: width measurement, padding, truncation, wrapping.
 
+import cliTruncate from "cli-truncate";
+import stringWidth from "string-width";
+import wrapAnsi from "wrap-ansi";
 import { stripAnsi } from "./color.mjs";
 
 export function visualWidth(text) {
   if (text == null) return 0;
-  const stripped = stripAnsi(String(text));
-  // Count code points, not UTF-16 code units; box-drawing chars are width 1.
-  let width = 0;
-  for (const _ of stripped) width += 1;
-  return width;
+  return stringWidth(String(text));
 }
 
 export function padEnd(text, width, char = " ") {
@@ -24,13 +23,9 @@ export function padStart(text, width, char = " ") {
 }
 
 export function truncate(text, width, ellipsis = "…") {
-  const w = visualWidth(text);
-  if (w <= width) return text;
-  if (width <= 1) return ellipsis.slice(0, width);
-  // Walk visible chars while preserving ANSI; simple approach: strip, truncate,
-  // and discard color rather than try to interleave - the renderer can re-color.
-  const plain = stripAnsi(text);
-  return plain.slice(0, Math.max(0, width - 1)) + ellipsis;
+  const columns = normalizeColumns(width);
+  if (columns === 0) return "";
+  return cliTruncate(String(text), columns, { truncationCharacter: ellipsis });
 }
 
 export function repeat(char, n) {
@@ -38,25 +33,33 @@ export function repeat(char, n) {
   return char.repeat(n);
 }
 
-// Wrap a plain string at word boundaries to the given visual width.
-// ANSI-naive: callers should wrap before colorizing.
+// Wrap at word boundaries while preserving ANSI styling. Long words are hard
+// wrapped so no returned line exceeds the requested terminal-cell width.
 export function wrap(text, width) {
-  if (width <= 0) return [String(text)];
-  const out = [];
-  for (const para of String(text).split("\n")) {
-    if (para.length === 0) { out.push(""); continue; }
-    let line = "";
-    for (const word of para.split(/\s+/)) {
-      if (line.length === 0) { line = word; continue; }
-      if (line.length + 1 + word.length <= width) line += " " + word;
-      else { out.push(line); line = word; }
-    }
-    if (line) out.push(line);
+  const columns = normalizeColumns(width);
+  if (columns === 0) return [""];
+  const source = String(text);
+  const lines = wrapAnsi(source, columns, {
+    hard: true,
+    trim: true,
+    wordWrap: true,
+  }).split("\n");
+  if (
+    lines.length > 1
+    && visualWidth(lines[0]) === 0
+    && !stripAnsi(source).startsWith("\n")
+  ) {
+    lines.shift();
   }
-  return out;
+  return lines.map((line) => (visualWidth(line) <= columns ? line : truncate(line, columns)));
 }
 
 // Indent every line of a multi-line string with the given prefix.
 export function indent(text, prefix = "  ") {
   return String(text).split("\n").map((line) => prefix + line).join("\n");
+}
+
+function normalizeColumns(width) {
+  const columns = Number(width);
+  return Number.isFinite(columns) && columns > 0 ? Math.floor(columns) : 0;
 }

--- a/src/ui/width.mjs
+++ b/src/ui/width.mjs
@@ -4,7 +4,11 @@
 // of their designed proportions. We cap content at a soft maximum and
 // leave the rest of the terminal as empty margin.
 //
-// Pure stdlib. No ANSI awareness needed; margin is whitespace.
+// Width resolution is numeric; final line fitting uses shared ANSI-aware text
+// helpers so rendered output stays within the chosen terminal-cell budget.
+
+import { truncate, visualWidth, wrap } from "./text.mjs";
+import { stripAnsi } from "./color.mjs";
 
 export const WIDTH_DEFAULT = 80;
 export const WIDTH_MIN = 40;
@@ -19,12 +23,13 @@ export const ALIGN_ENV = "KOVA_ALIGN";
 // env.KOVA_WIDTH same shape as flags.width
 // env.KOVA_ALIGN same shape as flags.align
 export function resolveWidth(termCols, flags = {}, env = process.env) {
+  const terminalWidth = positiveInteger(termCols) ?? WIDTH_DEFAULT;
   const align = pickAlign(flags.align, env[ALIGN_ENV]);
-  const target = pickWidth(flags.width, env[WIDTH_ENV], termCols);
-  const width = Math.max(WIDTH_MIN, Math.min(target, termCols));
-  const slack = Math.max(0, termCols - width);
+  const target = pickWidth(flags.width, env[WIDTH_ENV], terminalWidth);
+  const width = Math.min(terminalWidth, Math.max(WIDTH_MIN, target));
+  const slack = terminalWidth - width;
   const leftPad = align === "center" ? Math.floor(slack / 2) : 0;
-  return { width, leftPad, capped: width < termCols, align };
+  return { width, leftPad, capped: width < terminalWidth, align };
 }
 
 function pickWidth(flag, envVal, termCols) {
@@ -48,14 +53,118 @@ function pickAlign(flag, envVal) {
   return "left";
 }
 
-// withMargin(text, leftPad) -> text with `leftPad` spaces prepended to
-// every non-empty line. Empty lines stay empty so blank rows do not
-// produce trailing whitespace.
-export function withMargin(text, leftPad) {
-  if (!leftPad || leftPad <= 0) return text;
-  const pad = " ".repeat(leftPad);
+function positiveInteger(value) {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : null;
+}
+
+// withMargin(text, leftPad, width) -> text constrained to `width` content
+// cells with `leftPad` spaces prepended. Margin is part of line fitting so
+// wrapped shell expressions never gain whitespace between literal chunks.
+export function withMargin(text, leftPad, width = null) {
+  const contentWidth = positiveInteger(width);
+  const margin = positiveInteger(leftPad) ?? 0;
+  const pad = " ".repeat(margin);
+  const totalWidth = contentWidth === null ? null : contentWidth + margin;
   return String(text)
     .split("\n")
-    .map((line) => (line === "" ? line : pad + line))
+    .flatMap((line) => constrainLine(line === "" ? line : pad + line, totalWidth))
     .join("\n");
+}
+
+function constrainLine(line, width) {
+  if (!width || visualWidth(line) <= width) return [line];
+  const plain = stripAnsi(line);
+  const command = plain.match(/^(\s*(?:→|->)\s+)(.+)$/u);
+  if (command) {
+    const rawCommandIndex = line.lastIndexOf(command[2]);
+    const rawPrefix = rawCommandIndex >= 0 ? line.slice(0, rawCommandIndex) : command[1];
+    return constrainCommandLine(rawPrefix, command[2], width);
+  }
+  const leading = line.match(/^\s*/u)?.[0] ?? "";
+  const indentWidth = Math.min(visualWidth(leading), Math.max(0, width - 1));
+  const indent = " ".repeat(indentWidth);
+  const bodyWidth = Math.max(1, width - indentWidth);
+  return wrap(line.slice(leading.length), bodyWidth).map((part) => indent + part);
+}
+
+function constrainCommandLine(prefix, command, width) {
+  if (width < 12) return [truncate(prefix + command, width)];
+  if (!isSimpleShellCommand(command)) return constrainShellExpression(prefix, command, width);
+  const prefixFits = visualWidth(prefix) + 3 <= width;
+  const continuationWidth = prefixFits ? visualWidth(prefix) : 0;
+  const continuation = " ".repeat(continuationWidth);
+  const bodyWidth = Math.max(1, width - continuationWidth - 2);
+  const chunks = wrapShellCommand(command, bodyWidth);
+  if (!chunks) return constrainShellExpression(prefix, command, width);
+  const lines = prefixFits ? [] : [truncate(prefix, width)];
+  chunks.forEach((chunk, index) => {
+    const linePrefix = prefixFits && index === 0 ? prefix : continuation;
+    const suffix = index < chunks.length - 1 ? " \\" : "";
+    lines.push(linePrefix + chunk.text + suffix);
+  });
+  return lines;
+}
+
+function wrapShellCommand(command, width) {
+  const chunks = [];
+  let current = "";
+  for (const word of String(command).trim().split(/\s+/u)) {
+    if (visualWidth(word) > width) return null;
+    if (current && visualWidth(`${current} ${word}`) <= width) {
+      current += ` ${word}`;
+      continue;
+    }
+    if (current) {
+      chunks.push({ text: current });
+      current = "";
+    }
+    current = word;
+  }
+  if (current) chunks.push({ text: current });
+  return chunks;
+}
+
+function isSimpleShellCommand(command) {
+  return /^[A-Za-z0-9_@%+=:,./-]+(?:\s+[A-Za-z0-9_@%+=:,./-]+)*$/u.test(command);
+}
+
+function constrainShellExpression(prefix, command, width) {
+  let inlinePrefix = visualWidth(prefix) + 9 < width ? prefix : "";
+  let chunks = splitShellLiteral(command, width - visualWidth(inlinePrefix) - 6);
+  if (!chunks && inlinePrefix) {
+    inlinePrefix = "";
+    chunks = splitShellLiteral(command, width - 6);
+  }
+  if (!chunks) return [truncate(prefix + command, width)];
+
+  const lines = inlinePrefix ? [] : [truncate(prefix, width)];
+  chunks.forEach((chunk, index) => {
+    const linePrefix = index === 0 ? `${inlinePrefix}eval ` : "";
+    const suffix = index < chunks.length - 1 ? "\\" : "";
+    lines.push(linePrefix + quoteShellLiteral(chunk) + suffix);
+  });
+  return lines;
+}
+
+function splitShellLiteral(value, width) {
+  if (width < 2) return null;
+  const chunks = [];
+  let current = "";
+  for (const { segment } of new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(value)) {
+    const candidate = current + segment;
+    if (visualWidth(quoteShellLiteral(candidate)) <= width) {
+      current = candidate;
+      continue;
+    }
+    if (!current) return null;
+    chunks.push(current);
+    current = segment;
+    if (visualWidth(quoteShellLiteral(current)) > width) return null;
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+function quoteShellLiteral(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
 }

--- a/tests/render-snapshots.mjs
+++ b/tests/render-snapshots.mjs
@@ -99,7 +99,9 @@ function normalize(out, snapshotCase) {
     structured = normalizePlanPlatformLine(structured);
   }
   const normalized = structured
-    .replaceAll(SNAPSHOT_KOVA_HOME, "<kova-home>")
+    .replace(flexibleWrappedPath(SNAPSHOT_KOVA_HOME), (path) => (
+      path.replace(/\n\s*/g, "").replace(SNAPSHOT_KOVA_HOME, "<kova-home>")
+    ))
     .replaceAll(repoRoot, "<repo>")
     .replaceAll(home, "<home>")
     .replaceAll(HOST_PLATFORM.release, "<os-release>")
@@ -381,6 +383,14 @@ function currentPlatformKeysBlock(platformKeys) {
     ),
     "    ]"
   ].join("\n");
+}
+
+function flexibleWrappedPath(value) {
+  const root = [...value]
+    .map((char) => char.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("(?:\\n\\s*)?");
+  const suffix = "(?:(?:\\n\\s*)?/(?:(?:\\n\\s*)?[A-Za-z0-9_./-])*)?";
+  return new RegExp(root + suffix, "g");
 }
 
 function runCase(c) {

--- a/tests/snapshots/compare-pass-vs-fail-full.snap
+++ b/tests/snapshots/compare-pass-vs-fail-full.snap
@@ -6,14 +6,16 @@
 
   baseline  runtime:stable    kova-<runId>
   current   runtime:stable    kova-<runId>
-  delta     3 regressions  ·  1 scenario affected  ·  1 resource contract mismatch  ·  5 metrics skipped
+  delta     3 regressions  ·  1 scenario affected  ·  1 resource contract
+  mismatch  ·  5 metrics skipped
 
 ─── resource contracts ─────────────────────────────────────────────────────────
 
   ⚠ 1 mismatch · 5 metrics skipped
   fresh-install:fresh
     contract unknown-scope/unknown-contract → unknown-scope/unknown-contract
-    skipped  peakRssMb, cpuPercentMax, resourceSampleCount, resourcePeakTrackedRssMb, resourcePeakGatewayRssMb
+    skipped  peakRssMb, cpuPercentMax, resourceSampleCount,
+    resourcePeakTrackedRssMb, resourcePeakGatewayRssMb
 
 ─── scenarios ──────────────────────────────────────────────────────────────────
 

--- a/tests/snapshots/compare-pass-vs-fail.snap
+++ b/tests/snapshots/compare-pass-vs-fail.snap
@@ -6,14 +6,16 @@
 
   baseline  runtime:stable    kova-<runId>
   current   runtime:stable    kova-<runId>
-  delta     3 regressions  ·  1 scenario affected  ·  1 resource contract mismatch  ·  5 metrics skipped
+  delta     3 regressions  ·  1 scenario affected  ·  1 resource contract
+  mismatch  ·  5 metrics skipped
 
 ─── resource contracts ─────────────────────────────────────────────────────────
 
   ⚠ 1 mismatch · 5 metrics skipped
   fresh-install:fresh
     contract unknown-scope/unknown-contract → unknown-scope/unknown-contract
-    skipped  peakRssMb, cpuPercentMax, resourceSampleCount, resourcePeakTrackedRssMb, resourcePeakGatewayRssMb
+    skipped  peakRssMb, cpuPercentMax, resourceSampleCount,
+    resourcePeakTrackedRssMb, resourcePeakGatewayRssMb
 
 ─── scenarios ──────────────────────────────────────────────────────────────────
 

--- a/tests/snapshots/help-default.snap
+++ b/tests/snapshots/help-default.snap
@@ -5,15 +5,21 @@
 
 ─── commands ───────────────────────────────────────────────────────────────────
   ◆ kova version      Print Kova version and runtime info.
-  ◆ kova setup        Verify prerequisites, configure auth, and prepare directories.
-  ◆ kova self-check   Run the full Kova suite (dry-runs, parsers, gates, evaluators).
+  ◆ kova setup        Verify prerequisites, configure auth, and prepare
+  directories.
+  ◆ kova self-check   Run the full Kova suite (dry-runs, parsers, gates,
+  evaluators).
   ◆ kova plan         Show OpenClaw surfaces, scenarios, states, and metrics.
-  ◆ kova inventory    Discover OpenClaw coverage gaps and repeated Kova run work.
+  ◆ kova inventory    Discover OpenClaw coverage gaps and repeated Kova run
+  work.
   ◆ kova run          Run one OpenClaw scenario. Dry-run unless --execute.
-  ◆ kova matrix       Profile-driven multi-scenario plan / run with optional gate.
+  ◆ kova matrix       Profile-driven multi-scenario plan / run with optional
+  gate.
   ◆ kova reports      List recent stored reports and their run IDs.
-  ◆ kova report       Render a Kova report dashboard, summary, paste, compare, or bundle.
-  ◆ kova publish      Validate a web-payload release and write it into web/src/content/releases/.
+  ◆ kova report       Render a Kova report dashboard, summary, paste, compare,
+  or bundle.
+  ◆ kova publish      Validate a web-payload release and write it into
+  web/src/content/releases/.
   ◆ kova cleanup      Remove stale Kova-owned envs and run artifact dirs.
 
 ─── selectors ──────────────────────────────────────────────────────────────────
@@ -26,11 +32,14 @@
   • Kova uses OCM to create isolated OpenClaw envs and runtimes.
   • Reports describe OpenClaw behavior, not OCM behavior.
   • run/matrix run are dry-run unless --execute is passed.
-  • --repeat records independent samples and computes aggregate performance stats.
+  • --repeat records independent samples and computes aggregate performance
+  stats.
   • --auth defaults to mock so every disposable env has deliberate model auth.
   • --model pins the model id for live-auth runs.
-  • --deep-profile enables Node CPU/heap/trace + diagnostic report + denser sampling.
-  • Human-facing commands render dashboards by default; --plain renders compact text.
+  • --deep-profile enables Node CPU/heap/trace + diagnostic report + denser
+  sampling.
+  • Human-facing commands render dashboards by default; --plain renders compact
+  text.
   • Report commands accept either full JSON paths or run IDs from kova reports.
 
 ─── next ───────────────────────────────────────────────────────────────────────

--- a/tests/snapshots/matrix-run-receipt-dry.snap
+++ b/tests/snapshots/matrix-run-receipt-dry.snap
@@ -2,7 +2,8 @@
 ║  KOVA  ·  matrix run                                                         ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
    [DRY-RUN]   12 planned
-               mode: dry-run · target: runtime:stable · runId: kova-<runId>
+               mode: dry-run · target: runtime:stable · runId:
+               kova-<runId>
 
   Entries 12   ·   Dry-run 12   ·   Failed 0   ·   Performance 12 groups
 

--- a/tests/snapshots/report-fail-compact.snap
+++ b/tests/snapshots/report-fail-compact.snap
@@ -21,5 +21,6 @@
 
 ─── next ───────────────────────────────────────────────────────────────────────
   → kova report --full kova-<runId>
-  → node bin/kova.mjs run --target runtime:stable --scenario fresh-install --state fresh --execute --profile-on-failure --retain-on-failure --json
+  → node bin/kova.mjs run --target runtime:stable --scenario fresh-install \
+    --state fresh --execute --profile-on-failure --retain-on-failure --json
   → kova report bundle kova-<runId>

--- a/tests/snapshots/report-fail-full.snap
+++ b/tests/snapshots/report-fail-full.snap
@@ -27,5 +27,6 @@
         fresh-install/fresh gateway peak RSS 950 MB (cap 800 MB)
 
 ─── next ───────────────────────────────────────────────────────────────────────
-  → node bin/kova.mjs run --target runtime:stable --scenario fresh-install --state fresh --execute --profile-on-failure --retain-on-failure --json
+  → node bin/kova.mjs run --target runtime:stable --scenario fresh-install \
+    --state fresh --execute --profile-on-failure --retain-on-failure --json
   → kova report bundle kova-<runId>

--- a/tests/snapshots/run-receipt-dry.snap
+++ b/tests/snapshots/run-receipt-dry.snap
@@ -2,7 +2,8 @@
 ║  KOVA  ·  run                                                                ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
    [DRY-RUN]   1 planned
-               mode: dry-run · target: runtime:stable · runId: kova-<runId>
+               mode: dry-run · target: runtime:stable · runId:
+               kova-<runId>
 
   Total 1   ·   Dry-run █████ 1   ·   Failed ░░░░░ 0   ·   Performance 1 group
 


### PR DESCRIPTION
## What Problem This Solves

Kova's terminal renderers mixed code-unit length, terminal cell width, and ANSI-decorated width. Unicode, emoji, narrow terminals, long shell hints, duration rollover, strict numeric samples, and long artifact paths could overflow or corrupt aligned output.

## Why This Change Was Made

Centralize ANSI- and Unicode-aware width, truncation, wrapping, padding, and numeric formatting, then route report renderers through those helpers. Artifact paths reserve their label width and use hanging-indent continuations, so host-specific temp path lengths cannot split labels unpredictably.

## User Impact

- terminal reports stay within the requested width
- Unicode and ANSI styling no longer break alignment
- narrow layouts wrap shell hints and preserve readable structure
- long artifact paths remain attached to their labels
- duration and numeric edge cases remain bounded
- changelog documents the user-visible rendering fix

## Evidence

- base: `69e87ab03752bf9a012d64216356ed857fdcf1ee`
- reviewed head: `4fe1c2d99e7c38fe4947e061f3217020113078de`
- `npm run check:full`
  - 265/265 self-checks
  - 21/21 render snapshots
  - web payload contract passed
  - release contract checks passed
- path-length portability regression
  - 21/21 snapshots with a deliberately long `TMPDIR`
  - artifact continuations verified to retain a hanging indent within 80 columns
- packed/extracted release smoke
  - `npm run pack:release`
  - fresh `install.sh --archive ./dist/kova.tar.gz --require-ocm`
  - extracted `kova version`, `kova setup --ci --json`, and `kova self-check`
  - extracted self-check: 265/265
- dependency lock/cache
  - lock hash: `bc4e12acc0862d1ab750f6b69f3ab3e14ecf11def44ecee0667ab448a7e97515`
  - dependencies installed in the external content-addressed cache; the worktree `node_modules` remained a symlink
- autoreview
  - model: `gpt-5.6-sol`
  - reasoning: high
  - verdict: patch is correct, no findings, confidence 0.88

Commits are intentionally preserved as implementation, changelog, test-fix, and CI portability fix commits. Merge with rebase; do not squash.
