### PR TITLE
fix(e2e): restore packaged channel probe dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Remove the stale channel-recovery reference that caused every packaged channel workflow probe to fail before evaluating OpenClaw behavior.
 - Run installed self-checks from the packaged Kova root and smoke them outside the source checkout so releases cannot borrow missing files from a developer tree.
 - Collect final post-ready health samples when readiness has no wait budget so successful executed scenarios retain complete pre-cleanup evidence.
 - Made terminal reports width-safe for Unicode, narrow layouts, wrapped shell hints, duration rollover, and strict numeric samples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Use OpenClaw's canonical inbound dispatch API in the packaged channel probe after the deprecated channel turn aliases were removed.
 - Remove the stale channel-recovery reference that caused every packaged channel workflow probe to fail before evaluating OpenClaw behavior.
 - Run installed self-checks from the packaged Kova root and smoke them outside the source checkout so releases cannot borrow missing files from a developer tree.
 - Collect final post-ready health samples when readiness has no wait budget so successful executed scenarios retain complete pre-cleanup evidence.

--- a/support/plugins/kova-channel-probe/index.js
+++ b/support/plugins/kova-channel-probe/index.js
@@ -509,7 +509,7 @@ async function runOpenClawModelTurn({
     CommandAuthorized: true
   });
 
-  return await runtime.turn.runAssembled({
+  return await runtime.inbound.dispatchReply({
     cfg,
     channel: CHANNEL_ID,
     accountId: ACCOUNT_ID,

--- a/support/run-channel-probe-turn.mjs
+++ b/support/run-channel-probe-turn.mjs
@@ -370,7 +370,7 @@ function evaluateCase(testCase, observation, injectResult) {
     invariant(`${testCase.id}:probe-injected`, injectResult?.ok === true && Boolean(observation), `${testCase.id} injected one inbound user event through the channel probe`),
     invariant(`${testCase.id}:no-probe-error`, !observation?.error, `${testCase.id} completed without probe or OpenClaw transport error`),
     invariant(`${testCase.id}:durable-handled`, unhandledDeliveries.length === 0, `${testCase.id} had every final durable delivery handled by OpenClaw; unhandled ${unhandledDeliveries.length}`),
-    invariant(`${testCase.id}:turn-dispatched`, observation?.dispatched === true || (recoveryExpectation.required && modelDispatchStarts.length > 0), `${testCase.id} dispatched through the OpenClaw runtime`),
+    invariant(`${testCase.id}:turn-dispatched`, observation?.dispatched === true, `${testCase.id} dispatched through the OpenClaw runtime`),
     finalDeliveryInvariant(testCase.id, visibleDeliveryPolicy, finalRecords.length),
     invariant(`${testCase.id}:expected-kind`, expectedKindMatches(expects.kind, finalRecords), `${testCase.id} produced the expected visible delivery kind`),
     invariant(`${testCase.id}:expected-text`, !expectedText || finalTexts.some((text) => textEquals(text, expectedText)), `${testCase.id} produced the expected visible text`),


### PR DESCRIPTION
## What Problem This Solves

Packaged channel workflow probes could not evaluate OpenClaw behavior. The runner referenced a removed recovery contract, and the probe plugin still called OpenClaw's removed `channel.turn.runAssembled` alias.

## Why This Change Was Made

Commit `0a9a95f` removed the fake recovery workflow and its expectation object but left one dispatch-invariant reference behind. OpenClaw later removed deprecated channel turn aliases in `v2026.5.27`; the same dispatch function now lives on the canonical `channel.inbound.dispatchReply` surface.

## User Impact

Kova can execute packaged channel workflow scenarios instead of failing in its own harness before or during dispatch.

## Evidence

- Reproduced the first failure in the packaged `release:beta` smoke matrix as `ReferenceError: recoveryExpectation is not defined`.
- After fixing that reference, reproduced the removed OpenClaw alias as `Cannot read properties of undefined (reading 'runAssembled')`.
- `CI=1 NO_COLOR=1 npm run check` (269/269 self-checks passed).
- Sol/high autoreview of each code change: clean, no accepted or actionable findings.
- Packaged exact-runtime rerun is in progress and will be posted before merge.
