### PR TITLE
fix(runs): preserve setup failures before env creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Preserve the original scenario failure when `--retain-on-failure` runs before an OCM environment exists.
 - Wait for asynchronous channel-probe and provider evidence to go quiet before resetting the next case's mock script.
 - Give every channel-probe invocation a unique synthetic conversation target so stale records and late async completions cannot satisfy or consume a later rerun.
 - Isolate channel-probe observations by inbound event and target, and preserve every media item when fallback delivery receives a batch.

--- a/src/run/teardown.mjs
+++ b/src/run/teardown.mjs
@@ -30,13 +30,15 @@ export async function teardownScenario(record, scenario, context, envName, artif
   ], options);
   errors.push(...beforeRetention.errors);
 
-  const retainEnv = shouldRetainEnv(context, record);
+  let retainEnv = shouldRetainEnv(context, record);
   if (retainEnv) {
     // The OCM protection is the destruction fence. Do not emit a retained
     // record when that fence could not be established.
-    await protectRetainedEnv(record, context, envName);
-    record.cleanup = "retained";
-    record.retainedReason = context.keepEnv ? "keep-env" : "failure";
+    retainEnv = await protectRetainedEnv(record, context, envName);
+    if (retainEnv) {
+      record.cleanup = "retained";
+      record.retainedReason = context.keepEnv ? "keep-env" : "failure";
+    }
   }
 
   record.networkFrontage = context.networkFrontageAllocation ?? record.networkFrontage;
@@ -147,10 +149,24 @@ async function protectRetainedEnv(record, context, envName) {
     timeoutMs: context.timeoutMs
   });
   record.retentionProtectionResult = result;
-  if (result.status !== 0) {
+  const outcome = classifyRetentionProtection(result, envName);
+  if (outcome === "already-absent") {
+    return false;
+  }
+  if (outcome === "failed") {
     const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`;
     throw new Error(`failed to protect retained env ${envName}: ${detail}`);
   }
+  return true;
+}
+
+export function classifyRetentionProtection(result, envName) {
+  if (result.status === 0) {
+    return "protected";
+  }
+  return isMissingOcmResource(result, "environment", envName)
+    ? "already-absent"
+    : "failed";
 }
 
 function appendCleanupPhase(record, phase) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -66,7 +66,7 @@ import { runAuthCommand, runScenarioCommand } from "./run/command-executor.mjs";
 import { runEntries } from "./run/engine.mjs";
 import { executeStateLifecycleSteps } from "./run/state-lifecycle.mjs";
 import { executeTargetSetup } from "./run/target-setup.mjs";
-import { runGuardedTeardownStages } from "./run/teardown.mjs";
+import { classifyRetentionProtection, runGuardedTeardownStages } from "./run/teardown.mjs";
 import { runWithTargetRuntimeCleanup } from "./run/target-cleanup.mjs";
 import { loadProcessRoles } from "./registries/process-roles.mjs";
 import { validateProfileShape } from "./registries/profiles.mjs";
@@ -2111,7 +2111,7 @@ function localBuildRuntimeNameCheck() {
 
 function ocmMissingResourceCheck() {
   try {
-    const result = (stderr) => ({ stdout: "", stderr });
+    const result = (stderr, status = 1) => ({ status, stdout: "", stderr });
     assertEqual(
       isMissingOcmResource(result('ocm: runtime "kova-local-test" does not exist'), "runtime", "kova-local-test"),
       true,
@@ -2131,6 +2131,24 @@ function ocmMissingResourceCheck() {
       isMissingOcmResource(result('ocm: runtime "different" does not exist'), "runtime", "kova-local-test"),
       false,
       "different missing runtime"
+    );
+    assertEqual(
+      classifyRetentionProtection(
+        result('ocm: environment "kova-test" does not exist'),
+        "kova-test"
+      ),
+      "already-absent",
+      "missing retained env preserves the original scenario failure"
+    );
+    assertEqual(
+      classifyRetentionProtection(result("", 0), "kova-test"),
+      "protected",
+      "successful retained env protection"
+    );
+    assertEqual(
+      classifyRetentionProtection(result("permission denied"), "kova-test"),
+      "failed",
+      "unexpected retained env protection failure"
     );
     return {
       id: "ocm-missing-resource-classification",
@@ -15025,9 +15043,9 @@ async function networkFrontagePartialStartupCleanupInvariantCheck() {
       await new Promise((resolve) => blocker.close(resolve));
     }
     const teardownSource = await readFile(selfCheckPath("src", "run", "teardown.mjs"), "utf8");
-    const retentionPattern = /id: "network-frontage-cleanup"[\s\S]+const retainEnv = shouldRetainEnv\(context, record\)/;
+    const retentionPattern = /id: "network-frontage-cleanup"[\s\S]+let retainEnv = shouldRetainEnv\(context, record\)/;
     assertEqual(retentionPattern.test(teardownSource), true, "retain-on-failure is computed after network frontage cleanup can update status");
-    const protectionPattern = /const retainEnv = shouldRetainEnv\(context, record\);[\s\S]+await protectRetainedEnv\(record, context, envName\);[\s\S]+record\.cleanup = "retained"/;
+    const protectionPattern = /let retainEnv = shouldRetainEnv\(context, record\);[\s\S]+retainEnv = await protectRetainedEnv\(record, context, envName\);[\s\S]+if \(retainEnv\)[\s\S]+record\.cleanup = "retained"/;
     assertEqual(protectionPattern.test(teardownSource), true, "retained env is protected before retention is published");
     assertEqual(
       ocmEnvProtect("kova-retained", true),


### PR DESCRIPTION
## What Problem This Solves

A scenario that fails before OCM creates its environment can be run with `--retain-on-failure`. Teardown then tried to protect the nonexistent environment and replaced the useful setup failure with a secondary `ocm env protect` error.

## Why This Change Was Made

Retention protection now classifies an exact missing-environment result as already absent, continues normal cleanup, and only publishes `cleanup: retained` after OCM protection succeeds. Unexpected protection failures remain fatal so Kova never claims an unprotected environment was retained.

## User Impact

Kova reports the original scenario/setup failure instead of masking it, while preserving the existing safety fence for environments that do exist.

## Evidence

- reproduced with packaged Kova + current-main OCM during the OpenClaw media handoff E2E
- retention classification probe covers protected, already-absent, and failed outcomes
- `node bin/kova.mjs self-check --json`: 269/269 pass
- `git diff --check`
- fresh `gpt-5.6-sol` high autoreview: no accepted/actionable findings, confidence 0.93
