### PR TITLE
fix(reporting): preserve aggregate evidence integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Kova are documented in this file.
 - Made matrix gates honor scenario-wide policies and validate all seven coverage dimensions only from records that actually executed.
 - Stopped parallel matrix workers from scheduling new scenarios after a rejection, drained active workers before rethrowing, and made lifecycle command indexes phase-wide to prevent artifact overwrites.
 - Fixed web release projections to select same-day priors numerically, match headline deltas by scenario, metric, and unit, label comparisons with the measured metric, and median-aggregate repeated turn measurements.
+- Fixed report status precedence, repeated-sample diagnostics, finding identity, worst-case metrics, confidence labels, blocked outcomes, and rendered CLI guidance.
 - Hardened release validation against missing, malformed, misplaced, partial, or incomplete provider, health, snapshot, plugin-security, command-timing, and measurement evidence.
 - Hardened release publishing and run evidence contracts so invalid payloads are rejected and missing final metrics cannot be reported as healthy.
 - Hardened runtime teardown with collision-resistant local-build names, exact OCM missing-resource matching, awaited proxy shutdown, and independent cleanup stages.

--- a/src/matrix/gate.mjs
+++ b/src/matrix/gate.mjs
@@ -98,16 +98,20 @@ export function evaluateGate(report, profile, options = {}) {
   const blockingCards = cards.filter((card) => card.severity === "blocking");
   const warningCards = cards.filter((card) => card.severity === "warning");
   const infoCards = cards.filter((card) => card.severity === "info");
-  const blockedByHarness = blockingCards.some((card) =>
-    ["not-executed", "blocked", "incomplete-proof", "skipped", "dry-run"].includes(card.kind)
-  );
-  const openClawBlockingFailures = blockingCards.filter((card) => card.kind === "openclaw-failure");
-  const incompleteProof = blockingCards.some((card) => card.kind === "incomplete-proof");
-  const incomplete = missingRequired.length > 0 || incompleteProof;
+  const harnessBlockKinds = new Set([
+    "not-executed",
+    "blocked",
+    "incomplete-proof",
+    "skipped",
+    "dry-run"
+  ]);
+  const harnessBlockingCards = blockingCards.filter((card) => harnessBlockKinds.has(card.kind));
+  const blockedByHarness = harnessBlockingCards.length > 0;
+  const incomplete = missingRequired.length > 0 || blockedByHarness;
   const productBlockingFailures = blockingCards.filter((card) =>
-    !["not-executed", "blocked", "incomplete-proof", "skipped", "dry-run"].includes(card.kind)
+    !harnessBlockKinds.has(card.kind)
   );
-  const verdict = openClawBlockingFailures.length > 0 || productBlockingFailures.length > 0
+  const verdict = productBlockingFailures.length > 0
     ? "DO_NOT_SHIP"
     : blockedByHarness
       ? "BLOCKED"

--- a/src/matrix/gate.mjs
+++ b/src/matrix/gate.mjs
@@ -109,15 +109,17 @@ export function evaluateGate(report, profile, options = {}) {
   const blockedByHarness = harnessBlockingCards.length > 0;
   const incomplete = missingRequired.length > 0 || blockedByHarness;
   const productBlockingFailures = blockingCards.filter((card) =>
-    !harnessBlockKinds.has(card.kind)
+    card.kind === "openclaw-failure" || card.kind === "performance-regression"
   );
   const verdict = productBlockingFailures.length > 0
     ? "DO_NOT_SHIP"
     : blockedByHarness
       ? "BLOCKED"
-      : incomplete
-        ? "PARTIAL"
-        : "SHIP";
+      : blockingCards.length > 0
+        ? "DO_NOT_SHIP"
+        : incomplete
+          ? "PARTIAL"
+          : "SHIP";
   const subsystems = summarizeSubsystems(cards);
   const fixerSummaries = buildFixerSummaries(subsystems);
 

--- a/src/matrix/gate.mjs
+++ b/src/matrix/gate.mjs
@@ -104,15 +104,16 @@ export function evaluateGate(report, profile, options = {}) {
   const openClawBlockingFailures = blockingCards.filter((card) => card.kind === "openclaw-failure");
   const incompleteProof = blockingCards.some((card) => card.kind === "incomplete-proof");
   const incomplete = missingRequired.length > 0 || incompleteProof;
-  const verdict = blockedByHarness
-    ? "BLOCKED"
-    : openClawBlockingFailures.length > 0
-      ? "DO_NOT_SHIP"
-      : blockingCards.length > 0
-        ? "DO_NOT_SHIP"
-        : incomplete
-          ? "PARTIAL"
-          : "SHIP";
+  const productBlockingFailures = blockingCards.filter((card) =>
+    !["not-executed", "blocked", "incomplete-proof", "skipped", "dry-run"].includes(card.kind)
+  );
+  const verdict = openClawBlockingFailures.length > 0 || productBlockingFailures.length > 0
+    ? "DO_NOT_SHIP"
+    : blockedByHarness
+      ? "BLOCKED"
+      : incomplete
+        ? "PARTIAL"
+        : "SHIP";
   const subsystems = summarizeSubsystems(cards);
   const fixerSummaries = buildFixerSummaries(subsystems);
 

--- a/src/reporting/compare-aggregate.mjs
+++ b/src/reporting/compare-aggregate.mjs
@@ -16,7 +16,7 @@
 import { METRIC_LABELS, METRIC_UNITS, HEADLINE_METRICS, metricDirection } from "./scenario-aggregate.mjs";
 import { worseRecordStatus } from "../statuses.mjs";
 
-const VERDICT_RANK = { FAIL: 0, BLOCKED: 1, REGRESSED: 2, NEW: 3, MISSING: 3, IMPROVED: 4, UNCHANGED: 5, OK: 6 };
+const VERDICT_RANK = { FAIL: 0, REGRESSED: 1, BLOCKED: 2, NEW: 3, MISSING: 3, IMPROVED: 4, UNCHANGED: 5, OK: 6 };
 
 // rollupScenarios(comparison) -> [{ id, verdict, baselineStatus, currentStatus,
 //   regressionCount, totalMetrics, worst, samples }]

--- a/src/reporting/compare-aggregate.mjs
+++ b/src/reporting/compare-aggregate.mjs
@@ -16,7 +16,7 @@
 import { METRIC_LABELS, METRIC_UNITS, HEADLINE_METRICS, metricDirection } from "./scenario-aggregate.mjs";
 import { worseRecordStatus } from "../statuses.mjs";
 
-const VERDICT_RANK = { FAIL: 0, BLOCKED: 0, REGRESSED: 1, NEW: 2, MISSING: 2, IMPROVED: 3, UNCHANGED: 4, OK: 5 };
+const VERDICT_RANK = { FAIL: 0, BLOCKED: 1, REGRESSED: 2, NEW: 3, MISSING: 3, IMPROVED: 4, UNCHANGED: 5, OK: 6 };
 
 // rollupScenarios(comparison) -> [{ id, verdict, baselineStatus, currentStatus,
 //   regressionCount, totalMetrics, worst, samples }]

--- a/src/reporting/compare-aggregate.mjs
+++ b/src/reporting/compare-aggregate.mjs
@@ -14,6 +14,7 @@
 // scenario-aggregate.metricDirection.
 
 import { METRIC_LABELS, METRIC_UNITS, HEADLINE_METRICS, metricDirection } from "./scenario-aggregate.mjs";
+import { worseRecordStatus } from "../statuses.mjs";
 
 const VERDICT_RANK = { FAIL: 0, BLOCKED: 0, REGRESSED: 1, NEW: 2, MISSING: 2, IMPROVED: 3, UNCHANGED: 4, OK: 5 };
 
@@ -36,6 +37,7 @@ export function rollupScenarios(comparison) {
         worst: null,
         totalSamples: 0,
         failedSamples: 0,
+        passedSamples: 0,
       });
     }
     const acc = byId.get(id);
@@ -45,8 +47,14 @@ export function rollupScenarios(comparison) {
       acc.resourceContractMismatchCount += 1;
     }
     acc.verdict = pickWorseVerdict(acc.verdict, s.status);
+    acc.baselineStatus = worseRecordStatus(acc.baselineStatus, s.baselineStatus);
+    acc.currentStatus = worseRecordStatus(acc.currentStatus, s.currentStatus);
     acc.totalSamples += s.currentSampleCount ?? 0;
-    acc.failedSamples += s.currentStatuses?.FAIL ?? 0;
+    acc.failedSamples +=
+      (s.currentStatuses?.FAIL ?? 0) +
+      (s.currentStatuses?.BLOCKED ?? 0) +
+      (s.currentStatuses?.INCOMPLETE ?? 0);
+    acc.passedSamples += s.currentStatuses?.PASS ?? 0;
     // Surface worst regression as the "worst metric" headline.
     const worst = pickWorstRegression(s.regressions);
     if (worst && (!acc.worst || worstSeverity(worst) > worstSeverity(acc.worst))) {

--- a/src/reporting/compare.mjs
+++ b/src/reporting/compare.mjs
@@ -668,16 +668,16 @@ function stableFindingId(finding) {
 }
 
 function normalizeFindingText(finding) {
-  const expected = String(finding?.expected ?? "");
-  const thresholded = /(?:<=|>=|<|>)\s*-?\d/.test(expected);
   const text = String(finding?.summary ?? finding?.message ?? "").toLowerCase();
-  const normalizedMeasurements = text.replace(
+  return text
+    .replace(
     /-?\d+(?:\.\d+)?(?=\s*(?:ms|s|sec|seconds?|kb|mb|gb|bytes?|%)(?:\b|$))/gi,
     "#"
-  );
-  return (thresholded
-    ? normalizedMeasurements.replace(/(?<![a-z0-9_])-?\d+(?:\.\d+)?(?![a-z0-9_])/g, "#")
-    : normalizedMeasurements)
+    )
+    .replace(
+      /\b(threshold|limit|budget|ceiling|minimum|maximum)(\s*(?:of|=|:)?\s*)-?\d+(?:\.\d+)?/gi,
+      "$1$2#"
+    )
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/src/reporting/compare.mjs
+++ b/src/reporting/compare.mjs
@@ -1,4 +1,5 @@
 import { measurementMetricValue } from "../health.mjs";
+import { recordStatusRank } from "../statuses.mjs";
 import { buildReportSummary } from "./report.mjs";
 
 const defaultThresholds = {
@@ -415,14 +416,6 @@ export function renderCompareSummary(comparison) {
   return lines.join("\n");
 }
 
-function indexRecords(records) {
-  const index = new Map();
-  for (const record of records) {
-    index.set(recordKey(record), record);
-  }
-  return index;
-}
-
 function groupRecords(records) {
   const groups = new Map();
   for (const record of records) {
@@ -605,16 +598,23 @@ function compareGroupStatuses(baselineGroups = [], currentGroups = []) {
 }
 
 function compareFindings(baselineFindings = [], currentFindings = []) {
-  const baselineByKey = new Map(baselineFindings.map((finding) => [findingKey(finding), finding]));
-  const currentByKey = new Map(currentFindings.map((finding) => [findingKey(finding), finding]));
+  const baselineByKey = groupFindingsByKey(baselineFindings);
+  const currentByKey = groupFindingsByKey(currentFindings);
+  const keys = new Set([...baselineByKey.keys(), ...currentByKey.keys()]);
+  const added = [];
+  const resolved = [];
+  let unchangedCount = 0;
+  for (const key of keys) {
+    const baseline = baselineByKey.get(key) ?? [];
+    const current = currentByKey.get(key) ?? [];
+    unchangedCount += Math.min(baseline.length, current.length);
+    added.push(...current.slice(baseline.length));
+    resolved.push(...baseline.slice(current.length));
+  }
   return {
-    new: [...currentByKey.entries()]
-      .filter(([key]) => !baselineByKey.has(key))
-      .map(([, finding]) => finding),
-    resolved: [...baselineByKey.entries()]
-      .filter(([key]) => !currentByKey.has(key))
-      .map(([, finding]) => finding),
-    unchangedCount: [...currentByKey.keys()].filter((key) => baselineByKey.has(key)).length
+    new: added,
+    resolved,
+    unchangedCount
   };
 }
 
@@ -637,14 +637,42 @@ function statusCountsText(statuses = {}) {
 }
 
 function findingKey(finding) {
+  const id = stableFindingId(finding);
   return [
+    id,
     finding.severity ?? "unknown",
     finding.kind ?? "finding",
     finding.scenario ?? "run",
     finding.state ?? "none",
     finding.metric ?? "none",
-    finding.command ?? (finding.metric ? "metric" : finding.id ?? "none")
+    finding.command ?? (finding.metric ? "metric" : "none"),
+    normalizeFindingText(finding.summary ?? finding.message ?? "")
   ].join("|");
+}
+
+function groupFindingsByKey(findings) {
+  const groups = new Map();
+  for (const finding of findings) {
+    const key = findingKey(finding);
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key).push(finding);
+  }
+  return groups;
+}
+
+function stableFindingId(finding) {
+  const id = typeof finding?.id === "string" ? finding.id : "";
+  return id && !/:\d+$/.test(id) ? id : "none";
+}
+
+function normalizeFindingText(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/\b-?\d+(?:\.\d+)?\b/g, "#")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function isBlockingFinding(finding) {
@@ -660,8 +688,8 @@ function compareSourceReleaseDiagnostics(leftReport, rightReport) {
 
   const sourceReport = leftLane === "source-build" ? leftReport : rightReport;
   const releaseReport = leftLane === "release-runtime" ? leftReport : rightReport;
-  const sourceRecords = indexRecords(sourceReport.records ?? []);
-  const releaseRecords = indexRecords(releaseReport.records ?? []);
+  const sourceRecords = groupRecords(sourceReport.records ?? []);
+  const releaseRecords = groupRecords(releaseReport.records ?? []);
   const keys = [...sourceRecords.keys()].filter((key) => releaseRecords.has(key)).sort();
   const findings = [];
   const pairs = [];
@@ -675,22 +703,22 @@ function compareSourceReleaseDiagnostics(leftReport, rightReport) {
   }
 
   for (const key of keys) {
-    const source = sourceRecords.get(key);
-    const release = releaseRecords.get(key);
+    const source = sourceRecords.get(key) ?? [];
+    const release = releaseRecords.get(key) ?? [];
     const pair = sourceReleasePair(key, source, release);
     pairs.push(pair);
     if (!pair.source.timelineAvailable) {
       findings.push({
         severity: "blocking",
         key,
-        message: `${key} source-build report did not include OpenClaw timeline diagnostics`
+        message: `${key} source-build report omitted OpenClaw timeline diagnostics for ${pair.source.timelineMissingCount}/${pair.source.sampleCount} sample(s)`
       });
     }
     if (!pair.release.timelineAvailable) {
       findings.push({
         severity: "info",
         key,
-        message: `${key} release-runtime report has no timeline; use outside-in timings for released packages`
+        message: `${key} release-runtime report omitted timeline diagnostics for ${pair.release.timelineMissingCount}/${pair.release.sampleCount} sample(s); use outside-in timings for released packages`
       });
     }
     if (typeof pair.source.agentPreProviderMs === "number" && typeof pair.release.agentPreProviderMs === "number") {
@@ -722,21 +750,50 @@ function compareSourceReleaseDiagnostics(leftReport, rightReport) {
   };
 }
 
-function sourceReleasePair(key, source, release) {
+function sourceReleasePair(key, sourceRecords, releaseRecords) {
+  const source = sourceRecords[0] ?? {};
+  const release = releaseRecords[0] ?? {};
   return {
     key,
     scenario: source.scenario ?? release.scenario ?? null,
     state: source.state?.id ?? release.state?.id ?? null,
     surface: source.surface ?? release.surface ?? source.measurements?.surface ?? release.measurements?.surface ?? null,
-    source: diagnosticRecordSummary(source),
-    release: diagnosticRecordSummary(release)
+    source: diagnosticGroupSummary(sourceRecords),
+    release: diagnosticGroupSummary(releaseRecords)
+  };
+}
+
+function diagnosticGroupSummary(records) {
+  const summaries = records.map(diagnosticRecordSummary);
+  const timelineAvailableCount = summaries.filter((summary) => summary.timelineAvailable).length;
+  return {
+    status: groupWorstStatus(records),
+    sampleCount: summaries.length,
+    timelineAvailable: summaries.length > 0 && timelineAvailableCount === summaries.length,
+    timelineAvailableCount,
+    timelineMissingCount: summaries.length - timelineAvailableCount,
+    timelineEventCount: medianField(summaries, "timelineEventCount"),
+    slowestSpanName: maximumFieldSummary(summaries, "slowestSpanMs")?.slowestSpanName ?? null,
+    slowestSpanMs: maximumField(summaries, "slowestSpanMs"),
+    openRequiredSpanCount: maximumField(summaries, "openRequiredSpanCount"),
+    agentTurnMs: medianField(summaries, "agentTurnMs"),
+    agentPreProviderMs: medianField(summaries, "agentPreProviderMs"),
+    providerFinalMs: medianField(summaries, "providerFinalMs"),
+    agentMetadataScanCount: maximumField(summaries, "agentMetadataScanCount"),
+    agentMetadataScanTotalMs: maximumField(summaries, "agentMetadataScanTotalMs"),
+    agentEventLoopMaxMs: maximumField(summaries, "agentEventLoopMaxMs"),
+    agentSessionPollCount: maximumField(summaries, "agentSessionPollCount"),
+    runtimeDepsStagingMs: maximumField(summaries, "runtimeDepsStagingMs"),
+    readinessHealthReadyMs: medianField(summaries, "readinessHealthReadyMs"),
+    startupHealthP95Ms: maximumField(summaries, "startupHealthP95Ms"),
+    postReadyHealthP95Ms: maximumField(summaries, "postReadyHealthP95Ms"),
+    peakRssMb: maximumField(summaries, "peakRssMb")
   };
 }
 
 function diagnosticRecordSummary(record) {
   const measurements = record?.measurements ?? {};
   return {
-    status: record?.status ?? null,
     timelineAvailable: measurements.openclawTimelineAvailable === true,
     timelineEventCount: measurements.openclawTimelineEventCount ?? null,
     slowestSpanName: measurements.openclawSlowestSpanName ?? null,
@@ -755,6 +812,34 @@ function diagnosticRecordSummary(record) {
     postReadyHealthP95Ms: measurementMetricValue(measurements, "postReadyHealthP95Ms"),
     peakRssMb: measurementMetricValue(measurements, "peakRssMb")
   };
+}
+
+function medianField(summaries, field) {
+  const values = numericFieldValues(summaries, field).sort((left, right) => left - right);
+  if (values.length === 0) {
+    return null;
+  }
+  const midpoint = Math.floor(values.length / 2);
+  return values.length % 2 === 0
+    ? (values[midpoint - 1] + values[midpoint]) / 2
+    : values[midpoint];
+}
+
+function maximumField(summaries, field) {
+  const values = numericFieldValues(summaries, field);
+  return values.length > 0 ? Math.max(...values) : null;
+}
+
+function maximumFieldSummary(summaries, field) {
+  return summaries
+    .filter((summary) => Number.isFinite(summary[field]))
+    .toSorted((left, right) => right[field] - left[field])[0] ?? null;
+}
+
+function numericFieldValues(summaries, field) {
+  return summaries
+    .map((summary) => summary[field])
+    .filter((value) => typeof value === "number" && Number.isFinite(value));
 }
 
 function targetLane(target) {
@@ -776,15 +861,7 @@ function targetKind(target) {
 }
 
 function statusRank(status) {
-  const ranks = {
-    PASS: 0,
-    "DRY-RUN": 0,
-    SKIPPED: 1,
-    INCOMPLETE: 2,
-    FAIL: 3,
-    BLOCKED: 4
-  };
-  return ranks[status] ?? 3;
+  return recordStatusRank(status);
 }
 
 function metricRegressions(baselineRecords, currentRecords, thresholds, options = {}) {

--- a/src/reporting/compare.mjs
+++ b/src/reporting/compare.mjs
@@ -669,7 +669,13 @@ function stableFindingId(finding) {
 
 function normalizeFindingText(finding) {
   const text = String(finding?.summary ?? finding?.message ?? "").toLowerCase();
-  return text
+  const normalizedActual = typeof finding?.actual === "number" && Number.isFinite(finding.actual)
+    ? text.replace(
+      /(?<![a-z0-9_])-?\d+(?:\.\d+)?(?![a-z0-9_])/gi,
+      (value) => Number(value) === finding.actual ? "#" : value
+    )
+    : text;
+  return normalizedActual
     .replace(
       /-?\d+(?:\.\d+)?(?=\s*(?:(?:ms|s|sec|seconds?|kb|mb|gb|bytes?)\b|%))/gi,
       "#"

--- a/src/reporting/compare.mjs
+++ b/src/reporting/compare.mjs
@@ -671,8 +671,8 @@ function normalizeFindingText(finding) {
   const text = String(finding?.summary ?? finding?.message ?? "").toLowerCase();
   return text
     .replace(
-    /-?\d+(?:\.\d+)?(?=\s*(?:ms|s|sec|seconds?|kb|mb|gb|bytes?|%)(?:\b|$))/gi,
-    "#"
+      /-?\d+(?:\.\d+)?(?=\s*(?:(?:ms|s|sec|seconds?|kb|mb|gb|bytes?)\b|%))/gi,
+      "#"
     )
     .replace(
       /\b(threshold|limit|budget|ceiling|minimum|maximum)(\s*(?:of|=|:)?\s*)-?\d+(?:\.\d+)?/gi,

--- a/src/reporting/compare.mjs
+++ b/src/reporting/compare.mjs
@@ -646,7 +646,7 @@ function findingKey(finding) {
     finding.state ?? "none",
     finding.metric ?? "none",
     finding.command ?? (finding.metric ? "metric" : "none"),
-    normalizeFindingText(finding.summary ?? finding.message ?? "")
+    normalizeFindingText(finding)
   ].join("|");
 }
 
@@ -667,10 +667,17 @@ function stableFindingId(finding) {
   return id && !/:\d+$/.test(id) ? id : "none";
 }
 
-function normalizeFindingText(value) {
-  return String(value)
-    .toLowerCase()
-    .replace(/\b-?\d+(?:\.\d+)?\b/g, "#")
+function normalizeFindingText(finding) {
+  const expected = String(finding?.expected ?? "");
+  const thresholded = /(?:<=|>=|<|>)\s*-?\d/.test(expected);
+  const text = String(finding?.summary ?? finding?.message ?? "").toLowerCase();
+  const normalizedMeasurements = text.replace(
+    /-?\d+(?:\.\d+)?(?=\s*(?:ms|s|sec|seconds?|kb|mb|gb|bytes?|%)(?:\b|$))/gi,
+    "#"
+  );
+  return (thresholded
+    ? normalizedMeasurements.replace(/(?<![a-z0-9_])-?\d+(?:\.\d+)?(?![a-z0-9_])/g, "#")
+    : normalizedMeasurements)
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/src/reporting/render-assessment.mjs
+++ b/src/reporting/render-assessment.mjs
@@ -136,13 +136,14 @@ function renderHeader(summary, scenarios, ui) {
     sampleFailed > 0 ? `${sampleFailed} failed` : null,
     sampleBlocked > 0 ? `${sampleBlocked} blocked` : null,
     sampleIncomplete > 0 ? `${sampleIncomplete} incomplete` : null,
-    sampleSkipped > 0 ? `${sampleSkipped} skipped` : null
+    sampleSkipped > 0 ? `${sampleSkipped} skipped` : null,
+    sampleDryRun > 0 && sampleDryRun !== sampleTotal ? `${sampleDryRun} planned` : null
   ].filter(Boolean);
-  const samplesText = sampleIssues.length > 0
+  const samplesText = sampleDryRun > 0 && sampleDryRun === sampleTotal
+    ? `${sampleTotal} ${pluralize(sampleTotal, "sample")} planned`
+    : sampleIssues.length > 0
     ? `${sampleIssues.join(", ")} of ${sampleTotal} ${pluralize(sampleTotal, "sample")}`
-    : sampleDryRun > 0
-      ? `${sampleTotal} ${pluralize(sampleTotal, "sample")} planned`
-      : `${sampleTotal} ${pluralize(sampleTotal, "sample")}`;
+    : `${sampleTotal} ${pluralize(sampleTotal, "sample")}`;
 
   const headline = buildVerdictHeadline({
     scope: scopeText,

--- a/src/reporting/render-assessment.mjs
+++ b/src/reporting/render-assessment.mjs
@@ -110,33 +110,35 @@ function renderHeader(summary, scenarios, ui) {
   const verdict = String(summary.decision?.verdict ?? "UNKNOWN").toUpperCase();
   const shipLabel = deriveVerdictBadge(verdict, summary);
   const conf = runConfidence(scenarios);
-  const failed = scenarios.filter((s) => s.verdict === "FAIL" || s.verdict === "BLOCKED").length;
+  const failed = scenarios.filter((s) => s.verdict === "FAIL").length;
+  const blocked = scenarios.filter((s) => s.verdict === "BLOCKED").length;
   const incomplete = scenarios.filter((s) => s.verdict === "INCOMPLETE").length;
   const dryRun = scenarios.filter((s) => s.verdict === "DRY-RUN").length;
   const totalScn = scenarios.length;
   const sampleTotal = scenarios.reduce((a, s) => a + (s.total ?? 0), 0);
-  const sampleFailed = scenarios
-    .filter((s) => s.verdict === "FAIL" || s.verdict === "BLOCKED")
-    .reduce((a, s) => a + Math.max(0, (s.total ?? 0) - (s.passed ?? 0)), 0);
-  const sampleIncomplete = scenarios
-    .filter((s) => s.verdict === "INCOMPLETE")
-    .reduce((a, s) => a + Math.max(0, (s.total ?? 0) - (s.passed ?? 0)), 0);
+  const sampleFailed = scenarios.reduce((a, s) => a + (s.statuses?.FAIL ?? 0), 0);
+  const sampleBlocked = scenarios.reduce((a, s) => a + (s.statuses?.BLOCKED ?? 0), 0);
+  const sampleIncomplete = scenarios.reduce((a, s) => a + (s.statuses?.INCOMPLETE ?? 0), 0);
   // Pluralize against the count actually referenced in each clause so
   // "1 scenario failed" reads correctly while "3 scenarios passed" still works.
   const scopeText = failed > 0
-    ? `${failed} ${pluralize(failed, "scenario")} failed${totalScn > failed ? ` of ${totalScn}` : ""}`
-    : incomplete > 0
-      ? `${incomplete} ${pluralize(incomplete, "scenario")} incomplete${totalScn > incomplete ? ` of ${totalScn}` : ""}`
-      : dryRun > 0
-        ? `${dryRun} ${pluralize(dryRun, "scenario")} planned${totalScn > dryRun ? ` of ${totalScn}` : ""}`
-        : `${totalScn} ${pluralize(totalScn, "scenario")} passed`;
+    ? `${failed} ${pluralize(failed, "scenario")} failed${blocked > 0 ? `, ${blocked} blocked` : ""}${totalScn > failed + blocked ? ` of ${totalScn}` : ""}`
+    : blocked > 0
+      ? `${blocked} ${pluralize(blocked, "scenario")} blocked${totalScn > blocked ? ` of ${totalScn}` : ""}`
+      : incomplete > 0
+        ? `${incomplete} ${pluralize(incomplete, "scenario")} incomplete${totalScn > incomplete ? ` of ${totalScn}` : ""}`
+        : dryRun > 0
+          ? `${dryRun} ${pluralize(dryRun, "scenario")} planned${totalScn > dryRun ? ` of ${totalScn}` : ""}`
+          : `${totalScn} ${pluralize(totalScn, "scenario")} passed`;
   const samplesText = sampleFailed > 0
-    ? `${sampleFailed}/${sampleTotal} ${pluralize(sampleTotal, "sample")} failed`
-    : sampleIncomplete > 0
-      ? `${sampleIncomplete}/${sampleTotal} ${pluralize(sampleTotal, "sample")} incomplete`
-      : dryRun > 0
-        ? `${sampleTotal} ${pluralize(sampleTotal, "sample")} planned`
-        : `${sampleTotal} ${pluralize(sampleTotal, "sample")}`;
+    ? `${sampleFailed} failed${sampleBlocked > 0 ? `, ${sampleBlocked} blocked` : ""} of ${sampleTotal} ${pluralize(sampleTotal, "sample")}`
+    : sampleBlocked > 0
+      ? `${sampleBlocked}/${sampleTotal} ${pluralize(sampleTotal, "sample")} blocked`
+      : sampleIncomplete > 0
+        ? `${sampleIncomplete}/${sampleTotal} ${pluralize(sampleTotal, "sample")} incomplete`
+        : dryRun > 0
+          ? `${sampleTotal} ${pluralize(sampleTotal, "sample")} planned`
+          : `${sampleTotal} ${pluralize(sampleTotal, "sample")}`;
 
   const headline = buildVerdictHeadline({
     scope: scopeText,

--- a/src/reporting/render-assessment.mjs
+++ b/src/reporting/render-assessment.mjs
@@ -119,6 +119,8 @@ function renderHeader(summary, scenarios, ui) {
   const sampleFailed = scenarios.reduce((a, s) => a + (s.statuses?.FAIL ?? 0), 0);
   const sampleBlocked = scenarios.reduce((a, s) => a + (s.statuses?.BLOCKED ?? 0), 0);
   const sampleIncomplete = scenarios.reduce((a, s) => a + (s.statuses?.INCOMPLETE ?? 0), 0);
+  const sampleSkipped = scenarios.reduce((a, s) => a + (s.statuses?.SKIPPED ?? 0), 0);
+  const sampleDryRun = scenarios.reduce((a, s) => a + (s.statuses?.["DRY-RUN"] ?? 0), 0);
   // Pluralize against the count actually referenced in each clause so
   // "1 scenario failed" reads correctly while "3 scenarios passed" still works.
   const scopeText = failed > 0
@@ -130,15 +132,17 @@ function renderHeader(summary, scenarios, ui) {
         : dryRun > 0
           ? `${dryRun} ${pluralize(dryRun, "scenario")} planned${totalScn > dryRun ? ` of ${totalScn}` : ""}`
           : `${totalScn} ${pluralize(totalScn, "scenario")} passed`;
-  const samplesText = sampleFailed > 0
-    ? `${sampleFailed} failed${sampleBlocked > 0 ? `, ${sampleBlocked} blocked` : ""} of ${sampleTotal} ${pluralize(sampleTotal, "sample")}`
-    : sampleBlocked > 0
-      ? `${sampleBlocked}/${sampleTotal} ${pluralize(sampleTotal, "sample")} blocked`
-      : sampleIncomplete > 0
-        ? `${sampleIncomplete}/${sampleTotal} ${pluralize(sampleTotal, "sample")} incomplete`
-        : dryRun > 0
-          ? `${sampleTotal} ${pluralize(sampleTotal, "sample")} planned`
-          : `${sampleTotal} ${pluralize(sampleTotal, "sample")}`;
+  const sampleIssues = [
+    sampleFailed > 0 ? `${sampleFailed} failed` : null,
+    sampleBlocked > 0 ? `${sampleBlocked} blocked` : null,
+    sampleIncomplete > 0 ? `${sampleIncomplete} incomplete` : null,
+    sampleSkipped > 0 ? `${sampleSkipped} skipped` : null
+  ].filter(Boolean);
+  const samplesText = sampleIssues.length > 0
+    ? `${sampleIssues.join(", ")} of ${sampleTotal} ${pluralize(sampleTotal, "sample")}`
+    : sampleDryRun > 0
+      ? `${sampleTotal} ${pluralize(sampleTotal, "sample")} planned`
+      : `${sampleTotal} ${pluralize(sampleTotal, "sample")}`;
 
   const headline = buildVerdictHeadline({
     scope: scopeText,

--- a/src/reporting/render-bundle.mjs
+++ b/src/reporting/render-bundle.mjs
@@ -41,7 +41,6 @@ export function renderBundleReceipt(receipt, flags = {}, env = process.env, stre
   sections.push("");
   sections.push(ruleSection("next", ui.width, ui));
   sections.push("");
-  sections.push(`  ${c.dim(g.arrow)} kova report ${displayPath(receipt.outputPath) ?? ""}`);
   if (receipt.runId) sections.push(`  ${c.dim(g.arrow)} kova report ${receipt.runId}`);
 
   return withMargin(sections.join("\n"), ui.leftPad, ui.width);

--- a/src/reporting/render-compare.mjs
+++ b/src/reporting/render-compare.mjs
@@ -207,7 +207,7 @@ function formatResourceIdentity(identity) {
 function renderRollup(comparison, ui) {
   const rows = rollupScenarios(comparison).map((r) => ({
     id: r.id,
-    passed: Math.max(0, (r.totalSamples ?? 0) - (r.failedSamples ?? 0)) || undefined,
+    passed: r.passedSamples ?? 0,
     total: r.totalSamples || undefined,
     verdict: r.verdict,
     delta: formatScenarioDelta(r),
@@ -220,7 +220,6 @@ function renderRollup(comparison, ui) {
 
 function formatScenarioDelta(r) {
   if (r.regressionCount > 0) return `+${r.regressionCount}`;
-  if (r.verdict === "IMPROVED") return "-0";
   return "";
 }
 

--- a/src/reporting/render-help.mjs
+++ b/src/reporting/render-help.mjs
@@ -23,6 +23,7 @@ const COMMANDS = [
       ["--ci", "non-interactive defaults for CI"],
       ["--non-interactive", "use flag values, no prompts"],
       ["--auth <method>", "mock|api-key|env-only|external-cli|oauth|skip"],
+      ["--method <method>", "auth method for `kova setup auth`"],
       ["--provider <id>", "openai|anthropic|custom-openai"],
       ["--env-var <name>", "env var holding the API key"],
       ["--value <secret>", "secret to write into the credential store"],

--- a/src/reporting/render-inventory.mjs
+++ b/src/reporting/render-inventory.mjs
@@ -105,7 +105,7 @@ function renderFooter(plan, ui) {
   // footer; the JSON form carries timestamps when callers need them.
   const { c, g } = ui;
   const lines = [ruleSection("next", ui.width, ui), ""];
-  lines.push(`  ${c.dim(g.arrow)} kova inventory --json`);
+  lines.push(`  ${c.dim(g.arrow)} kova inventory plan --json`);
   lines.push(`  ${c.dim(g.arrow)} kova plan`);
   return lines.join("\n");
 }

--- a/src/reporting/render-matrix-plan.mjs
+++ b/src/reporting/render-matrix-plan.mjs
@@ -95,7 +95,10 @@ function renderEntries(planJson, ui) {
   lines.push(indentBlock(table, 2));
 
   const more = entries.length - top.length;
-  if (more > 0) lines.push(`  ${c.dim(`+ ${more} more entry${more === 1 ? "" : "ies"} (use --json for full list)`)}`);
+  if (more > 0) {
+    const noun = more === 1 ? "entry" : "entries";
+    lines.push(`  ${c.dim(`+ ${more} more ${noun} (use --json for full list)`)}`);
+  }
   return lines.join("\n");
 }
 

--- a/src/reporting/render-plan.mjs
+++ b/src/reporting/render-plan.mjs
@@ -163,7 +163,7 @@ function renderNext(planJson, ui) {
   const scenarios = planJson.scenarios ?? [];
   const lines = [ruleSection("next", ui.width, ui), ""];
   const sample = scenarios[0]?.id;
-  if (sample) lines.push(`  ${c.dim(g.arrow)} kova run --scenario ${sample}`);
+  if (sample) lines.push(`  ${c.dim(g.arrow)} kova run --target runtime:stable --scenario ${sample}`);
   lines.push(`  ${c.dim(g.arrow)} kova matrix plan --profile smoke --target runtime:stable`);
   lines.push(`  ${c.dim(g.arrow)} kova plan --json`);
   return lines.join("\n");

--- a/src/reporting/render-run-progress.mjs
+++ b/src/reporting/render-run-progress.mjs
@@ -94,7 +94,9 @@ export function createRunProgress({ flags = {}, env = process.env, stream = proc
     runFinish({ total, statuses }) {
       const dur = fmtDuration(elapsedMs(start));
       const fail = (statuses?.FAIL ?? 0) > 0;
-      const tone = fail ? c.err : c.ok;
+      const blocked = (statuses?.BLOCKED ?? 0) > 0;
+      const incomplete = (statuses?.INCOMPLETE ?? 0) > 0;
+      const tone = fail ? c.err : blocked || incomplete ? c.warn : c.ok;
       const counts = formatCounts(statuses, c);
       footer.stop();
       stream.write(`${tag("FINISH", tone)} ${c.dim(`${total} ${total === 1 ? "entry" : "entries"} in ${dur}`)}${counts ? c.dim(`  ${g.sep}  `) + counts : ""}\n`);

--- a/src/reporting/render-run-progress.mjs
+++ b/src/reporting/render-run-progress.mjs
@@ -96,7 +96,8 @@ export function createRunProgress({ flags = {}, env = process.env, stream = proc
       const fail = (statuses?.FAIL ?? 0) > 0;
       const blocked = (statuses?.BLOCKED ?? 0) > 0;
       const incomplete = (statuses?.INCOMPLETE ?? 0) > 0;
-      const tone = fail ? c.err : blocked || incomplete ? c.warn : c.ok;
+      const skipped = (statuses?.SKIPPED ?? 0) > 0;
+      const tone = fail ? c.err : blocked || incomplete || skipped ? c.warn : c.ok;
       const counts = formatCounts(statuses, c);
       footer.stop();
       stream.write(`${tag("FINISH", tone)} ${c.dim(`${total} ${total === 1 ? "entry" : "entries"} in ${dur}`)}${counts ? c.dim(`  ${g.sep}  `) + counts : ""}\n`);

--- a/src/reporting/render-run-receipt.mjs
+++ b/src/reporting/render-run-receipt.mjs
@@ -76,9 +76,11 @@ function buildRunHeadline(report) {
   const total = report.summary?.total ?? 0;
   const pass = statuses.PASS ?? 0;
   const fail = statuses.FAIL ?? 0;
+  const blocked = statuses.BLOCKED ?? 0;
   const dry = statuses["DRY-RUN"] ?? 0;
   if (report.mode === "dry-run") return `${dry || total} planned`;
-  if (fail > 0) return `${fail} failed of ${total}`;
+  if (fail > 0) return `${fail} failed${blocked > 0 ? `, ${blocked} blocked` : ""} of ${total}`;
+  if (blocked > 0) return `${blocked} blocked of ${total}`;
   if (pass === total && total > 0) return `${total} passed`;
   return `${pass}/${total} passed`;
 }
@@ -115,11 +117,29 @@ function renderKpiStrip(report, ui, opts = {}) {
     ? { label: "Dry-run", value: String(dry), hint: "planned", tone: "neutral", bar: { filled: dry, total: Math.max(total, dry) } }
     : { label: "Passed", value: String(pass), hint: "scenarios", tone: pass > 0 ? "ok" : "dim", bar: { filled: pass, total: Math.max(total, pass) } };
 
-  const failHint = blocked > 0 ? `+${blocked} blocked` : (skip > 0 ? `+${skip} skipped` : null);
-  const failItem = {
-    label: "Failed", value: String(fail), hint: failHint, tone: fail > 0 ? "err" : "dim",
-    bar: { filled: fail, total: Math.max(total, fail) },
-  };
+  const failItem = fail > 0
+    ? {
+      label: "Failed",
+      value: String(fail),
+      hint: blocked > 0 ? `+${blocked} blocked` : (skip > 0 ? `+${skip} skipped` : null),
+      tone: "err",
+      bar: { filled: fail, total: Math.max(total, fail) },
+    }
+    : blocked > 0
+      ? {
+        label: "Blocked",
+        value: String(blocked),
+        hint: skip > 0 ? `+${skip} skipped` : "incomplete",
+        tone: "warn",
+        bar: { filled: blocked, total: Math.max(total, blocked) },
+      }
+      : {
+        label: "Failed",
+        value: "0",
+        hint: skip > 0 ? `+${skip} skipped` : null,
+        tone: "dim",
+        bar: { filled: 0, total: Math.max(total, 1) },
+      };
 
   const perfHint = perf.unstableGroupCount > 0
     ? `${perf.unstableGroupCount} unstable`

--- a/src/reporting/report-store.mjs
+++ b/src/reporting/report-store.mjs
@@ -129,8 +129,8 @@ function reportStatus(report) {
     return report.gate.verdict;
   }
   const statuses = report.summary?.statuses ?? {};
-  if ((statuses.BLOCKED ?? 0) > 0) return "BLOCKED";
   if ((statuses.FAIL ?? 0) > 0) return "FAIL";
+  if ((statuses.BLOCKED ?? 0) > 0) return "BLOCKED";
   if ((statuses.INCOMPLETE ?? 0) > 0) return "INCOMPLETE";
   if ((statuses["DRY-RUN"] ?? 0) > 0) return "DRY-RUN";
   if ((statuses.PASS ?? 0) > 0) return "PASS";

--- a/src/reporting/report.mjs
+++ b/src/reporting/report.mjs
@@ -669,6 +669,16 @@ function buildDecision(report, statuses, findings, blockingFindingCount, warning
       warningFindingCount
     };
   }
+  if ((statuses[RECORD_STATUS.FAIL] ?? 0) > 0) {
+    const primary = primaryFailFinding(findings) ?? findings[0] ?? null;
+    return {
+      verdict: RECORD_STATUS.FAIL,
+      ok: false,
+      reason: primary?.summary ?? "one or more scenarios failed",
+      blockingFindingCount,
+      warningFindingCount
+    };
+  }
   if ((statuses[RECORD_STATUS.BLOCKED] ?? 0) > 0) {
     const primary = findings.find((finding) => finding.severity === "blocked") ?? findings[0] ?? null;
     return {
@@ -685,16 +695,6 @@ function buildDecision(report, statuses, findings, blockingFindingCount, warning
       verdict: RECORD_STATUS.INCOMPLETE,
       ok: false,
       reason: primary?.summary ?? "one or more scenarios were missing required proof",
-      blockingFindingCount,
-      warningFindingCount
-    };
-  }
-  if ((statuses[RECORD_STATUS.FAIL] ?? 0) > 0) {
-    const primary = primaryFailFinding(findings) ?? findings[0] ?? null;
-    return {
-      verdict: RECORD_STATUS.FAIL,
-      ok: false,
-      reason: primary?.summary ?? "one or more scenarios failed",
       blockingFindingCount,
       warningFindingCount
     };

--- a/src/reporting/scenario-aggregate.mjs
+++ b/src/reporting/scenario-aggregate.mjs
@@ -471,11 +471,15 @@ export function scenarioConfidence(scenario) {
 // samples that produced it; unrelated large scenarios cannot inflate it.
 export function runConfidence(scenarios) {
   const confidences = (scenarios ?? [])
-    .flatMap((scenario) => (scenario.metrics ?? []).map(metricConfidence))
-    .filter(Boolean);
-  return weakestConfidence(confidences.length > 0
-    ? confidences
-    : (scenarios ?? []).map((scenario) => confidenceForSamples(scenario.total ?? 0, null)));
+    .flatMap((scenario) => {
+      const metricConfidences = (scenario.metrics ?? [])
+        .map(metricConfidence)
+        .filter(Boolean);
+      return metricConfidences.length > 0
+        ? metricConfidences
+        : [confidenceForSamples(scenario.total ?? 0, null)];
+    });
+  return weakestConfidence(confidences);
 }
 
 function roleViolationCandidate(violation, role) {

--- a/src/reporting/scenario-aggregate.mjs
+++ b/src/reporting/scenario-aggregate.mjs
@@ -459,9 +459,12 @@ function groupFindingsByScenario(findings) {
 // Aggregate scenario-level confidence from all numeric headline metrics
 // (worst CV wins, so the verdict line reflects the noisiest signal).
 export function scenarioConfidence(scenario) {
-  return weakestConfidence((scenario.metrics ?? [])
+  const confidences = (scenario.metrics ?? [])
     .map(metricConfidence)
-    .filter(Boolean), scenario.total ?? 0);
+    .filter(Boolean);
+  return weakestConfidence(confidences.length > 0
+    ? confidences
+    : [confidenceForSamples(scenario.total ?? 0, null)]);
 }
 
 // Run-wide confidence keeps each variability estimate paired with the
@@ -470,8 +473,9 @@ export function runConfidence(scenarios) {
   const confidences = (scenarios ?? [])
     .flatMap((scenario) => (scenario.metrics ?? []).map(metricConfidence))
     .filter(Boolean);
-  const fallbackSamples = (scenarios ?? []).reduce((total, scenario) => total + (scenario.total ?? 0), 0);
-  return weakestConfidence(confidences, fallbackSamples);
+  return weakestConfidence(confidences.length > 0
+    ? confidences
+    : (scenarios ?? []).map((scenario) => confidenceForSamples(scenario.total ?? 0, null)));
 }
 
 function roleViolationCandidate(violation, role) {
@@ -481,38 +485,44 @@ function roleViolationCandidate(violation, role) {
     role,
     threshold,
     actual,
-    score: normalizedThresholdOverage(actual, threshold),
+    score: normalizedThresholdOverage(actual, threshold, thresholdDirection(violation.expected)),
     key: violationSortKey(violation)
   };
 }
 
 function violationScore(violation, measurements) {
-  if (violation.kind !== "threshold") {
+  const threshold = parseThreshold(violation.expected);
+  if (threshold === null) {
     return 0;
   }
   const metricKey = violation.metric ?? null;
   const actual = finiteNumber(metricKey
     ? measurementMetricValue(measurements, metricKey) ?? violation.actual
     : violation.actual);
-  return 1 + normalizedThresholdOverage(actual, parseThreshold(violation.expected));
+  return 1 + normalizedThresholdOverage(actual, threshold, thresholdDirection(violation.expected));
 }
 
-function normalizedThresholdOverage(actual, threshold) {
+function normalizedThresholdOverage(actual, threshold, direction) {
   if (actual === null || threshold === null) {
     return 0;
   }
-  return (actual - threshold) / Math.max(Math.abs(threshold), 1);
+  const distance = direction === "minimum"
+    ? threshold - actual
+    : actual - threshold;
+  return distance / Math.max(Math.abs(threshold), 1);
+}
+
+function thresholdDirection(expected) {
+  const value = String(expected ?? "");
+  return value.includes(">=") || /(^|\s)>\s/.test(value)
+    ? "minimum"
+    : "maximum";
 }
 
 function compareViolationCandidates(left, right) {
   const scoreDelta = left.score - right.score;
   if (scoreDelta !== 0) {
     return scoreDelta;
-  }
-  const actualDelta = (left.actual ?? Number.NEGATIVE_INFINITY) -
-    (right.actual ?? Number.NEGATIVE_INFINITY);
-  if (actualDelta !== 0) {
-    return actualDelta;
   }
   return right.key.localeCompare(left.key);
 }
@@ -537,17 +547,26 @@ function metricConfidence(metric) {
   if (!stats || !Number.isFinite(stats.n) || stats.n <= 0) {
     return null;
   }
-  return classifyConfidence({ n: stats.n, cv: stats.cv });
+  return confidenceForSamples(stats.n, stats.cv);
 }
 
-function weakestConfidence(confidences, fallbackSamples) {
+function confidenceForSamples(n, cv) {
+  return {
+    ...classifyConfidence({ n, cv }),
+    sampleCount: n
+  };
+}
+
+function weakestConfidence(confidences) {
   if (confidences.length === 0) {
-    return classifyConfidence({ n: fallbackSamples, cv: null });
+    return confidenceForSamples(0, null);
   }
   return confidences.reduce((worst, current) =>
     confidenceRank(current) > confidenceRank(worst) ||
       (confidenceRank(current) === confidenceRank(worst) &&
-        (current.percent ?? -1) > (worst.percent ?? -1))
+        ((current.percent ?? -1) > (worst.percent ?? -1) ||
+          ((current.percent ?? -1) === (worst.percent ?? -1) &&
+            current.sampleCount < worst.sampleCount)))
       ? current
       : worst
   );

--- a/src/reporting/scenario-aggregate.mjs
+++ b/src/reporting/scenario-aggregate.mjs
@@ -14,6 +14,7 @@
 
 import { measurementMetricValue } from "../health.mjs";
 import { commandResultFailed } from "../measurement-contract.mjs";
+import { recordStatusRank } from "../statuses.mjs";
 import { summarizeSamples, classifyConfidence } from "../ui/confidence.mjs";
 
 // Metrics we always surface (when present) as scenario headline metrics,
@@ -120,19 +121,10 @@ export function aggregateScenarios(report, findings = []) {
 
   const out = [];
   for (const [id, samples] of byScenario) {
-    const passed = samples.filter((s) => s.status === "PASS").length;
-    const failed = samples.filter((s) => s.status === "FAIL").length;
-    const blocked = samples.filter((s) => s.status === "BLOCKED").length;
-    const dryRun = samples.filter((s) => s.status === "DRY-RUN").length;
-    const verdict = blocked > 0
-      ? "BLOCKED"
-      : failed > 0
-        ? "FAIL"
-        : dryRun === samples.length
-          ? "DRY-RUN"
-          : passed === samples.length
-            ? "PASS"
-            : "INCOMPLETE";
+    const statuses = sampleStatusCounts(samples);
+    const passed = statuses.PASS ?? 0;
+    const dryRun = statuses["DRY-RUN"] ?? 0;
+    const verdict = worstScenarioStatus(samples, { passed, dryRun });
     const first = samples[0];
 
     out.push({
@@ -143,6 +135,7 @@ export function aggregateScenarios(report, findings = []) {
       verdict,
       total: samples.length,
       passed,
+      statuses,
       phases: aggregatePhases(samples),
       metrics: aggregateMetrics(samples),
       fixtureAccounting: aggregateFixtureAccounting(samples),
@@ -155,6 +148,14 @@ export function aggregateScenarios(report, findings = []) {
   // Failure-first: failed/blocked first, then incomplete, then pass
   out.sort((a, b) => verdictRank(a.verdict) - verdictRank(b.verdict));
   return out;
+}
+
+function sampleStatusCounts(samples) {
+  const counts = {};
+  for (const sample of samples) {
+    counts[sample.status] = (counts[sample.status] ?? 0) + 1;
+  }
+  return counts;
 }
 
 function aggregateFixtureAccounting(samples) {
@@ -178,13 +179,23 @@ function aggregateFixtureAccounting(samples) {
 }
 
 function verdictRank(v) {
-  switch (v) {
-    case "FAIL": return 0;
-    case "BLOCKED": return 1;
-    case "INCOMPLETE": return 2;
-    case "PASS": return 3;
-    default: return 4;
+  return -recordStatusRank(v);
+}
+
+function worstScenarioStatus(samples, { passed, dryRun }) {
+  if (samples.some((sample) => sample.status === "FAIL")) {
+    return "FAIL";
   }
+  if (samples.some((sample) => sample.status === "BLOCKED")) {
+    return "BLOCKED";
+  }
+  if (dryRun === samples.length) {
+    return "DRY-RUN";
+  }
+  if (passed === samples.length) {
+    return "PASS";
+  }
+  return "INCOMPLETE";
 }
 
 function aggregatePhases(samples) {
@@ -243,13 +254,10 @@ function aggregateMetrics(samples) {
         }
         if (!roleChildren.has(parentKey)) roleChildren.set(parentKey, new Map());
         const byRole = roleChildren.get(parentKey);
-        if (!byRole.has(role)) {
-          const actualNum = typeof v.actual === "number" ? v.actual : Number(v.actual);
-          byRole.set(role, {
-            role,
-            threshold: parseThreshold(v.expected),
-            actual: Number.isFinite(actualNum) ? actualNum : null,
-          });
+        const candidate = roleViolationCandidate(v, role);
+        const existing = byRole.get(role);
+        if (!existing || compareViolationCandidates(candidate, existing) > 0) {
+          byRole.set(role, candidate);
         }
         continue;
       }
@@ -296,7 +304,14 @@ function aggregateMetrics(samples) {
       unit: meta.unit,
       direction: meta.direction,
       value: stats && stats.n === 1 ? stats.median : null,
-      stats: stats && stats.n > 1 ? { median: stats.median, stdev: stats.stdev, p95: stats.p95, max: stats.max } : null,
+      stats: stats ? {
+        n: stats.n,
+        median: stats.median,
+        stdev: stats.stdev,
+        p95: stats.p95,
+        max: stats.max,
+        cv: stats.cv
+      } : null,
       threshold: meta.threshold,
       status: thresholdStatus,
     });
@@ -352,17 +367,24 @@ function parseThreshold(expected) {
 }
 
 function findWorstViolation(samples) {
+  let worst = null;
   for (const s of samples) {
-    const v = (s.violations ?? [])[0];
-    if (!v) {
-      continue;
-    }
-    const summary = summarizeViolation(v, s.measurements ?? {});
-    if (summary) {
-      return summary;
+    for (const violation of s.violations ?? []) {
+      const summary = summarizeViolation(violation, s.measurements ?? {});
+      if (!summary) {
+        continue;
+      }
+      const candidate = {
+        summary,
+        score: violationScore(violation, s.measurements ?? {}),
+        key: violationSortKey(violation)
+      };
+      if (!worst || compareViolationCandidates(candidate, worst) > 0) {
+        worst = candidate;
+      }
     }
   }
-  return null;
+  return worst?.summary ?? null;
 }
 
 // Surface one claim per scenario derived from its declared objective.
@@ -437,28 +459,106 @@ function groupFindingsByScenario(findings) {
 // Aggregate scenario-level confidence from all numeric headline metrics
 // (worst CV wins, so the verdict line reflects the noisiest signal).
 export function scenarioConfidence(scenario) {
-  let worst = null;
-  let n = 0;
-  for (const m of scenario.metrics ?? []) {
-    if (!m.stats) continue;
-    const cv = m.stats.stdev != null && m.stats.median ? Math.abs(m.stats.stdev / m.stats.median) : null;
-    if (cv != null && (worst == null || cv > worst)) worst = cv;
-  }
-  n = scenario.total ?? 1;
-  return classifyConfidence({ n, cv: worst });
+  return weakestConfidence((scenario.metrics ?? [])
+    .map(metricConfidence)
+    .filter(Boolean), scenario.total ?? 0);
 }
 
-// Run-wide confidence (worst CV across all scenarios).
+// Run-wide confidence keeps each variability estimate paired with the
+// samples that produced it; unrelated large scenarios cannot inflate it.
 export function runConfidence(scenarios) {
-  let n = 0;
-  let worst = null;
-  for (const sc of scenarios) {
-    n = Math.max(n, sc.total ?? 1);
-    for (const m of sc.metrics ?? []) {
-      if (!m.stats || m.stats.median == null || m.stats.stdev == null || m.stats.median === 0) continue;
-      const cv = Math.abs(m.stats.stdev / m.stats.median);
-      if (worst == null || cv > worst) worst = cv;
-    }
+  const confidences = (scenarios ?? [])
+    .flatMap((scenario) => (scenario.metrics ?? []).map(metricConfidence))
+    .filter(Boolean);
+  const fallbackSamples = (scenarios ?? []).reduce((total, scenario) => total + (scenario.total ?? 0), 0);
+  return weakestConfidence(confidences, fallbackSamples);
+}
+
+function roleViolationCandidate(violation, role) {
+  const actual = finiteNumber(violation.actual);
+  const threshold = parseThreshold(violation.expected);
+  return {
+    role,
+    threshold,
+    actual,
+    score: normalizedThresholdOverage(actual, threshold),
+    key: violationSortKey(violation)
+  };
+}
+
+function violationScore(violation, measurements) {
+  if (violation.kind !== "threshold") {
+    return 0;
   }
-  return classifyConfidence({ n, cv: worst });
+  const metricKey = violation.metric ?? null;
+  const actual = finiteNumber(metricKey
+    ? measurementMetricValue(measurements, metricKey) ?? violation.actual
+    : violation.actual);
+  return 1 + normalizedThresholdOverage(actual, parseThreshold(violation.expected));
+}
+
+function normalizedThresholdOverage(actual, threshold) {
+  if (actual === null || threshold === null) {
+    return 0;
+  }
+  return (actual - threshold) / Math.max(Math.abs(threshold), 1);
+}
+
+function compareViolationCandidates(left, right) {
+  const scoreDelta = left.score - right.score;
+  if (scoreDelta !== 0) {
+    return scoreDelta;
+  }
+  const actualDelta = (left.actual ?? Number.NEGATIVE_INFINITY) -
+    (right.actual ?? Number.NEGATIVE_INFINITY);
+  if (actualDelta !== 0) {
+    return actualDelta;
+  }
+  return right.key.localeCompare(left.key);
+}
+
+function violationSortKey(violation) {
+  return [
+    violation.metric ?? "",
+    violation.kind ?? "",
+    violation.message ?? "",
+    violation.expected ?? "",
+    violation.actual ?? ""
+  ].join("|");
+}
+
+function finiteNumber(value) {
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function metricConfidence(metric) {
+  const stats = metric?.stats;
+  if (!stats || !Number.isFinite(stats.n) || stats.n <= 0) {
+    return null;
+  }
+  return classifyConfidence({ n: stats.n, cv: stats.cv });
+}
+
+function weakestConfidence(confidences, fallbackSamples) {
+  if (confidences.length === 0) {
+    return classifyConfidence({ n: fallbackSamples, cv: null });
+  }
+  return confidences.reduce((worst, current) =>
+    confidenceRank(current) > confidenceRank(worst) ||
+      (confidenceRank(current) === confidenceRank(worst) &&
+        (current.percent ?? -1) > (worst.percent ?? -1))
+      ? current
+      : worst
+  );
+}
+
+function confidenceRank(confidence) {
+  const ranks = {
+    stable: 0,
+    moderate: 1,
+    noisy: 2,
+    "single-sample": 3
+  };
+  return ranks[confidence?.bucket] ?? 3;
 }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -158,12 +158,17 @@ import {
   retainedArtifactTreeDigest,
   retainGateArtifacts
 } from "./reporting/artifacts.mjs";
-import { pickAffectedScenarios, scenarioMetricRows } from "./reporting/compare-aggregate.mjs";
+import { pickAffectedScenarios, rollupScenarios, scenarioMetricRows } from "./reporting/compare-aggregate.mjs";
 import { renderCompareAssessment } from "./reporting/render-compare.mjs";
 import { renderAssessment } from "./reporting/render-assessment.mjs";
 import { renderCleanupArtifacts, renderCleanupEnvs } from "./reporting/render-cleanup.mjs";
+import { renderBundleReceipt } from "./reporting/render-bundle.mjs";
+import { renderHelp } from "./reporting/render-help.mjs";
+import { renderInventoryPlan } from "./reporting/render-inventory.mjs";
+import { renderMatrixPlan } from "./reporting/render-matrix-plan.mjs";
+import { renderPlan } from "./reporting/render-plan.mjs";
 import { renderRunReceipt } from "./reporting/render-run-receipt.mjs";
-import { aggregateScenarios } from "./reporting/scenario-aggregate.mjs";
+import { aggregateScenarios, runConfidence } from "./reporting/scenario-aggregate.mjs";
 import { summarizePerformanceReceipt } from "./run/options.mjs";
 import { saveBaselineUpdate } from "./run/report-finalization.mjs";
 import {
@@ -621,6 +626,9 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(envNameLengthCheck());
     checks.push(evaluationViolationHelpersCheck());
     checks.push(statusFoundationCheck());
+    checks.push(reportStatusPrecedenceCheck());
+    checks.push(reportAggregationIntegrityCheck());
+    checks.push(renderedCommandGuidanceCheck());
     checks.push(evidenceLedgerGatingCheck());
     checks.push(channelCapabilityReportSummaryCheck());
     checks.push(channelCapabilityResultIngestionCheck());
@@ -1279,6 +1287,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(gatewayProcessResourceRoleCheck());
     checks.push(compareRepeatAggregationCheck());
     checks.push(compareMetricOrderingCheck());
+    checks.push(compareIdentityAndRollupCheck());
     checks.push(compareGatewayRssDedupeCheck());
     checks.push(resourceContractCompareCheck());
     checks.push(await reportCompareExitStatusCheck(tmp));
@@ -2785,6 +2794,120 @@ function compareMetricOrderingCheck() {
   }
 }
 
+function compareIdentityAndRollupCheck() {
+  try {
+    const findingRecord = (violations) => ({
+      scenario: "finding-identity",
+      surface: "finding-identity",
+      title: "Finding Identity",
+      state: { id: "fresh" },
+      status: "FAIL",
+      likelyOwner: "OpenClaw",
+      phases: [],
+      measurements: {},
+      violations
+    });
+    const repeatedFailure = {
+      kind: "threshold",
+      metric: "agentTurnMs",
+      message: "agent turn latency exceeded the configured threshold at 1200 ms"
+    };
+    const distinctFailure = {
+      kind: "threshold",
+      metric: "agentTurnMs",
+      message: "agent turn returned duplicate visible output after 1300 ms"
+    };
+    const baseline = syntheticPerformanceReport({
+      runId: "finding-baseline",
+      platform: { os: "darwin", arch: "arm64", release: "test", node: "v24.0.0" },
+      target: "runtime:stable",
+      records: [findingRecord([repeatedFailure])]
+    });
+    const current = syntheticPerformanceReport({
+      runId: "finding-current",
+      platform: baseline.platform,
+      target: "runtime:stable",
+      records: [findingRecord([repeatedFailure, repeatedFailure, distinctFailure])]
+    });
+    const comparison = compareReports(baseline, current);
+    assertEqual(comparison.findingChanges.unchangedCount, 1, "finding compare preserves one matching occurrence");
+    assertEqual(comparison.findingChanges.new.length, 2, "finding compare preserves repeated and distinct additions");
+    assertEqual(
+      comparison.findingChanges.new.some((finding) => finding.summary.includes("duplicate visible output")),
+      true,
+      "finding compare uses semantic message identity"
+    );
+
+    const rollupInput = {
+      scenarios: [{
+        scenario: "rollup-status",
+        status: "OK",
+        baselineStatus: "PASS",
+        currentStatus: "BLOCKED",
+        currentSampleCount: 1,
+        currentStatuses: { BLOCKED: 1 },
+        regressions: []
+      }, {
+        scenario: "rollup-status",
+        status: "REGRESSED",
+        baselineStatus: "BLOCKED",
+        currentStatus: "FAIL",
+        currentSampleCount: 1,
+        currentStatuses: { FAIL: 1 },
+        regressions: [{ kind: "status", message: "status regressed" }]
+      }]
+    };
+    for (const scenarios of [rollupInput.scenarios, [...rollupInput.scenarios].reverse()]) {
+      const rollup = rollupScenarios({ scenarios })[0];
+      assertEqual(rollup.baselineStatus, "BLOCKED", "rollup retains worst baseline status");
+      assertEqual(rollup.currentStatus, "FAIL", "rollup retains worst current status");
+      assertEqual(rollup.failedSamples, 2, "rollup counts all non-passing samples");
+      assertEqual(rollup.passedSamples, 0, "rollup counts passed samples explicitly");
+    }
+
+    const improved = {
+      baseline: { target: "runtime:old", runId: "old" },
+      current: { target: "runtime:new", runId: "new" },
+      regressionCount: 0,
+      improvementCount: 1,
+      scenarios: [{
+        scenario: "rollup-status",
+        status: "IMPROVED",
+        baselineStatus: "FAIL",
+        currentStatus: "PASS",
+        baselineSampleCount: 1,
+        currentSampleCount: 1,
+        currentStatuses: { PASS: 1 },
+        regressions: [],
+        metrics: {}
+      }],
+      statusChanges: { changes: [], improvements: [], regressions: [] },
+      findingChanges: { new: [], resolved: [], unchangedCount: 0 }
+    };
+    const rendered = renderCompareAssessment(
+      improved,
+      { color: "never" },
+      process.env,
+      process.stdout
+    );
+    assertEqual(rendered.includes("-0"), false, "improved compare avoids negative zero");
+    return {
+      id: "compare-identity-rollup",
+      status: "PASS",
+      command: "evaluate finding identity and status rollups",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "compare-identity-rollup",
+      status: "FAIL",
+      command: "evaluate finding identity and status rollups",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
 function compareGatewayRssDedupeCheck() {
   try {
     const baseline = syntheticPerformanceReport({
@@ -3140,6 +3263,230 @@ function statusFoundationCheck() {
       id: "status-foundation",
       status: "FAIL",
       command: "evaluate INCOMPLETE status handling",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function reportStatusPrecedenceCheck() {
+  try {
+    const baseRecord = {
+      scenario: "mixed-status",
+      surface: "mixed-status",
+      title: "Mixed Status",
+      state: { id: "fresh" },
+      likelyOwner: "OpenClaw",
+      phases: [],
+      measurements: {}
+    };
+    const records = [{
+      ...baseRecord,
+      status: "BLOCKED",
+      blockedReason: "test harness unavailable"
+    }, {
+      ...baseRecord,
+      status: "FAIL",
+      violations: [{ message: "OpenClaw behavior failed" }]
+    }];
+    const report = {
+      schemaVersion: "kova.report.v1",
+      runId: "mixed-status-run",
+      mode: "execution",
+      target: "runtime:stable",
+      records,
+      summary: summarizeRecords(records)
+    };
+    const scenarios = aggregateScenarios(report);
+    assertEqual(scenarios[0]?.verdict, "FAIL", "scenario FAIL outranks BLOCKED");
+    assertEqual(scenarios[0]?.statuses?.FAIL, 1, "scenario retains failed sample count");
+    assertEqual(scenarios[0]?.statuses?.BLOCKED, 1, "scenario retains blocked sample count");
+    assertEqual(buildReportSummary(report).decision.verdict, "FAIL", "report FAIL outranks BLOCKED");
+
+    const assessment = renderAssessment(report, { full: true, color: "never" }, process.env, process.stdout);
+    assertEqual(assessment.includes("1 scenario failed"), true, "mixed assessment reports failed scenario");
+    assertEqual(assessment.includes("1 failed, 1 blocked of 2 samples"), true, "mixed assessment preserves blocked sample");
+
+    const receipt = renderRunReceipt({ report }, { color: "never" }, process.env, process.stdout);
+    assertEqual(receipt.includes("1 failed, 1 blocked of 2"), true, "mixed receipt preserves blocked count");
+
+    const blockedReport = {
+      ...report,
+      runId: "blocked-status-run",
+      records: [records[0]],
+      summary: summarizeRecords([records[0]])
+    };
+    assertEqual(buildReportSummary(blockedReport).decision.verdict, "BLOCKED", "blocked-only report verdict");
+    const blockedAssessment = renderAssessment(
+      blockedReport,
+      { full: true, color: "never" },
+      process.env,
+      process.stdout
+    );
+    assertEqual(blockedAssessment.includes("1 scenario blocked"), true, "blocked assessment uses blocked language");
+    assertEqual(blockedAssessment.includes("scenario failed"), false, "blocked assessment avoids failed language");
+    const blockedReceipt = renderRunReceipt(
+      { report: blockedReport },
+      { color: "never" },
+      process.env,
+      process.stdout
+    );
+    assertEqual(blockedReceipt.includes("1 blocked of 1"), true, "blocked receipt headline");
+    assertEqual(blockedReceipt.includes("Blocked"), true, "blocked receipt KPI");
+
+    const gate = evaluateGate(report, {
+      id: "mixed-status-gate",
+      gate: {
+        id: "mixed-status-gate",
+        blocking: [{ scenario: "mixed-status", state: "fresh" }]
+      }
+    });
+    assertEqual(gate.verdict, "DO_NOT_SHIP", "gate FAIL outranks harness BLOCKED");
+    return {
+      id: "report-status-precedence",
+      status: "PASS",
+      command: "evaluate mixed fail and blocked report semantics",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "report-status-precedence",
+      status: "FAIL",
+      command: "evaluate mixed fail and blocked report semantics",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function reportAggregationIntegrityCheck() {
+  try {
+    const record = (actual, roleActual) => ({
+      scenario: "aggregate-worst",
+      surface: "aggregate-worst",
+      title: "Aggregate Worst",
+      state: { id: "fresh" },
+      status: "FAIL",
+      likelyOwner: "OpenClaw",
+      phases: [],
+      measurements: { peakRssMb: actual },
+      violations: [{
+        kind: "threshold",
+        metric: "peakRssMb",
+        expected: "<= 100",
+        actual,
+        message: `peak RSS ${actual} MB exceeded threshold 100 MB`
+      }, {
+        kind: "threshold",
+        metric: "resourceByRole.gateway.peakRssMb",
+        expected: "<= 100",
+        actual: roleActual,
+        message: `gateway role RSS ${roleActual} MB exceeded threshold 100 MB`
+      }]
+    });
+    const records = [record(150, 180), record(600, 700)];
+    for (const ordered of [records, [...records].reverse()]) {
+      const scenario = aggregateScenarios({ records: ordered })[0];
+      const roleMetric = scenario.metrics.find((metric) => metric.key === "peakRssMb#gateway");
+      const parentMetric = scenario.metrics.find((metric) => metric.key === "peakRssMb");
+      assertEqual(roleMetric?.value, 700, "role aggregation keeps worst violation");
+      assertEqual(parentMetric?.stats?.n, 2, "metric aggregation retains sample count");
+      assertEqual(scenario.worst?.note.includes("700"), true, "scenario worst evaluates every violation");
+    }
+
+    const confidenceRecords = [
+      ...[100, 100, 100].map((agentTurnMs) => ({
+        scenario: "stable-confidence",
+        title: "Stable Confidence",
+        status: "PASS",
+        phases: [],
+        measurements: { agentTurnMs }
+      })),
+      {
+        scenario: "sparse-confidence",
+        title: "Sparse Confidence",
+        status: "PASS",
+        phases: [],
+        measurements: { agentTurnMs: 100 }
+      }
+    ];
+    const confidenceScenarios = aggregateScenarios({ records: confidenceRecords });
+    const sparseMetric = confidenceScenarios
+      .find((scenario) => scenario.id === "sparse-confidence")
+      ?.metrics.find((metric) => metric.key === "agentTurnMs");
+    assertEqual(sparseMetric?.stats?.n, 1, "single-sample metric retains its own n");
+    assertEqual(runConfidence(confidenceScenarios).bucket, "single-sample", "run confidence uses weakest metric confidence");
+    return {
+      id: "report-aggregation-integrity",
+      status: "PASS",
+      command: "evaluate worst-case metrics and per-metric confidence",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "report-aggregation-integrity",
+      status: "FAIL",
+      command: "evaluate worst-case metrics and per-metric confidence",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function renderedCommandGuidanceCheck() {
+  try {
+    const flags = { color: "never" };
+    const plan = renderPlan({
+      scenarios: [{ id: "fresh-install", states: [], phases: [] }],
+      states: [],
+      profiles: [],
+      surfaces: []
+    }, flags, process.env, process.stdout);
+    assertEqual(
+      plan.includes("kova run --target runtime:stable --scenario fresh-install"),
+      true,
+      "plan run hint includes required target"
+    );
+
+    const inventory = renderInventoryPlan({
+      coverage: { ok: true, discoveredCount: 0, matchedCount: 0, modeledSurfaceCount: 0, warnings: [] },
+      sources: []
+    }, flags, process.env, process.stdout);
+    assertEqual(inventory.includes("kova inventory plan --json"), true, "inventory hint uses plan subcommand");
+
+    const bundle = renderBundleReceipt({
+      runId: "kova-guidance-check",
+      outputPath: "/tmp/kova-guidance-check.tar.gz",
+      checksumPath: "/tmp/kova-guidance-check.tar.gz.sha256",
+      included: []
+    }, flags, process.env, process.stdout);
+    assertEqual(bundle.includes("kova report kova-guidance-check"), true, "bundle hint uses report run id");
+    assertEqual(bundle.includes("kova report /tmp/kova-guidance-check.tar.gz"), false, "bundle hint avoids archive input");
+
+    const matrix = renderMatrixPlan({
+      profile: { id: "smoke" },
+      target: "runtime:stable",
+      entries: Array.from({ length: 22 }, (_, index) => ({
+        scenario: { id: `scenario-${index}`, title: `Scenario ${index}` },
+        state: { id: "fresh" }
+      }))
+    }, flags, process.env, process.stdout);
+    assertEqual(matrix.includes("+ 2 more entries"), true, "matrix plan pluralizes entries");
+    assertEqual(matrix.includes("entryies"), false, "matrix plan avoids invalid plural");
+
+    const help = renderHelp("setup", flags, process.env, process.stdout);
+    assertEqual(help.includes("--method <method>"), true, "setup help documents auth method flag");
+    return {
+      id: "rendered-command-guidance",
+      status: "PASS",
+      command: "validate rendered CLI follow-up commands",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "rendered-command-guidance",
+      status: "FAIL",
+      command: "validate rendered CLI follow-up commands",
       durationMs: 0,
       message: error.message
     };
@@ -15943,10 +16290,43 @@ function sourceReleaseCompareCheck() {
     assertEqual(missingTimelineComparison.ok, false, "source missing timeline should fail comparison");
     assertEqual(missingTimelineComparison.sourceRelease?.blockingCount, 1, "source missing timeline blocking count");
     assertEqual(
-      renderCompareSummary(missingTimelineComparison).includes("source-build report did not include OpenClaw timeline diagnostics"),
+      renderCompareSummary(missingTimelineComparison).includes("source-build report omitted OpenClaw timeline diagnostics"),
       true,
       "compare summary includes source timeline blocker"
     );
+
+    const repeatedSource = syntheticCompareReport({
+      runId: "source-repeated",
+      target: "local-build:/tmp/openclaw",
+      timelineAvailable: true,
+      preProviderMs: 4000,
+      slowestSpanMs: 3200
+    });
+    repeatedSource.records.push({
+      ...structuredClone(repeatedSource.records[0]),
+      status: "FAIL",
+      measurements: {
+        ...repeatedSource.records[0].measurements,
+        openclawTimelineAvailable: false,
+        openclawTimelineEventCount: 0,
+        openclawSlowestSpanName: null,
+        openclawSlowestSpanMs: null,
+        coldPreProviderMs: 6000,
+        agentPreProviderMs: 6000
+      }
+    });
+    repeatedSource.summary = { statuses: { PASS: 1, FAIL: 1 } };
+    for (const records of [repeatedSource.records, [...repeatedSource.records].reverse()]) {
+      const orderedSource = { ...repeatedSource, records };
+      const repeatedComparison = compareReports(releaseReport, orderedSource);
+      const source = repeatedComparison.sourceRelease?.pairs?.[0]?.source;
+      assertEqual(repeatedComparison.sourceRelease?.blockingCount, 1, "repeated source missing timeline blocks");
+      assertEqual(source?.sampleCount, 2, "source diagnostics retain repeated samples");
+      assertEqual(source?.status, "FAIL", "source diagnostics retain worst status");
+      assertEqual(source?.timelineMissingCount, 1, "source diagnostics count missing timelines");
+      assertEqual(source?.agentPreProviderMs, 5000, "source diagnostics use repeated-sample median");
+      assertEqual(source?.slowestSpanMs, 3200, "source diagnostics retain worst slow span");
+    }
 
     const failingReport = syntheticCompareReport({
       runId: "gateway-rss-failing",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -8663,6 +8663,7 @@ async function gateDryRunCheck(tmp) {
     assertEqual(data.schemaVersion, "kova.matrix.run.receipt.v1", "gate receipt schema");
     assertEqual(data.gate?.verdict, "BLOCKED", "gate dry-run verdict");
     assertEqual(data.gate?.ok, false, "gate dry-run ok");
+    assertEqual(data.gate?.complete, false, "gate dry-run is incomplete");
     const report = JSON.parse(await readFile(data.jsonPath, "utf8"));
     assertEqual(report.gate?.cards?.some((card) => card.kind === "not-executed"), true, "gate not-executed card");
     const summary = renderReportSummary(report, { structured: true });
@@ -8672,6 +8673,25 @@ async function gateDryRunCheck(tmp) {
     const retained = JSON.parse(await readFile(`${data.retainedGateArtifacts.outputDir}/retained-artifacts.json`, "utf8"));
     assertEqual(retained.verdict, "BLOCKED", "retained artifact verdict");
     await rm(data.retainedGateArtifacts.outputDir, { recursive: true, force: true });
+
+    const skippedGate = evaluateGate({
+      mode: "execution",
+      records: [{
+        scenario: "release-runtime-startup",
+        state: { id: "fresh" },
+        status: "SKIPPED",
+        title: "Release Runtime Startup",
+        phases: []
+      }]
+    }, {
+      id: "skipped-gate",
+      gate: {
+        id: "skipped-gate",
+        blocking: [{ scenario: "release-runtime-startup", state: "fresh" }]
+      }
+    });
+    assertEqual(skippedGate.verdict, "BLOCKED", "required skipped gate verdict");
+    assertEqual(skippedGate.complete, false, "required skipped gate is incomplete");
     return {
       id: "gate-dry-run-blocked",
       status: "PASS",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3355,6 +3355,27 @@ function reportStatusPrecedenceCheck() {
     );
     assertEqual(skippedAssessment.includes("1 skipped of 2 samples"), true, "assessment reports skipped samples");
 
+    const plannedRecords = [{
+      ...baseRecord,
+      status: "PASS"
+    }, {
+      ...baseRecord,
+      status: "DRY-RUN"
+    }];
+    const plannedReport = {
+      ...report,
+      runId: "planned-status-run",
+      records: plannedRecords,
+      summary: summarizeRecords(plannedRecords)
+    };
+    const plannedAssessment = renderAssessment(
+      plannedReport,
+      { full: true, color: "never" },
+      process.env,
+      process.stdout
+    );
+    assertEqual(plannedAssessment.includes("1 planned of 2 samples"), true, "assessment reports mixed planned samples");
+
     const gate = evaluateGate(report, {
       id: "mixed-status-gate",
       gate: {
@@ -3464,6 +3485,11 @@ function reportAggregationIntegrityCheck() {
       metrics: []
     })));
     assertEqual(noMetricConfidence.label, "single-sample", "run confidence does not pool unrelated no-metric scenarios");
+    const mixedConfidence = runConfidence([
+      confidenceScenarios.find((scenario) => scenario.id === "stable-confidence"),
+      { id: "blocked-without-metrics", total: 1, metrics: [] }
+    ]);
+    assertEqual(mixedConfidence.label, "single-sample", "run confidence includes metric-less scenarios");
     return {
       id: "report-aggregation-integrity",
       status: "PASS",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -2863,6 +2863,31 @@ function compareIdentityAndRollupCheck() {
     const categoricalComparison = compareReports(categoricalBaseline, categoricalCurrent);
     assertEqual(categoricalComparison.findingChanges.new.length, 1, "categorical numeric finding is new");
     assertEqual(categoricalComparison.findingChanges.resolved.length, 1, "categorical numeric finding is resolved");
+    const percentageBaseline = syntheticPerformanceReport({
+      runId: "percentage-baseline",
+      platform: baseline.platform,
+      target: "runtime:stable",
+      records: [findingRecord([{
+        kind: "threshold",
+        metric: "errorRate",
+        expected: "<= 4",
+        message: "error rate 5% exceeded threshold 4%"
+      }])]
+    });
+    const percentageCurrent = syntheticPerformanceReport({
+      runId: "percentage-current",
+      platform: baseline.platform,
+      target: "runtime:stable",
+      records: [findingRecord([{
+        kind: "threshold",
+        metric: "errorRate",
+        expected: "<= 4",
+        message: "error rate 6% exceeded threshold 4%"
+      }])]
+    });
+    const percentageComparison = compareReports(percentageBaseline, percentageCurrent);
+    assertEqual(percentageComparison.findingChanges.new.length, 0, "percentage measurement remains same finding");
+    assertEqual(percentageComparison.findingChanges.resolved.length, 0, "percentage measurement is not resolved");
 
     const rollupInput = {
       scenarios: [{

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -167,6 +167,7 @@ import { renderHelp } from "./reporting/render-help.mjs";
 import { renderInventoryPlan } from "./reporting/render-inventory.mjs";
 import { renderMatrixPlan } from "./reporting/render-matrix-plan.mjs";
 import { renderPlan } from "./reporting/render-plan.mjs";
+import { createRunProgress } from "./reporting/render-run-progress.mjs";
 import { renderRunReceipt } from "./reporting/render-run-receipt.mjs";
 import { aggregateScenarios, runConfidence } from "./reporting/scenario-aggregate.mjs";
 import { summarizePerformanceReceipt } from "./run/options.mjs";
@@ -2844,6 +2845,7 @@ function compareIdentityAndRollupCheck() {
       records: [findingRecord([{
         kind: "protocol",
         metric: "providerResponse",
+        expected: "<= 0",
         message: "provider returned HTTP 401"
       }])]
     });
@@ -2854,6 +2856,7 @@ function compareIdentityAndRollupCheck() {
       records: [findingRecord([{
         kind: "protocol",
         metric: "providerResponse",
+        expected: "<= 0",
         message: "provider returned HTTP 500"
       }])]
     });
@@ -2907,6 +2910,23 @@ function compareIdentityAndRollupCheck() {
     for (const scenarios of [mixedExecutionStates, [...mixedExecutionStates].reverse()]) {
       const rollup = rollupScenarios({ scenarios })[0];
       assertEqual(rollup.currentStatus, "DRY-RUN", "rollup dry-run outranks pass deterministically");
+    }
+    const mixedVerdictStates = [{
+      scenario: "mixed-verdict",
+      status: "BLOCKED",
+      currentSampleCount: 1,
+      currentStatuses: { BLOCKED: 1 },
+      regressions: []
+    }, {
+      scenario: "mixed-verdict",
+      status: "FAIL",
+      currentSampleCount: 1,
+      currentStatuses: { FAIL: 1 },
+      regressions: []
+    }];
+    for (const scenarios of [mixedVerdictStates, [...mixedVerdictStates].reverse()]) {
+      const rollup = rollupScenarios({ scenarios })[0];
+      assertEqual(rollup.verdict, "FAIL", "compare rollup FAIL outranks BLOCKED");
     }
 
     const improved = {
@@ -3419,6 +3439,26 @@ function reportStatusPrecedenceCheck() {
       process.stdout
     );
     assertEqual(plannedAssessment.includes("1 planned of 2 samples"), true, "assessment reports mixed planned samples");
+
+    const progressOutput = [];
+    const progress = createRunProgress({
+      flags: { color: "always" },
+      env: { TERM: "xterm-256color" },
+      stream: {
+        isTTY: true,
+        columns: 120,
+        write(value) {
+          progressOutput.push(String(value));
+          return true;
+        }
+      }
+    });
+    progress.runFinish({ total: 1, statuses: { SKIPPED: 1 } });
+    assertEqual(
+      progressOutput.join("").includes("\u001b[33m[FINISH]"),
+      true,
+      "skipped run finish uses warning tone"
+    );
 
     const gate = evaluateGate(report, {
       id: "mixed-status-gate",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3334,6 +3334,27 @@ function reportStatusPrecedenceCheck() {
     assertEqual(blockedReceipt.includes("1 blocked of 1"), true, "blocked receipt headline");
     assertEqual(blockedReceipt.includes("Blocked"), true, "blocked receipt KPI");
 
+    const skippedRecords = [{
+      ...baseRecord,
+      status: "PASS"
+    }, {
+      ...baseRecord,
+      status: "SKIPPED"
+    }];
+    const skippedReport = {
+      ...report,
+      runId: "skipped-status-run",
+      records: skippedRecords,
+      summary: summarizeRecords(skippedRecords)
+    };
+    const skippedAssessment = renderAssessment(
+      skippedReport,
+      { full: true, color: "never" },
+      process.env,
+      process.stdout
+    );
+    assertEqual(skippedAssessment.includes("1 skipped of 2 samples"), true, "assessment reports skipped samples");
+
     const gate = evaluateGate(report, {
       id: "mixed-status-gate",
       gate: {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -3394,6 +3394,27 @@ function reportAggregationIntegrityCheck() {
       assertEqual(scenario.worst?.note.includes("700"), true, "scenario worst evaluates every violation");
     }
 
+    const lowerBoundRecords = [50, 90].map((actual) => ({
+      scenario: "aggregate-minimum",
+      surface: "aggregate-minimum",
+      title: "Aggregate Minimum",
+      state: { id: "fresh" },
+      status: "FAIL",
+      phases: [],
+      measurements: {},
+      violations: [{
+        kind: "soak",
+        metric: "soakDurationMs",
+        expected: ">= 100",
+        actual,
+        message: `soak duration ${actual}ms was below required 100ms`
+      }]
+    }));
+    for (const ordered of [lowerBoundRecords, [...lowerBoundRecords].reverse()]) {
+      const scenario = aggregateScenarios({ records: ordered })[0];
+      assertEqual(scenario.worst?.note.includes("50ms"), true, "minimum threshold keeps farthest underage");
+    }
+
     const confidenceRecords = [
       ...[100, 100, 100].map((agentTurnMs) => ({
         scenario: "stable-confidence",
@@ -3416,6 +3437,12 @@ function reportAggregationIntegrityCheck() {
       ?.metrics.find((metric) => metric.key === "agentTurnMs");
     assertEqual(sparseMetric?.stats?.n, 1, "single-sample metric retains its own n");
     assertEqual(runConfidence(confidenceScenarios).bucket, "single-sample", "run confidence uses weakest metric confidence");
+    const noMetricConfidence = runConfidence(Array.from({ length: 10 }, (_, index) => ({
+      id: `blocked-${index}`,
+      total: 1,
+      metrics: []
+    })));
+    assertEqual(noMetricConfidence.label, "single-sample", "run confidence does not pool unrelated no-metric scenarios");
     return {
       id: "report-aggregation-integrity",
       status: "PASS",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -2888,6 +2888,33 @@ function compareIdentityAndRollupCheck() {
     const percentageComparison = compareReports(percentageBaseline, percentageCurrent);
     assertEqual(percentageComparison.findingChanges.new.length, 0, "percentage measurement remains same finding");
     assertEqual(percentageComparison.findingChanges.resolved.length, 0, "percentage measurement is not resolved");
+    const countBaseline = syntheticPerformanceReport({
+      runId: "count-baseline",
+      platform: baseline.platform,
+      target: "runtime:stable",
+      records: [findingRecord([{
+        kind: "threshold",
+        metric: "toolCallCount",
+        actual: 5,
+        expected: "<= 3",
+        message: "tool call count 5 exceeded limit 3"
+      }])]
+    });
+    const countCurrent = syntheticPerformanceReport({
+      runId: "count-current",
+      platform: baseline.platform,
+      target: "runtime:stable",
+      records: [findingRecord([{
+        kind: "threshold",
+        metric: "toolCallCount",
+        actual: 6,
+        expected: "<= 3",
+        message: "tool call count 6 exceeded limit 3"
+      }])]
+    });
+    const countComparison = compareReports(countBaseline, countCurrent);
+    assertEqual(countComparison.findingChanges.new.length, 0, "count measurement remains same finding");
+    assertEqual(countComparison.findingChanges.resolved.length, 0, "count measurement is not resolved");
 
     const rollupInput = {
       scenarios: [{
@@ -2952,6 +2979,28 @@ function compareIdentityAndRollupCheck() {
     for (const scenarios of [mixedVerdictStates, [...mixedVerdictStates].reverse()]) {
       const rollup = rollupScenarios({ scenarios })[0];
       assertEqual(rollup.verdict, "FAIL", "compare rollup FAIL outranks BLOCKED");
+    }
+    const blockedAndRegressedStates = [{
+      scenario: "blocked-and-regressed",
+      status: "BLOCKED",
+      baselineStatus: "BLOCKED",
+      currentStatus: "BLOCKED",
+      currentSampleCount: 1,
+      currentStatuses: { BLOCKED: 1 },
+      regressions: []
+    }, {
+      scenario: "blocked-and-regressed",
+      status: "REGRESSED",
+      baselineStatus: "PASS",
+      currentStatus: "FAIL",
+      currentSampleCount: 1,
+      currentStatuses: { FAIL: 1 },
+      regressions: [{ kind: "status", message: "status regressed from PASS to FAIL" }]
+    }];
+    for (const scenarios of [blockedAndRegressedStates, [...blockedAndRegressedStates].reverse()]) {
+      const rollup = rollupScenarios({ scenarios })[0];
+      assertEqual(rollup.verdict, "REGRESSED", "compare rollup regression outranks blocked evidence");
+      assertEqual(rollup.currentStatus, "FAIL", "compare rollup retains regressed failure status");
     }
 
     const improved = {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -2837,6 +2837,29 @@ function compareIdentityAndRollupCheck() {
       true,
       "finding compare uses semantic message identity"
     );
+    const categoricalBaseline = syntheticPerformanceReport({
+      runId: "categorical-baseline",
+      platform: baseline.platform,
+      target: "runtime:stable",
+      records: [findingRecord([{
+        kind: "protocol",
+        metric: "providerResponse",
+        message: "provider returned HTTP 401"
+      }])]
+    });
+    const categoricalCurrent = syntheticPerformanceReport({
+      runId: "categorical-current",
+      platform: baseline.platform,
+      target: "runtime:stable",
+      records: [findingRecord([{
+        kind: "protocol",
+        metric: "providerResponse",
+        message: "provider returned HTTP 500"
+      }])]
+    });
+    const categoricalComparison = compareReports(categoricalBaseline, categoricalCurrent);
+    assertEqual(categoricalComparison.findingChanges.new.length, 1, "categorical numeric finding is new");
+    assertEqual(categoricalComparison.findingChanges.resolved.length, 1, "categorical numeric finding is resolved");
 
     const rollupInput = {
       scenarios: [{
@@ -2863,6 +2886,27 @@ function compareIdentityAndRollupCheck() {
       assertEqual(rollup.currentStatus, "FAIL", "rollup retains worst current status");
       assertEqual(rollup.failedSamples, 2, "rollup counts all non-passing samples");
       assertEqual(rollup.passedSamples, 0, "rollup counts passed samples explicitly");
+    }
+    const mixedExecutionStates = [{
+      scenario: "mixed-execution",
+      status: "OK",
+      baselineStatus: "PASS",
+      currentStatus: "PASS",
+      currentSampleCount: 1,
+      currentStatuses: { PASS: 1 },
+      regressions: []
+    }, {
+      scenario: "mixed-execution",
+      status: "OK",
+      baselineStatus: "PASS",
+      currentStatus: "DRY-RUN",
+      currentSampleCount: 1,
+      currentStatuses: { "DRY-RUN": 1 },
+      regressions: []
+    }];
+    for (const scenarios of [mixedExecutionStates, [...mixedExecutionStates].reverse()]) {
+      const rollup = rollupScenarios({ scenarios })[0];
+      assertEqual(rollup.currentStatus, "DRY-RUN", "rollup dry-run outranks pass deterministically");
     }
 
     const improved = {

--- a/src/statuses.mjs
+++ b/src/statuses.mjs
@@ -26,3 +26,25 @@ export function findingSeverityForStatus(status) {
   }
   return "fail";
 }
+
+export function recordStatusRank(status) {
+  const ranks = {
+    [RECORD_STATUS.PASS]: 0,
+    [RECORD_STATUS.DRY_RUN]: 0,
+    [RECORD_STATUS.SKIPPED]: 1,
+    [RECORD_STATUS.INCOMPLETE]: 2,
+    [RECORD_STATUS.BLOCKED]: 3,
+    [RECORD_STATUS.FAIL]: 4
+  };
+  return ranks[status] ?? 2;
+}
+
+export function worseRecordStatus(left, right) {
+  if (left == null) {
+    return right ?? null;
+  }
+  if (right == null) {
+    return left;
+  }
+  return recordStatusRank(right) > recordStatusRank(left) ? right : left;
+}

--- a/src/statuses.mjs
+++ b/src/statuses.mjs
@@ -30,13 +30,13 @@ export function findingSeverityForStatus(status) {
 export function recordStatusRank(status) {
   const ranks = {
     [RECORD_STATUS.PASS]: 0,
-    [RECORD_STATUS.DRY_RUN]: 0,
-    [RECORD_STATUS.SKIPPED]: 1,
-    [RECORD_STATUS.INCOMPLETE]: 2,
-    [RECORD_STATUS.BLOCKED]: 3,
-    [RECORD_STATUS.FAIL]: 4
+    [RECORD_STATUS.DRY_RUN]: 1,
+    [RECORD_STATUS.SKIPPED]: 2,
+    [RECORD_STATUS.INCOMPLETE]: 3,
+    [RECORD_STATUS.BLOCKED]: 4,
+    [RECORD_STATUS.FAIL]: 5
   };
-  return ranks[status] ?? 2;
+  return ranks[status] ?? 3;
 }
 
 export function worseRecordStatus(left, right) {

--- a/tests/snapshots/plan-default.snap
+++ b/tests/snapshots/plan-default.snap
@@ -97,6 +97,7 @@
 
 ─── next ───────────────────────────────────────────────────────────────────────
 
-  → kova run --target runtime:stable --scenario adversarial-input-openai-compatible
+  → kova run --target runtime:stable --scenario \
+    adversarial-input-openai-compatible
   → kova matrix plan --profile smoke --target runtime:stable
   → kova plan --json

--- a/tests/snapshots/plan-default.snap
+++ b/tests/snapshots/plan-default.snap
@@ -97,6 +97,6 @@
 
 ─── next ───────────────────────────────────────────────────────────────────────
 
-  → kova run --scenario adversarial-input-openai-compatible
+  → kova run --target runtime:stable --scenario adversarial-input-openai-compatible
   → kova matrix plan --profile smoke --target runtime:stable
   → kova plan --json

--- a/tests/snapshots/report-fail-compact.snap
+++ b/tests/snapshots/report-fail-compact.snap
@@ -1,7 +1,7 @@
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║  KOVA  ·  report                                                             ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
-   [FAIL]   1 scenario failed · 1/1 sample failed · single-sample
+   [FAIL]   1 scenario failed · 1 failed of 1 sample · single-sample
 
   run kova-<runId> · target runtime:stable · <ts>
 

--- a/tests/snapshots/report-fail-full.snap
+++ b/tests/snapshots/report-fail-full.snap
@@ -1,7 +1,7 @@
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║  KOVA  ·  report                                                             ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
-   [FAIL]   1 scenario failed · 1/1 sample failed · single-sample
+   [FAIL]   1 scenario failed · 1 failed of 1 sample · single-sample
 
   run kova-<runId> · target runtime:stable · <ts>
 


### PR DESCRIPTION
## What Problem This Solves

Kova report aggregation could lose or misclassify evidence across repeated samples:

- a blocked harness sample could mask a separate product regression
- count and unitless measurements could appear as resolved plus newly introduced findings when only the measured value changed
- repeated diagnostics, skipped samples, mixed outcomes, worst-case metrics, and confidence labels were not consistently preserved
- some rendered follow-up commands were incomplete or stale

## Why This Change Was Made

This makes report aggregation deterministic and evidence-preserving across sample order, status combinations, metric direction, and finding identity. It keeps product failures ahead of harness blockers while retaining the blocked sample counts, and it uses structured numeric measurements when stabilizing finding identity without collapsing categorical values such as HTTP status codes.

The branch was rebased onto exact `main` SHA `82f52fd2227f799889a4de7aad11467328797b13`. All 10 original reporting commits were audited and preserved. Two additional commits reconcile the current terminal wrapping snapshot and close the final autoreview findings.

## User Impact

- repeated reports retain every sample outcome and diagnostic gap
- product regressions remain visible even when another sample is blocked
- count, percentage, duration, byte, and unitless measurement changes remain the same finding
- categorical numeric changes remain distinct findings
- worst-case metric selection respects higher-better and lower-better thresholds
- gate summaries correctly distinguish failed, blocked, incomplete, skipped, and mixed evidence
- CLI guidance includes complete runnable commands and current hanging-wrap behavior

## Evidence

- Head: `8d48884f2a2614cc52420779cfc1066bcc32ceae`
- `npm run check:full`
  - Kova selfcheck: `269/269`
  - render snapshots: `21/21`
  - web payload contract: passed
  - release contract checks: passed
- packed/extracted install smoke:
  - installed archive version `0.1.0`
  - setup CI JSON path passed
  - extracted Kova selfcheck: `269/269`
  - archive SHA-256: `b9028611da616ee525d902123006662579448bf59307fae62a1fc883d9beb2f0`
- fresh whole-branch autoreview:
  - engine/model: Codex `gpt-5.6-sol`
  - thinking: high
  - result: clean, no accepted or actionable findings
