### PR TITLE
fix(openclaw): update release fixture config

### DIFF
--- a/support/configure-openclaw-mock-auth.mjs
+++ b/support/configure-openclaw-mock-auth.mjs
@@ -39,6 +39,8 @@ const modelRef = "openai/gpt-5.5";
 const imageModelRef = "openai/gpt-image-1";
 const videoModelRef = "openai/sora-2";
 const gatewayToken = "kova-mock-gateway-token";
+const imageModelConfig = asObject(config.agents?.defaults?.mediaModels?.image);
+const videoModelConfig = asObject(config.agents?.defaults?.mediaModels?.video);
 const cost = {
   input: 0,
   output: 0,
@@ -121,13 +123,16 @@ config.agents = {
         }
       }
     },
-    imageGenerationModel: {
-      ...(config.agents?.defaults?.imageGenerationModel || {}),
-      primary: imageModelRef
-    },
-    videoGenerationModel: {
-      ...(config.agents?.defaults?.videoGenerationModel || {}),
-      primary: videoModelRef
+    mediaModels: {
+      ...(config.agents?.defaults?.mediaModels || {}),
+      image: {
+        ...imageModelConfig,
+        primary: imageModelRef
+      },
+      video: {
+        ...videoModelConfig,
+        primary: videoModelRef
+      }
     }
   }
 };
@@ -231,6 +236,10 @@ function parseArgs(args) {
     skipHealthCheck: parsed.skiphealthcheck === true,
     gatewayHttpEndpoints: parsed.gatewayHttpEndpoints
   };
+}
+
+function asObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
 }
 
 function requiredEnv(name) {

--- a/support/configure-openclaw-mock-auth.mjs
+++ b/support/configure-openclaw-mock-auth.mjs
@@ -39,6 +39,19 @@ const modelRef = "openai/gpt-5.5";
 const imageModelRef = "openai/gpt-image-1";
 const videoModelRef = "openai/sora-2";
 const gatewayToken = "kova-mock-gateway-token";
+const existingAgents = asObject(config.agents);
+const existingAgentEntries = asObject(config.agents?.entries);
+const legacyAgentEntries = Object.fromEntries(
+  (Array.isArray(config.agents?.list) ? config.agents.list : []).flatMap((entry) => {
+    const normalized = asObject(entry);
+    const id = typeof normalized.id === "string" ? normalized.id.trim() : "";
+    if (!id) return [];
+    const agentConfig = { ...normalized };
+    delete agentConfig.id;
+    return [[id, agentConfig]];
+  })
+);
+const agentEntries = { ...legacyAgentEntries, ...existingAgentEntries };
 const imageModelConfig = asObject(config.agents?.defaults?.mediaModels?.image);
 const videoModelConfig = asObject(config.agents?.defaults?.mediaModels?.video);
 const cost = {
@@ -105,8 +118,11 @@ config.models = {
   }
 };
 
+const canonicalAgents = { ...existingAgents };
+delete canonicalAgents.list;
 config.agents = {
-  ...(config.agents || {}),
+  ...canonicalAgents,
+  entries: Object.keys(agentEntries).length > 0 ? agentEntries : { main: { default: true } },
   defaults: {
     ...(config.agents?.defaults || {}),
     model: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Kova's OpenClaw release profile could not start current OpenClaw builds after the persisted agent and media-model config shapes changed. All selected performance scenarios failed during gateway setup instead of measuring product behavior.

Related failure: https://github.com/openclaw/openclaw/actions/runs/29894590707

## Why This Change Was Made

The mock-auth fixture now converts legacy `agents.list` values into canonical keyed `agents.entries`, removes the retired list field, and writes image/video defaults through `agents.defaults.mediaModels`. Existing canonical entry and child-model configuration is preserved.

## User Impact

Kova release runs can exercise current OpenClaw builds again instead of reporting configuration-validation failures as performance regressions.

## Evidence

- Executed the fixture against a temporary legacy config containing `agents.list` and string media-model shorthands; the resulting config contained keyed entries, canonical media models, and no retired fields.
- Autoreview: clean after media shorthand handling and agent-list normalization.

AI-assisted: yes. The generated config was checked against current OpenClaw strict schemas.
