### PR TITLE
fix(perf): calibrate release CLI RSS budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Give release-shaped plugin and agent CLI probes measured RSS headroom while keeping their scenario-specific regression caps.
 - Run the full release gate once per version bump and automatically select the local SSH key authorized by the repository release policy.
 - Move CI and release workflows off deprecated Node 20 action runtimes and pin their replacements.
 

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19424,11 +19424,11 @@ async function bundledPluginStartupSurfaceContractCheck() {
     );
     assertEqual(surface.roleThresholds?.gateway?.peakRssMb, 950, "bundled plugin surface owns gateway RSS cap");
     assertEqual(surface.roleThresholds?.gateway?.maxCpuPercent, 250, "bundled plugin surface owns gateway CPU cap");
-    assertEqual(surface.roleThresholds?.["plugin-cli"]?.peakRssMb, 800, "bundled plugin surface owns plugin CLI RSS cap");
+    assertEqual(surface.roleThresholds?.["plugin-cli"]?.peakRssMb, 900, "bundled plugin surface owns plugin CLI RSS cap");
     assertEqual(surface.roleThresholds?.["plugin-cli"]?.maxCpuPercent, 250, "bundled plugin surface owns plugin CLI CPU cap");
     assertEqual(policy.roleThresholds?.gateway?.peakRssMb, 950, "bundled plugin resolved gateway RSS cap");
     assertEqual(policy.roleThresholds?.gateway?.maxCpuPercent, 250, "bundled plugin resolved gateway CPU cap");
