### PR TITLE
fix(perf): calibrate bundled plugin restart RSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Calibrate the bundled-plugin restart overlap RSS budget against repeated OpenClaw main release runs.
 - Calibrate the fresh-install status CLI RSS budget against repeated release-run evidence.
 - Calibrate the gateway pressure scenario's status CLI RSS budget against repeated release-run evidence.
 - Calibrate the gateway pressure scenario's plugin CLI RSS budget against repeated release-run evidence.

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -19422,11 +19422,11 @@ async function bundledPluginStartupSurfaceContractCheck() {
       30000,
       "bundled plugin startup waits for gateway readiness"
     );
-    assertEqual(surface.roleThresholds?.gateway?.peakRssMb, 950, "bundled plugin surface owns gateway RSS cap");
+    assertEqual(surface.roleThresholds?.gateway?.peakRssMb, 1000, "bundled plugin surface owns gateway RSS cap");
     assertEqual(surface.roleThresholds?.gateway?.maxCpuPercent, 250, "bundled plugin surface owns gateway CPU cap");
     assertEqual(surface.roleThresholds?.["plugin-cli"]?.peakRssMb, 900, "bundled plugin surface owns plugin CLI RSS cap");
     assertEqual(surface.roleThresholds?.["plugin-cli"]?.maxCpuPercent, 250, "bundled plugin surface owns plugin CLI CPU cap");
-    assertEqual(policy.roleThresholds?.gateway?.peakRssMb, 950, "bundled plugin resolved gateway RSS cap");
+    assertEqual(policy.roleThresholds?.gateway?.peakRssMb, 1000, "bundled plugin resolved gateway RSS cap");
     assertEqual(policy.roleThresholds?.gateway?.maxCpuPercent, 250, "bundled plugin resolved gateway CPU cap");
     assertEqual(policy.roleThresholds?.["plugin-cli"]?.peakRssMb, 900, "bundled plugin resolved plugin CLI RSS cap");
     assertEqual(policy.roleThresholds?.["plugin-cli"]?.maxCpuPercent, 250, "bundled plugin resolved plugin CLI CPU cap");
@@ -19529,7 +19529,7 @@ async function releaseResourceCalibrationCheck() {
         scenario: null,
         surface: bundledPluginSurface,
         primaryRssMb: null,
-        roles: { gateway: 950, "plugin-cli": 900 }
+        roles: { gateway: 1000, "plugin-cli": 900 }
       }
     ];
 

--- a/surfaces/bundled-plugin-startup.json
+++ b/surfaces/bundled-plugin-startup.json
@@ -17,7 +17,7 @@
   },
   "roleThresholds": {
     "gateway": {
-      "peakRssMb": 950,
+      "peakRssMb": 1000,
       "maxCpuPercent": 250
     },
     "plugin-cli": {

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -336,7 +336,7 @@
       },
       "roleThresholds": {
         "gateway": {
-          "peakRssMb": 950,
+          "peakRssMb": 1000,
           "maxCpuPercent": 250
         },
         "plugin-cli": {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw release performance validation rejects current `main` when the bundled-plugin restart briefly reaches 951-961 MB RSS against the older 950 MB overlap budget.

## Why This Change Was Made

Raise only the bundled-plugin startup Gateway RSS cap by the established 50 MB calibration step. The cap remains blocking at 1000 MB; CPU and all other scenario budgets are unchanged.

## User Impact

Release validation still blocks material Gateway memory regressions without rejecting the current measured restart overlap.

## Evidence

- Failing release run: https://github.com/openclaw/openclaw/actions/runs/30168909219
- Three measured restart-overlap peaks: 955.5 MB, 960.5 MB, and 951.3 MB.
- `npm run test:snapshots`: 21 passed.
- `npm run check:web-payload`: passed.
- `npm run test:release-contracts`: passed.
- `node bin/kova.mjs self-check`: all 266 applicable checks passed, including `bundled-plugin-startup-surface-contract` and `release-resource-calibration`; four pre-existing local OCM setup/cleanup checks remained unavailable.
- Autoreview: clean.
