### PR TITLE
fix(auth): migrate retired fallback policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Migrate credential stores written by older Kova builds by removing the retired provider fallback policy instead of rejecting every run.
 - Preserve the original scenario failure when `--retain-on-failure` runs before an OCM environment exists.
 - Wait for asynchronous channel-probe and provider evidence to go quiet before resetting the next case's mock script.
 - Give every channel-probe invocation a unique synthetic conversation target so stale records and late async completions cannot satisfy or consume a later rerun.

--- a/src/auth.mjs
+++ b/src/auth.mjs
@@ -54,7 +54,7 @@ export async function configureCredentialProvider(options = {}) {
       throw new Error(`unsupported auth method '${method}'; expected one of ${credentialMethods.join(", ")}`);
     }
 
-    const metadata = await readProvidersMetadata();
+    const metadata = await readProvidersMetadataUnlocked();
     const liveEnv = await loadLiveEnv();
     const previousMetadata = structuredClone(metadata);
     const previousLiveEnv = { ...liveEnv };
@@ -344,7 +344,7 @@ export async function loadCredentialStore() {
 }
 
 async function loadCredentialStoreUnlocked() {
-  const providers = await readProvidersMetadata();
+  const providers = await readProvidersMetadataUnlocked();
   const liveEnv = await loadLiveEnv();
   return {
     schemaVersion: "kova.credentials.store.v1",
@@ -368,11 +368,16 @@ function defaultProvidersMetadata() {
   };
 }
 
-async function readProvidersMetadata() {
+async function readProvidersMetadataUnlocked() {
   try {
     const text = await readFile(providersPath, "utf8");
     const metadata = JSON.parse(text);
+    const migrated = removeLegacyFallbackPolicies(metadata);
     validateProvidersMetadata(metadata);
+    if (migrated) {
+      // Both callers hold the credential-store lock across this read and rewrite.
+      await writeProvidersMetadata(metadata);
+    }
     return metadata;
   } catch (error) {
     if (error.code === "ENOENT") {
@@ -380,6 +385,21 @@ async function readProvidersMetadata() {
     }
     throw error;
   }
+}
+
+function removeLegacyFallbackPolicies(metadata) {
+  if (!metadata?.providers || typeof metadata.providers !== "object" || Array.isArray(metadata.providers)) {
+    return false;
+  }
+  let migrated = false;
+  for (const provider of Object.values(metadata.providers)) {
+    if (provider && typeof provider === "object" && !Array.isArray(provider) &&
+        Object.hasOwn(provider, "fallbackPolicy")) {
+      delete provider.fallbackPolicy;
+      migrated = true;
+    }
+  }
+  return migrated;
 }
 
 function validateProvidersMetadata(metadata) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -586,6 +586,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       "unknown command: not-a-command"
     ));
     checks.push(await credentialStoreSelfCheck(tmp));
+    checks.push(await credentialStoreLegacyFallbackMigrationCheck(tmp));
     checks.push(await credentialStoreConcurrentWritersCheck(tmp));
     checks.push(await credentialStoreInterruptedTransactionCheck(tmp));
     checks.push(await setupDirectoryWriteProbeCheck(tmp));
@@ -22433,6 +22434,69 @@ async function credentialStoreSelfCheck(tmp) {
   } catch (error) {
     return {
       id: "credential-store",
+      status: "FAIL",
+      command,
+      durationMs: result.durationMs,
+      message: error.message
+    };
+  }
+}
+
+async function credentialStoreLegacyFallbackMigrationCheck(tmp) {
+  const home = join(tmp, "legacy-fallback-credentials-home");
+  const credentials = join(home, "credentials");
+  const providersPath = join(credentials, "providers.json");
+  const scriptPath = join(home, "load-store.mjs");
+  const legacyProviders = {
+    schemaVersion: "kova.credentials.providers.v1",
+    defaultProvider: "openai",
+    providers: {
+      openai: {
+        id: "openai",
+        method: "mock",
+        envVars: ["OPENAI_API_KEY"],
+        fallbackPolicy: "mock",
+        configuredAt: null
+      }
+    }
+  };
+  await mkdir(credentials, { recursive: true });
+  await writeFile(providersPath, `${JSON.stringify(legacyProviders, null, 2)}\n`, "utf8");
+  await writeFile(join(credentials, "live.env"), "", { encoding: "utf8", mode: 0o600 });
+  await writeFile(
+    scriptPath,
+    `import { loadCredentialStore } from ${JSON.stringify(new URL("./auth.mjs", import.meta.url).href)};\n` +
+      "console.log(JSON.stringify(await loadCredentialStore()));\n",
+    "utf8"
+  );
+
+  const command = `KOVA_HOME=${quoteShell(home)} node ${quoteShell(scriptPath)}`;
+  const result = await runCommand(command, { timeoutMs: 30000, maxOutputChars: 1000000 });
+  try {
+    if (result.status !== 0) {
+      throw new Error(result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`);
+    }
+    const loaded = JSON.parse(result.stdout);
+    const persisted = JSON.parse(await readFile(providersPath, "utf8"));
+    assertEqual(
+      Object.hasOwn(loaded.providers.providers.openai, "fallbackPolicy"),
+      false,
+      "legacy fallback policy removed from loaded credentials"
+    );
+    assertEqual(
+      Object.hasOwn(persisted.providers.openai, "fallbackPolicy"),
+      false,
+      "legacy fallback policy removed from persisted credentials"
+    );
+    return {
+      id: "credential-store-legacy-fallback-migration",
+      status: "PASS",
+      command,
+      durationMs: result.durationMs
+    };
+  } catch (error) {
+    return {
+      id: "credential-store-legacy-fallback-migration",
       status: "FAIL",
       command,
       durationMs: result.durationMs,


### PR DESCRIPTION
## What Problem This Solves

Kova builds before the provider fallback-policy removal persisted `fallbackPolicy` in `credentials/providers.json`. Current Kova rejects that same store before any plan or run can start, so an upgrade can make every command fail.

## Why This Change Was Made

The credential store already serializes readers and writers with its cross-process lock. This change performs one narrow migration while that lock is held: remove only the retired field, validate the canonical shape, and atomically persist it. Other malformed metadata still fails normally.

## User Impact

Existing Kova homes created by older builds load normally after upgrade. The migration is automatic and idempotent.

## Evidence

- `node --check src/auth.mjs`
- `node --check src/selfcheck.mjs`
- isolated legacy-store load and persisted-file probe
- full `kova self-check`: pass, including `credential-store-legacy-fallback-migration`
- `gpt-5.6-sol` / high autoreview: clean, confidence 0.93