-    assertEqual(policy.roleThresholds?.["plugin-cli"]?.peakRssMb, 800, "bundled plugin resolved plugin CLI RSS cap");
+    assertEqual(policy.roleThresholds?.["plugin-cli"]?.peakRssMb, 900, "bundled plugin resolved plugin CLI RSS cap");
     assertEqual(policy.roleThresholds?.["plugin-cli"]?.maxCpuPercent, 250, "bundled plugin resolved plugin CLI CPU cap");
 
     return {
@@ -19508,14 +19508,14 @@ async function releaseResourceCalibrationCheck() {
         scenario: freshScenario,
         surface: freshSurface,
         primaryRssMb: 1050,
-        roles: { gateway: 1050, "status-cli": 850, "plugin-cli": 800 }
+        roles: { gateway: 1050, "status-cli": 850, "plugin-cli": 900 }
       },
       {
         id: "gateway-performance",
         scenario: gatewayScenario,
         surface: gatewaySurface,
         primaryRssMb: 1050,
-        roles: { gateway: 1050, "gateway-tree": 1200, "status-cli": 850, "plugin-cli": 800 }
+        roles: { gateway: 1050, "gateway-tree": 1200, "status-cli": 850, "plugin-cli": 900 }
       },
       {
         id: "bundled-runtime-deps",
@@ -19529,7 +19529,7 @@ async function releaseResourceCalibrationCheck() {
         scenario: null,
         surface: bundledPluginSurface,
         primaryRssMb: null,
-        roles: { gateway: 950, "plugin-cli": 800 }
+        roles: { gateway: 950, "plugin-cli": 900 }
       }
     ];
 
@@ -19655,6 +19655,12 @@ async function officialPluginInstallSurfaceContractCheck() {
 async function agentCliLocalTurnSurfaceContractCheck() {
   try {
     const surface = await readSelfCheckJson("surfaces", "agent-cli-local-turn.json");
+    const releaseProfile = await readSelfCheckJson("profiles", "release.json");
+    const policy = resolveThresholdPolicy({
+      profile: releaseProfile,
+      surface,
+      scenario: null
+    });
     const expectedSpans = surface.diagnostics?.expectedSpans ?? [];
     const staleSpans = [
       "agent.turn",
@@ -19670,6 +19676,11 @@ async function agentCliLocalTurnSurfaceContractCheck() {
       assertEqual(expectedSpans.includes(span), false, `agent CLI surface must not require stale ${span} span`);
     }
     assertEqual(expectedSpans.includes("plugins.metadata.scan"), true, "agent CLI surface requires plugin metadata scan timeline span");
+    assertEqual(surface.thresholds?.peakRssMb, 1000, "agent CLI surface owns primary RSS cap");
+    assertEqual(surface.roleThresholds?.["agent-cli"]?.peakRssMb, 1000, "agent CLI surface owns agent CLI RSS cap");
+    assertEqual(surface.roleThresholds?.["agent-process"]?.peakRssMb, 1000, "agent CLI surface owns agent process RSS cap");
+    assertEqual(policy.roleThresholds?.["agent-cli"]?.peakRssMb, 1000, "agent CLI resolved agent CLI RSS cap");
+    assertEqual(policy.roleThresholds?.["agent-process"]?.peakRssMb, 1000, "agent CLI resolved agent process RSS cap");
     return {
       id: "agent-cli-local-turn-surface-contract",
       status: "PASS",

--- a/surfaces/agent-cli-local-turn.json
+++ b/surfaces/agent-cli-local-turn.json
@@ -19,7 +19,7 @@
     "preProviderMs": 10000,
     "providerFinalMs": 3000,
     "agentCleanupMs": 5000,
-    "peakRssMb": 900,
+    "peakRssMb": 1000,
     "postReadyHealthP95Ms": 1000
   },
   "roleThresholds": {
@@ -28,11 +28,11 @@
       "maxCpuPercent": 250
     },
     "agent-cli": {
-      "peakRssMb": 900,
+      "peakRssMb": 1000,
       "maxCpuPercent": 300
     },
     "agent-process": {
-      "peakRssMb": 900,
+      "peakRssMb": 1000,
       "maxCpuPercent": 300
     },
     "mock-provider": {

--- a/surfaces/bundled-plugin-startup.json
+++ b/surfaces/bundled-plugin-startup.json
@@ -21,7 +21,7 @@
       "maxCpuPercent": 250
     },
     "plugin-cli": {
-      "peakRssMb": 800,
+      "peakRssMb": 900,
       "maxCpuPercent": 250
     },
     "runtime-staging": {

--- a/surfaces/fresh-install.json
+++ b/surfaces/fresh-install.json
@@ -26,7 +26,7 @@
       "maxCpuPercent": 200
     },
     "plugin-cli": {
-      "peakRssMb": 800,
+      "peakRssMb": 900,
       "maxCpuPercent": 250
     },
     "model-cli": {

--- a/surfaces/gateway-performance.json
+++ b/surfaces/gateway-performance.json
@@ -31,7 +31,7 @@
       "maxCpuPercent": 200
     },
     "plugin-cli": {
-      "peakRssMb": 800,
+      "peakRssMb": 900,
       "maxCpuPercent": 250
     }
   },

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -101,7 +101,7 @@
         "preProviderMs": 10000,
         "providerFinalMs": 3000,
         "agentCleanupMs": 5000,
-        "peakRssMb": 900,
+        "peakRssMb": 1000,
         "postReadyHealthP95Ms": 1000
       },
       "roleThresholds": {
@@ -110,11 +110,11 @@
           "maxCpuPercent": 250
         },
         "agent-cli": {
-          "peakRssMb": 900,
+          "peakRssMb": 1000,
           "maxCpuPercent": 300
         },
         "agent-process": {
-          "peakRssMb": 900,
+          "peakRssMb": 1000,
           "maxCpuPercent": 300
         },
         "mock-provider": {
@@ -340,7 +340,7 @@
           "maxCpuPercent": 250
         },
         "plugin-cli": {
-          "peakRssMb": 800,
+          "peakRssMb": 900,
           "maxCpuPercent": 250
         },
         "runtime-staging": {
@@ -1077,7 +1077,7 @@
           "maxCpuPercent": 200
         },
         "plugin-cli": {
-          "peakRssMb": 800,
+          "peakRssMb": 900,
           "maxCpuPercent": 250
         },
         "model-cli": {
@@ -1159,7 +1159,7 @@
           "maxCpuPercent": 200
         },
         "plugin-cli": {
-          "peakRssMb": 800,
+          "peakRssMb": 900,
           "maxCpuPercent": 250
         }
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw release performance validation could reject healthy release-shaped CLI runs because Kova's scenario-specific RSS caps had no operating headroom against observed shipped and candidate builds.

## Why This Change Was Made

Calibrate only the affected release surfaces: plugin CLI probes move from 800 MB to 900 MB, while the agent-local CLI/process surface moves from 900 MB to 1000 MB. The global release profile and unrelated surfaces remain unchanged, and self-check contracts plus the generated plan snapshot lock the new bounds.

## User Impact

Release operators retain bounded RSS regression gates without false failures from normal CLI process variance.

## Evidence

- `npm run check:full`
- Kova self-check: 270/270 passed
- OpenClaw `v2026.7.1`: plugin CLI reached 801.5 MB against the old 800 MB cap
- OpenClaw `2026.7.2-beta.1` candidate diagnostics: plugin CLI reached 861.8 MB and agent CLI reached 957.1 MB
- Autoreview: clean, no accepted/actionable findings
