### PR TITLE
fix(perf): calibrate channel provider window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Calibrate the channel workflow provider window for its intentionally batched multi-request and asynchronous completion phases.
 - Validate asynchronous threaded completion handoffs by their preserved thread route without requiring a stale reply to the original inbound message.
 - Accept complete no-service final evidence without fabricated health samples, and recognize explicit local runtime bindings without a release track.
 - Migrate credential stores written by older Kova builds by removing the retired provider fallback policy instead of rejecting every run.

--- a/scenarios/channel-model-turn-baseline.json
+++ b/scenarios/channel-model-turn-baseline.json
@@ -23,7 +23,7 @@
     "gatewayReadyMs": 45000,
     "agentTurnMs": 45000,
     "preProviderMs": 10000,
-    "providerFinalMs": 3000,
+    "providerFinalMs": 6000,
     "peakRssMb": 1024,
     "providerTimeoutMentions": 8,
     "roleThresholds": {

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -11156,7 +11156,7 @@
         "gatewayReadyMs": 45000,
         "agentTurnMs": 45000,
         "preProviderMs": 10000,
-        "providerFinalMs": 3000,
+        "providerFinalMs": 6000,
         "peakRssMb": 1024,
         "providerTimeoutMentions": 8,
         "roleThresholds": {


### PR DESCRIPTION
## What Problem This Solves

The exact-main channel workflow passed every behavioral capability but still failed because Kova applied a 3-second single-turn provider budget to an intentionally batched command spanning eight provider requests and an asynchronous completion handoff.

## Why This Change Was Made

The channel baseline keeps batching cases for speed. Its provider window is now calibrated to 6 seconds, preserving a bounded regression gate while matching the metric's actual first-request-to-last-response meaning for this workflow.

## User Impact

Release smoke no longer reports a false provider slowdown after successful asynchronous completion delivery. The workflow remains gated at 6 seconds, while total turn, pre-provider, memory, dependency, plugin, and capability checks remain unchanged.

## Evidence

- Exact-main `channel-model-turn-baseline`: `PASS`, all capability atoms passed
- Observed completion handoff provider window: 4.587s across 8 requests
- `npm run check:full`
- 270/270 self-checks passed
- 21/21 renderer snapshots passed
- web payload and release contract checks passed
- fresh `gpt-5.6-sol` high autoreview: clean, confidence 0.98
