### PR TITLE
fix(perf): avoid fresh-install RSS sampling flakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Calibrate the fresh-install status CLI RSS budget against repeated release-run evidence.
 - Calibrate the gateway pressure scenario's status CLI RSS budget against repeated release-run evidence.
 - Calibrate the gateway pressure scenario's plugin CLI RSS budget against repeated release-run evidence.
 - Keep the agent cold/warm scenario's RSS gate aligned with the calibrated agent CLI surface budget.

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19508,7 +19508,7 @@ async function releaseResourceCalibrationCheck() {
         scenario: freshScenario,
         surface: freshSurface,
         primaryRssMb: 1050,
-        roles: { gateway: 1050, "status-cli": 850, "plugin-cli": 900 }
+        roles: { gateway: 1050, "status-cli": 900, "plugin-cli": 900 }
       },
       {
         id: "gateway-performance",

--- a/surfaces/fresh-install.json
+++ b/surfaces/fresh-install.json
@@ -22,7 +22,7 @@
       "maxCpuPercent": 250
     },
     "status-cli": {
-      "peakRssMb": 850,
+      "peakRssMb": 900,
       "maxCpuPercent": 200
     },
     "plugin-cli": {

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -1073,7 +1073,7 @@
           "maxCpuPercent": 250
         },
         "status-cli": {
-          "peakRssMb": 850,
+          "peakRssMb": 900,
           "maxCpuPercent": 200
         },
         "plugin-cli": {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the OpenClaw release matrix could fail an otherwise healthy fresh-install run when one sampling interval briefly observed three overlapping status CLI processes totaling just over the 850 MB budget.

Observed proof: https://github.com/openclaw/openclaw/actions/runs/29378161871

## Why This Change Was Made

Calibrate the fresh-install status CLI RSS budget from 850 MB to 900 MB. This matches the already-calibrated gateway-pressure status CLI budget while retaining the 900 MB scenario-specific regression cap and all gateway/plugin/model limits.

The failed sample was 852.5 MB; the other five fresh-install samples in the adjacent exact-head runs ranged from 670.4 MB to 777.9 MB, and the exact retry passed.

## User Impact

Release validation remains sensitive to meaningful status CLI memory regressions without failing on a single small process-overlap sample.

## Evidence

- Release resource calibration self-check: green
- Snapshot suite: 21/21 green
- Web payload contract: green
- Release contract suite: green
- Full local self-check: 266/270; all changed-surface checks green, four OCM-backed setup/cleanup checks blocked because the local `ocm` binary is absent
- Fresh autoreview: clean, correctness 0.99, no accepted/actionable findings
- OpenClaw exact retry after the transient sample: https://github.com/openclaw/openclaw/actions/runs/29378658559
