### PR TITLE
fix(states): emit valid plugin install records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.
 - Calibrate the bundled-plugin restart overlap RSS budget against repeated OpenClaw main release runs.
 - Calibrate the fresh-install status CLI RSS budget against repeated release-run evidence.
 - Calibrate the gateway pressure scenario's status CLI RSS budget against repeated release-run evidence.

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1236,6 +1236,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       }
     ));
     checks.push(await stateLifecycleCommandIndexesCheck(tmp));
+    checks.push(await pluginInstallIndexFixturesCheck(tmp));
     checks.push(await jsonCommandCheck(
       "allowlisted-scenario-omitted-state-falls-back-json",
       `node bin/kova.mjs run --target runtime:stable --scenario official-plugin-install --report-dir ${quoteShell(tmp)} --json`,
@@ -5634,6 +5635,89 @@ async function stateLifecycleCommandIndexesCheck(tmp) {
       message: error.message
     };
   }
+}
+
+async function pluginInstallIndexFixturesCheck(tmp) {
+  const fixtures = [
+    {
+      id: "many-bundled-plugins",
+      expectedIds: Array.from({ length: 80 }, (_, index) => `kova-plugin-${index}`)
+    },
+    {
+      id: "plugin-index",
+      expectedIds: ["kova-index-alpha", "kova-index-beta", "kova-index-gamma"]
+    }
+  ];
+
+  return inlineCheck("plugin-install-index-fixtures", async () => {
+    for (const fixture of fixtures) {
+      const state = JSON.parse(await readFile(join(repoRoot, "states", `${fixture.id}.json`), "utf8"));
+      const commands = state.setup?.flatMap((step) => step.commands ?? []) ?? [];
+      assertEqual(commands.length, 1, `${fixture.id} setup command count`);
+
+      const prefix = "ocm env exec {env} -- node -e '";
+      const command = commands[0];
+      if (!command.startsWith(prefix) || !command.endsWith("'")) {
+        throw new Error(`${fixture.id} setup command is not an embedded Node script`);
+      }
+
+      const home = join(tmp, `${fixture.id}-home`);
+      const script = command.slice(prefix.length, -1);
+      const result = await runCommand(
+        `${quoteShell(process.execPath)} -e ${quoteShell(script)}`,
+        {
+          env: { OPENCLAW_HOME: home },
+          timeoutMs: 30000,
+          maxOutputChars: 100000
+        }
+      );
+      if (result.status !== 0) {
+        throw new Error(
+          `${fixture.id} setup failed: ${result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`}`
+        );
+      }
+
+      for (const relativePath of ["plugins/installs.json", ".openclaw/plugins/installs.json"]) {
+        const index = JSON.parse(await readFile(join(home, relativePath), "utf8"));
+        assertEqual(Array.isArray(index.plugins), false, `${fixture.id} omits private plugins array`);
+        const records = index.installRecords;
+        if (!records || typeof records !== "object" || Array.isArray(records)) {
+          throw new Error(`${fixture.id} ${relativePath} has no installRecords object`);
+        }
+        assertEqual(
+          Object.keys(records).sort().join("\n"),
+          [...fixture.expectedIds].sort().join("\n"),
+          `${fixture.id} install record ids`
+        );
+        for (const id of fixture.expectedIds) {
+          const pluginDir = join(home, "fixture-plugins", id);
+          assertEqual(records[id]?.source, "path", `${fixture.id} ${id} source`);
+          assertEqual(records[id]?.sourcePath, pluginDir, `${fixture.id} ${id} source path`);
+          assertEqual(records[id]?.installPath, pluginDir, `${fixture.id} ${id} install path`);
+          assertEqual(records[id]?.version, "0.0.0", `${fixture.id} ${id} version`);
+          assertEqual(records[id]?.spec, undefined, `${fixture.id} ${id} has no package spec`);
+
+          const packageJson = JSON.parse(await readFile(join(pluginDir, "package.json"), "utf8"));
+          assertEqual(packageJson.name, `@kova/${id}`, `${fixture.id} ${id} package name`);
+          assertEqual(packageJson.version, "0.0.0", `${fixture.id} ${id} package version`);
+          assertEqual(
+            packageJson.openclaw?.extensions?.join("\n"),
+            "./index.js",
+            `${fixture.id} ${id} package entry`
+          );
+          const manifest = JSON.parse(
+            await readFile(join(pluginDir, "openclaw.plugin.json"), "utf8")
+          );
+          assertEqual(manifest.id, id, `${fixture.id} ${id} manifest id`);
+          assertEqual(
+            (await readFile(join(pluginDir, "index.js"), "utf8")).includes(`id: ${JSON.stringify(id)}`),
+            true,
+            `${fixture.id} ${id} runtime entry`
+          );
+        }
+      }
+    }
+  });
 }
 
 async function matrixWorkerRejectionCheck() {

--- a/states/many-bundled-plugins.json
+++ b/states/many-bundled-plugins.json
@@ -1,7 +1,7 @@
 {
   "id": "many-bundled-plugins",
-  "title": "Many Bundled Plugins Enabled",
-  "objective": "A pressure state for bundled plugin and provider metadata paths. It creates a plugin install index with many bundled-like entries so OpenClaw startup and metadata paths run under heavier registry pressure.",
+  "title": "Many Installed Plugins Enabled",
+  "objective": "A pressure state for plugin and provider metadata paths. It creates a canonical plugin install index with many synthetic entries so OpenClaw startup and metadata paths run under heavier registry pressure.",
   "tags": [
     "plugins",
     "providers",
@@ -21,10 +21,10 @@
         "clone"
       ],
       "commands": [
-        "ocm env exec {env} -- node -e 'const fs=require(\"fs\"), path=require(\"path\"); const home=process.env.OPENCLAW_HOME; const entries=Array.from({length:80},(_,i)=>({id:`kova-bundled-${i}`,name:`kova-bundled-${i}`,source:\"bundled\",enabled:true,version:\"0.0.0\",manifest:{id:`kova-bundled-${i}`,runtimeDependencies:[\"zod\",\"ws\",\"undici\",\"chokidar\"]}})); for (const rel of [\"plugins\",\".openclaw/plugins\"]) { const dir=path.join(home,rel); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,\"installs.json\"), JSON.stringify({schemaVersion:\"kova.fixture.plugins.v1\",plugins:entries}, null, 2)); }'"
+        "ocm env exec {env} -- node -e 'const fs=require(\"fs\"), path=require(\"path\"); const home=process.env.OPENCLAW_HOME; const ids=Array.from({length:80},(_,i)=>`kova-plugin-${i}`); const installRecords={}; for (const id of ids) { const pluginDir=path.join(home,\"fixture-plugins\",id); fs.mkdirSync(pluginDir,{recursive:true}); fs.writeFileSync(path.join(pluginDir,\"package.json\"),JSON.stringify({name:`@kova/${id}`,version:\"0.0.0\",type:\"module\",openclaw:{extensions:[\"./index.js\"]}},null,2)); fs.writeFileSync(path.join(pluginDir,\"openclaw.plugin.json\"),JSON.stringify({id,configSchema:{type:\"object\",additionalProperties:false,properties:{}}},null,2)); fs.writeFileSync(path.join(pluginDir,\"index.js\"),`export default { id: ${JSON.stringify(id)}, register() {} };\\n`); installRecords[id]={source:\"path\",sourcePath:pluginDir,installPath:pluginDir,version:\"0.0.0\"}; } for (const rel of [\"plugins\",\".openclaw/plugins\"]) { const dir=path.join(home,rel); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,\"installs.json\"), JSON.stringify({installRecords}, null, 2)); }'"
       ],
       "evidence": [
-        "large plugin install index written"
+        "canonical large plugin install index written"
       ],
       "collectionIntent": "service-only"
     }
@@ -37,7 +37,7 @@
   "riskArea": "plugin-metadata-scan",
   "ownerArea": "plugins",
   "setupEvidence": [
-    "large plugin install index written"
+    "canonical large plugin install index written"
   ],
   "cleanupGuarantees": [
     "disposable env cleanup removes state fixture files"

--- a/states/plugin-index.json
+++ b/states/plugin-index.json
@@ -1,7 +1,7 @@
 {
   "id": "plugin-index",
   "title": "Existing Plugin Install Index",
-  "objective": "A user state with a real plugin install index already present, used to verify updates preserve and migrate plugin registry data.",
+  "objective": "A user state with a canonical plugin install index already present, used to verify updates preserve plugin registry data.",
   "tags": [
     "plugins",
     "migration",
@@ -21,7 +21,7 @@
         "clone"
       ],
       "commands": [
-        "ocm env exec {env} -- node -e 'const fs=require(\"fs\"), path=require(\"path\"); const home=process.env.OPENCLAW_HOME; const index={schemaVersion:\"kova.fixture.plugins.v1\",plugins:[{id:\"browser\",source:\"bundled\",enabled:true,version:\"bundled\"},{id:\"memory-core\",source:\"bundled\",enabled:true,version:\"bundled\"},{id:\"discord\",source:\"external\",enabled:true,version:\"0.0.0\",path:\"plugins/discord\"}]}; for (const rel of [\"plugins\",\".openclaw/plugins\"]) { const dir=path.join(home,rel); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,\"installs.json\"),JSON.stringify(index,null,2)); }'"
+        "ocm env exec {env} -- node -e 'const fs=require(\"fs\"), path=require(\"path\"); const home=process.env.OPENCLAW_HOME; const ids=[\"kova-index-alpha\",\"kova-index-beta\",\"kova-index-gamma\"]; const installRecords={}; for (const id of ids) { const pluginDir=path.join(home,\"fixture-plugins\",id); fs.mkdirSync(pluginDir,{recursive:true}); fs.writeFileSync(path.join(pluginDir,\"package.json\"),JSON.stringify({name:`@kova/${id}`,version:\"0.0.0\",type:\"module\",openclaw:{extensions:[\"./index.js\"]}},null,2)); fs.writeFileSync(path.join(pluginDir,\"openclaw.plugin.json\"),JSON.stringify({id,configSchema:{type:\"object\",additionalProperties:false,properties:{}}},null,2)); fs.writeFileSync(path.join(pluginDir,\"index.js\"),`export default { id: ${JSON.stringify(id)}, register() {} };\\n`); installRecords[id]={source:\"path\",sourcePath:pluginDir,installPath:pluginDir,version:\"0.0.0\"}; } for (const rel of [\"plugins\",\".openclaw/plugins\"]) { const dir=path.join(home,rel); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,\"installs.json\"),JSON.stringify({installRecords},null,2)); }'"
       ],
       "evidence": [
         "plugin install index exists in common locations"

--- a/tests/snapshots/matrix-plan-json.snap
+++ b/tests/snapshots/matrix-plan-json.snap
@@ -675,8 +675,8 @@
       },
       "state": {
         "id": "many-bundled-plugins",
-        "title": "Many Bundled Plugins Enabled",
-        "objective": "A pressure state for bundled plugin and provider metadata paths. It creates a plugin install index with many bundled-like entries so OpenClaw startup and metadata paths run under heavier registry pressure.",
+        "title": "Many Installed Plugins Enabled",
+        "objective": "A pressure state for plugin and provider metadata paths. It creates a canonical plugin install index with many synthetic entries so OpenClaw startup and metadata paths run under heavier registry pressure.",
         "tags": [
           "plugins",
           "providers",

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -16284,8 +16284,8 @@
     },
     {
       "id": "many-bundled-plugins",
-      "title": "Many Bundled Plugins Enabled",
-      "objective": "A pressure state for bundled plugin and provider metadata paths. It creates a plugin install index with many bundled-like entries so OpenClaw startup and metadata paths run under heavier registry pressure.",
+      "title": "Many Installed Plugins Enabled",
+      "objective": "A pressure state for plugin and provider metadata paths. It creates a canonical plugin install index with many synthetic entries so OpenClaw startup and metadata paths run under heavier registry pressure.",
       "tags": [
         "plugins",
         "providers",
@@ -16305,10 +16305,10 @@
             "clone"
           ],
           "commands": [
-            "ocm env exec {env} -- node -e 'const fs=require(\"fs\"), path=require(\"path\"); const home=process.env.OPENCLAW_HOME; const entries=Array.from({length:80},(_,i)=>({id:`kova-bundled-${i}`,name:`kova-bundled-${i}`,source:\"bundled\",enabled:true,version:\"0.0.0\",manifest:{id:`kova-bundled-${i}`,runtimeDependencies:[\"zod\",\"ws\",\"undici\",\"chokidar\"]}})); for (const rel of [\"plugins\",\".openclaw/plugins\"]) { const dir=path.join(home,rel); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,\"installs.json\"), JSON.stringify({schemaVersion:\"kova.fixture.plugins.v1\",plugins:entries}, null, 2)); }'"
+            "ocm env exec {env} -- node -e 'const fs=require(\"fs\"), path=require(\"path\"); const home=process.env.OPENCLAW_HOME; const ids=Array.from({length:80},(_,i)=>`kova-plugin-${i}`); const installRecords={}; for (const id of ids) { const pluginDir=path.join(home,\"fixture-plugins\",id); fs.mkdirSync(pluginDir,{recursive:true}); fs.writeFileSync(path.join(pluginDir,\"package.json\"),JSON.stringify({name:`@kova/${id}`,version:\"0.0.0\",type:\"module\",openclaw:{extensions:[\"./index.js\"]}},null,2)); fs.writeFileSync(path.join(pluginDir,\"openclaw.plugin.json\"),JSON.stringify({id,configSchema:{type:\"object\",additionalProperties:false,properties:{}}},null,2)); fs.writeFileSync(path.join(pluginDir,\"index.js\"),`export default { id: ${JSON.stringify(id)}, register() {} };\\n`); installRecords[id]={source:\"path\",sourcePath:pluginDir,installPath:pluginDir,version:\"0.0.0\"}; } for (const rel of [\"plugins\",\".openclaw/plugins\"]) { const dir=path.join(home,rel); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,\"installs.json\"), JSON.stringify({installRecords}, null, 2)); }'"
           ],
           "evidence": [
-            "large plugin install index written"
+            "canonical large plugin install index written"
           ],
           "collectionIntent": "service-only"
         }
@@ -16321,7 +16321,7 @@
       "riskArea": "plugin-metadata-scan",
       "ownerArea": "plugins",
       "setupEvidence": [
-        "large plugin install index written"
+        "canonical large plugin install index written"
       ],
       "cleanupGuarantees": [
         "disposable env cleanup removes state fixture files"
@@ -16813,7 +16813,7 @@
     {
       "id": "plugin-index",
       "title": "Existing Plugin Install Index",
-      "objective": "A user state with a real plugin install index already present, used to verify updates preserve and migrate plugin registry data.",
+      "objective": "A user state with a canonical plugin install index already present, used to verify updates preserve plugin registry data.",
       "tags": [
         "plugins",
         "migration",
@@ -16833,7 +16833,7 @@
             "clone"
           ],
           "commands": [
-            "ocm env exec {env} -- node -e 'const fs=require(\"fs\"), path=require(\"path\"); const home=process.env.OPENCLAW_HOME; const index={schemaVersion:\"kova.fixture.plugins.v1\",plugins:[{id:\"browser\",source:\"bundled\",enabled:true,version:\"bundled\"},{id:\"memory-core\",source:\"bundled\",enabled:true,version:\"bundled\"},{id:\"discord\",source:\"external\",enabled:true,version:\"0.0.0\",path:\"plugins/discord\"}]}; for (const rel of [\"plugins\",\".openclaw/plugins\"]) { const dir=path.join(home,rel); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,\"installs.json\"),JSON.stringify(index,null,2)); }'"
+            "ocm env exec {env} -- node -e 'const fs=require(\"fs\"), path=require(\"path\"); const home=process.env.OPENCLAW_HOME; const ids=[\"kova-index-alpha\",\"kova-index-beta\",\"kova-index-gamma\"]; const installRecords={}; for (const id of ids) { const pluginDir=path.join(home,\"fixture-plugins\",id); fs.mkdirSync(pluginDir,{recursive:true}); fs.writeFileSync(path.join(pluginDir,\"package.json\"),JSON.stringify({name:`@kova/${id}`,version:\"0.0.0\",type:\"module\",openclaw:{extensions:[\"./index.js\"]}},null,2)); fs.writeFileSync(path.join(pluginDir,\"openclaw.plugin.json\"),JSON.stringify({id,configSchema:{type:\"object\",additionalProperties:false,properties:{}}},null,2)); fs.writeFileSync(path.join(pluginDir,\"index.js\"),`export default { id: ${JSON.stringify(id)}, register() {} };\\n`); installRecords[id]={source:\"path\",sourcePath:pluginDir,installPath:pluginDir,version:\"0.0.0\"}; } for (const rel of [\"plugins\",\".openclaw/plugins\"]) { const dir=path.join(home,rel); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,\"installs.json\"),JSON.stringify({installRecords},null,2)); }'"
           ],
           "evidence": [
             "plugin install index exists in common locations"


### PR DESCRIPTION
## Summary

- replace unsupported private plugin-index fixture shapes with canonical `installRecords`
- create real local plugin packages for pressure and migration scenarios
- execute and validate both fixture commands during Kova self-check
- refresh plan snapshots and document the fix

## Testing

- `PATH="$HOME/.local/bin:$PATH" npm run check` (`271/271` passed)
- `npm run test:snapshots` (`21/21` passed)
- Ubuntu and macOS CI passed
- autoreview: clean
- OpenClaw performance run: https://github.com/openclaw/openclaw/actions/runs/30617642016
  - tested OpenClaw `fbf5f3f2e0968e1d98f45beeea2e78af03034f06`
  - tested Kova `9b519433414e91a57abb86ff52bd66a0a87aa876`
  - migrated all 80 fixture install records into shared SQLite state
  - `plugins list` reported 151 entries after migration
  - `gateway-performance/many-bundled-plugins` passed with zero plugin load or dependency failures
