### PR TITLE
fix: report agent runtime RSS separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.
 - Calibrate the bundled-plugin restart overlap RSS budget against repeated OpenClaw main release runs.
 - Calibrate the fresh-install status CLI RSS budget against repeated release-run evidence.

--- a/docs/CONTRACT_REGISTRY.md
+++ b/docs/CONTRACT_REGISTRY.md
@@ -57,7 +57,9 @@ recorded as cleanup work rather than product measurement.
 Scope belongs to the prepared phase because command resource samples and
 post-phase process snapshots share one owner. Command results cannot override
 their phase's scope. Product resource headlines use the versioned identity
-`primary-role-product-scope-v2`.
+`primary-role-product-scope-v3`, which keeps process-specific roles disjoint,
+tracks owned harness processes by validated PID, and avoids duplicate
+primary-role threshold findings.
 
 ## Add A State
 

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -57,7 +57,7 @@ kova.report.v1
   "performance": {
     "schemaVersion": "kova.performance.v1",
     "resourceMeasurementScope": "product",
-    "resourceHeadlineContract": "primary-role-product-scope-v2",
+    "resourceHeadlineContract": "primary-role-product-scope-v3",
     "repeat": 3,
     "groupCount": 1,
     "unstableGroupCount": 0,
@@ -96,9 +96,11 @@ failure cards.
 `performance` is present on run and matrix reports. It keeps individual scenario
 records untouched and adds aggregate stats grouped by scenario, surface, and
 state. Resource groups use `resourceMeasurementScope: "product"` and
-`resourceHeadlineContract: "primary-role-product-scope-v2"`; harness and cleanup
+`resourceHeadlineContract: "primary-role-product-scope-v3"`; harness and cleanup
 work remains visible as evidence but does not contribute to resource headlines
-or gates.
+or gates. Version 3 assigns command roles only where no process-specific role
+owns the process, tracks the validated mock-provider PID explicitly, and emits
+one primary-role threshold finding per metric.
 
 `baseline` is normally `null`. When `--baseline` is used, it contains the
 baseline store path and comparison results. When `--save-baseline` is used, it
@@ -580,7 +582,7 @@ continues comparing status and other non-resource metrics.
     "unstableGroupCount": 0,
     "profiledRunCount": 0,
     "resourceMeasurementScope": "product",
-    "resourceHeadlineContract": "primary-role-product-scope-v2",
+    "resourceHeadlineContract": "primary-role-product-scope-v3",
     "baselineRegressionCount": 0,
     "missingBaselineCount": 0,
     "skippedMetricCount": 0,
@@ -742,12 +744,12 @@ When a report contains failures, the structured summary also includes
     "missingBaselineCount": 0,
     "skippedMetricCount": 0,
     "resourceMeasurementScope": "product",
-    "resourceHeadlineContract": "primary-role-product-scope-v2",
+    "resourceHeadlineContract": "primary-role-product-scope-v3",
     "resourceContractMismatchCount": 0
   },
   "performance": {
     "resourceMeasurementScope": "product",
-    "resourceHeadlineContract": "primary-role-product-scope-v2",
+    "resourceHeadlineContract": "primary-role-product-scope-v3",
     "baselineRegressionCount": 0,
     "missingBaselineCount": 0,
     "skippedMetricCount": 0,
@@ -903,7 +905,7 @@ retained-artifacts.json
         },
         "current": {
           "measurementScope": "product",
-          "headlineContract": "primary-role-product-scope-v2"
+          "headlineContract": "primary-role-product-scope-v3"
         },
         "compatible": false
       },

--- a/process-roles/agent-cli.json
+++ b/process-roles/agent-cli.json
@@ -3,5 +3,5 @@
   "title": "Agent CLI",
   "description": "User-facing OpenClaw agent command invocations that send messages or manage local sessions.",
   "commandPatterns": ["agent --local", "agent --session-id", " -- agent ", "run-concurrent-agent-turns.mjs"],
-  "processPatterns": ["(^|\\s|/)openclaw\\s+.*\\bagent\\b", "(^|\\s|/)openclaw-agent(\\s|$)"]
+  "processPatterns": ["(^|\\s|/)openclaw\\s+.*\\bagent\\b"]
 }

--- a/process-roles/agent-process.json
+++ b/process-roles/agent-process.json
@@ -2,10 +2,6 @@
   "id": "agent-process",
   "title": "Agent Process",
   "description": "Longer-running agent execution work spawned by OpenClaw while processing a turn.",
-  "commandPatterns": ["(^|\\s)agent(\\s|$)"],
-  "processPatterns": [
-    "(^|\\s|/)openclaw-agent(\\s|$)",
-    "(^|\\s|/)openclaw\\s+.*\\bsession\\b",
-    "(^|\\s|/)openclaw\\s+.*\\bagent\\b"
-  ]
+  "commandPatterns": [],
+  "processPatterns": ["(^|\\s|/)openclaw-agent(\\s|$)"]
 }

--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -16,6 +16,10 @@ export function startResourceSampler(rootPid, options = {}) {
   const startedAt = Date.now();
   const intervalMs = Math.max(250, Number(options.intervalMs ?? 1000));
   const roleMatchers = compileRoleMatchers(options.processRoles ?? []);
+  const trackedRolePids = new Map(
+    Object.entries(options.trackedRolePids ?? {})
+      .filter(([role, pid]) => typeof role === "string" && role.length > 0 && Number.isSafeInteger(pid) && pid > 0)
+  );
   const samples = [];
   let gatewayPid = null;
   let nextGatewayLookupSample = 0;
@@ -84,6 +88,11 @@ export function startResourceSampler(rootPid, options = {}) {
       }
       if (gatewayTreePids.has(process.pid)) {
         roles.add("gateway-tree");
+      }
+      for (const [role, pid] of trackedRolePids.entries()) {
+        if (process.pid === pid) {
+          roles.add(role);
+        }
       }
       if (roles.size > 0) {
         for (const role of matchingRegistryRoles(process, options.rootCommand, roleMatchers, roles)) {
@@ -372,18 +381,33 @@ function compilePatterns(patterns) {
 }
 
 function matchingRegistryRoles(process, rootCommand, roleMatchers, existingRoles = new Set()) {
-  const roles = [];
-  const isCommandTree = existingRoles.has("command-tree");
-  for (const role of roleMatchers) {
-    if (role.id === "command-tree" || role.id === "gateway" || role.id === "gateway-tree") {
-      continue;
-    }
-    if (matchesAny(role.processPatterns, process.command) || (isCommandTree && matchesAny(role.commandPatterns, rootCommand)) ||
-      matchesAny(role.commandPatterns, process.command)) {
-      roles.push(role.id);
-    }
+  const processRoles = matchingRegistryProcessRoles(process, roleMatchers);
+  if (processRoles.length > 0) {
+    return processRoles;
   }
-  return roles;
+
+  const commandRoles = roleMatchers
+    .filter((role) =>
+      role.id !== "command-tree" &&
+      role.id !== "gateway" &&
+      role.id !== "gateway-tree" &&
+      matchesAny(role.commandPatterns, process.command)
+    )
+    .map((role) => role.id);
+  if (commandRoles.length > 0 || !existingRoles.has("command-tree")) {
+    return commandRoles;
+  }
+
+  // Generic wrappers inherit the root command role; owned child processes keep
+  // their process-specific role instead of duplicating the whole command tree.
+  return roleMatchers
+    .filter((role) =>
+      role.id !== "command-tree" &&
+      role.id !== "gateway" &&
+      role.id !== "gateway-tree" &&
+      matchesAny(role.commandPatterns, rootCommand)
+    )
+    .map((role) => role.id);
 }
 
 function matchingRegistryProcessRoles(process, roleMatchers) {

--- a/src/evaluation/violations.mjs
+++ b/src/evaluation/violations.mjs
@@ -41,14 +41,22 @@ export function checkEvidenceThreshold(violations, kind, metric, actual, thresho
   }
 }
 
-export function checkRoleThresholds(violations, byRole, roleThresholds) {
+export function checkRoleThresholds(violations, byRole, roleThresholds, options = {}) {
+  const skipPeakRssRoles = new Set(options.skipPeakRssRoles ?? []);
+  const skipMaxCpuRoles = new Set(options.skipMaxCpuRoles ?? []);
   for (const [role, thresholds] of Object.entries(roleThresholds)) {
     const summary = byRole?.[role];
     if (!summary) {
       continue;
     }
+    const peakRssThresholdActive = activeFiniteThreshold(
+      violations,
+      `resourceByRole.${role}.peakRssMb`,
+      thresholds.peakRssMb
+    );
     if (
-      activeFiniteThreshold(violations, `resourceByRole.${role}.peakRssMb`, thresholds.peakRssMb) &&
+      !skipPeakRssRoles.has(role) &&
+      peakRssThresholdActive &&
       finiteNonNegativeMeasurement(
         violations,
         `resourceByRole.${role}.peakRssMb`,
@@ -92,12 +100,14 @@ export function checkRoleThresholds(violations, byRole, roleThresholds) {
         message: `${role} peak process RSS ${peakProcessRssMb} MB exceeded threshold ${thresholds.peakProcessRssMb} MB`
       });
     }
+    const maxCpuThresholdActive = activeFiniteThreshold(
+      violations,
+      `resourceByRole.${role}.maxCpuPercent`,
+      thresholds.maxCpuPercent
+    );
     if (
-      activeFiniteThreshold(
-        violations,
-        `resourceByRole.${role}.maxCpuPercent`,
-        thresholds.maxCpuPercent
-      ) &&
+      !skipMaxCpuRoles.has(role) &&
+      maxCpuThresholdActive &&
       finiteNonNegativeMeasurement(
         violations,
         `resourceByRole.${role}.maxCpuPercent`,

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -113,6 +113,19 @@ export function evaluateRecord(record, scenario, options = {}) {
   const resourceGateKind = resourceGate.kind;
   const peakRssMb = resourceGate.peakRssMb;
   const cpuPercentMax = resourceGate.cpuPercentMax;
+  const primaryRoleOwnsResourceGate =
+    resourceGateKind === "role" && resourceGate.role === primaryResourceRole;
+  const primaryRoleThresholds = primaryRoleOwnsResourceGate
+    ? roleThresholds[primaryResourceRole] ?? {}
+    : {};
+  const peakRssThreshold = strictestPrimaryThreshold(
+    thresholds.peakRssMb,
+    primaryRoleThresholds.peakRssMb
+  );
+  const cpuPercentThreshold = strictestPrimaryThreshold(
+    thresholds.cpuPercentMax,
+    primaryRoleThresholds.maxCpuPercent
+  );
   const commandMissingDependencyErrors = countMissingDependencyErrors(allResults);
   const missingDependencyErrors = combineCommandAndLogCount(
     commandMissingDependencyErrors,
@@ -259,29 +272,38 @@ export function evaluateRecord(record, scenario, options = {}) {
     });
   }
 
-  if (typeof thresholds.peakRssMb === "number" && peakRssMb !== null && peakRssMb > thresholds.peakRssMb) {
+  if (peakRssThreshold !== null && peakRssMb !== null && peakRssMb > peakRssThreshold) {
     violations.push({
       kind: "threshold",
       metric: "peakRssMb",
       role: resourceGate.role ?? null,
       resourceGateKind,
       attribution: resourceGate.attribution,
-      expected: `<= ${thresholds.peakRssMb}`,
+      expected: `<= ${peakRssThreshold}`,
       actual: peakRssMb,
-      message: `${resourceRssLabel(primaryResourceRole, resourceGateKind)} ${peakRssMb} MB exceeded threshold ${thresholds.peakRssMb} MB${resourceBreakdownSuffix(resourceSummary, resourceGate)}`
+      message: `${resourceRssLabel(primaryResourceRole, resourceGateKind)} ${peakRssMb} MB exceeded threshold ${peakRssThreshold} MB${resourceBreakdownSuffix(resourceSummary, resourceGate)}`
     });
   }
 
-  if (typeof thresholds.cpuPercentMax === "number" && cpuPercentMax !== null && cpuPercentMax > thresholds.cpuPercentMax) {
+  if (cpuPercentThreshold !== null && cpuPercentMax !== null && cpuPercentMax > cpuPercentThreshold) {
     violations.push({
       kind: "threshold",
       metric: "cpuPercentMax",
-      expected: `<= ${thresholds.cpuPercentMax}`,
+      expected: `<= ${cpuPercentThreshold}`,
       actual: cpuPercentMax,
-      message: `max CPU ${cpuPercentMax}% exceeded threshold ${thresholds.cpuPercentMax}%`
+      message: `max CPU ${cpuPercentMax}% exceeded threshold ${cpuPercentThreshold}%`
     });
   }
-  checkRoleThresholds(violations, resourceSummary.byRole, roleThresholds);
+  checkRoleThresholds(violations, resourceSummary.byRole, roleThresholds, {
+    skipPeakRssRoles:
+      primaryRoleOwnsResourceGate && typeof thresholds.peakRssMb === "number"
+        ? [primaryResourceRole]
+        : [],
+    skipMaxCpuRoles:
+      primaryRoleOwnsResourceGate && typeof thresholds.cpuPercentMax === "number"
+        ? [primaryResourceRole]
+        : []
+  });
 
   const allowedMissingDependencyErrors =
     typeof thresholds.missingDependencyErrors === "number" ? thresholds.missingDependencyErrors : 0;
@@ -1214,6 +1236,15 @@ export function evaluateRecord(record, scenario, options = {}) {
   }
 
   return record;
+}
+
+function strictestPrimaryThreshold(headlineThreshold, roleThreshold) {
+  if (typeof headlineThreshold !== "number") {
+    return null;
+  }
+  return typeof roleThreshold === "number"
+    ? Math.min(headlineThreshold, roleThreshold)
+    : headlineThreshold;
 }
 
 function collectAgentTurns(record, providerEvidence, scenario, timelineSummary, logSummary) {

--- a/src/evidence/agent-turns.mjs
+++ b/src/evidence/agent-turns.mjs
@@ -721,8 +721,9 @@ function agentCliRecordExpectsRunningGateway(record) {
 
 function agentCliResourceProofOk(measurements) {
   return commonResourceProofOk(measurements) &&
-    (nonNegativeNumber(measurements?.resourceByRole?.["agent-cli"]?.peakRssMb) ||
-      nonNegativeNumber(measurements?.resourceByRole?.["agent-process"]?.peakRssMb));
+    expectedAgentResourceRoles(measurements).every((role) =>
+      nonNegativeNumber(measurements?.resourceByRole?.[role]?.peakRssMb)
+    );
 }
 
 function agentCliResourceProofReason(measurements) {
@@ -730,9 +731,18 @@ function agentCliResourceProofReason(measurements) {
   if (commonReason) {
     return commonReason;
   }
-  if (!nonNegativeNumber(measurements?.resourceByRole?.["agent-cli"]?.peakRssMb) &&
-    !nonNegativeNumber(measurements?.resourceByRole?.["agent-process"]?.peakRssMb)) {
-    return "agent CLI role resource measurements were not captured";
+  const missingRoles = expectedAgentResourceRoles(measurements).filter((role) =>
+    !nonNegativeNumber(measurements?.resourceByRole?.[role]?.peakRssMb)
+  );
+  if (missingRoles.length > 0) {
+    return `agent resource measurements were not captured for ${missingRoles.join(", ")}`;
   }
   return null;
+}
+
+function expectedAgentResourceRoles(measurements) {
+  return [...new Set([
+    "agent-cli",
+    measurements?.resourcePrimaryRole
+  ].filter((role) => typeof role === "string" && role.length > 0))];
 }

--- a/src/performance/stats.mjs
+++ b/src/performance/stats.mjs
@@ -2,7 +2,7 @@ import { measurementMetricValue } from "../health.mjs";
 
 export const PERFORMANCE_SCHEMA = "kova.performance.v1";
 export const RESOURCE_MEASUREMENT_SCOPE = "product";
-export const RESOURCE_HEADLINE_CONTRACT = "primary-role-product-scope-v2";
+export const RESOURCE_HEADLINE_CONTRACT = "primary-role-product-scope-v3";
 
 export const PERFORMANCE_METRICS = [
   { id: "readinessHealthReadyMs", title: "Health Ready", unit: "ms", regressionKey: "startupRegressionPercent" },

--- a/src/process-safety.mjs
+++ b/src/process-safety.mjs
@@ -57,6 +57,44 @@ export function mockProviderOwnerRecord(pid, token) {
   };
 }
 
+export async function resolveOwnedMockProviderPid(options) {
+  const {
+    pidFile,
+    supervisorPath,
+    scriptPath,
+    requestLog,
+    serverLog,
+    inspectProcess = readProcessCommand
+  } = options;
+  let rawOwner;
+  try {
+    rawOwner = await readFile(pidFile, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT" || error.code === "EISDIR") {
+      return null;
+    }
+    throw error;
+  }
+
+  let owner;
+  try {
+    owner = parseMockProviderOwner(rawOwner);
+  } catch {
+    return null;
+  }
+  const command = await inspectProcess(owner.pid);
+  if (command === null || !isOwnedMockProviderSupervisorCommand(command, {
+    pidFile,
+    supervisorPath,
+    scriptPath,
+    requestLog,
+    serverLog
+  })) {
+    return null;
+  }
+  return owner.pid;
+}
+
 export function mockProviderStopFile(pidFile, owner) {
   const pid = positiveProcessId(owner.pid, "mock provider pid");
   return `${pidFile}.stop.${pid}.${validOwnerToken(owner.token)}`;

--- a/src/run/command-executor.mjs
+++ b/src/run/command-executor.mjs
@@ -13,6 +13,8 @@ import {
   tagCommandResult
 } from "../measurement-contract.mjs";
 import { assertNetworkFrontageCommandSafe, maybeStartNetworkFrontage, networkFrontageCommandEnv } from "../network-frontage.mjs";
+import { repoRoot } from "../paths.mjs";
+import { resolveOwnedMockProviderPid } from "../process-safety.mjs";
 import { assertSafeScenarioCommand } from "../safety.mjs";
 import { safeSegment } from "./phase-commands.mjs";
 
@@ -52,6 +54,9 @@ async function runCommandWithContext(command, context, envName, artifactDir, pha
   if (beforeSnapshot) {
     await writeJsonArtifact(`${snapshotBase}-before.json`, beforeSnapshot);
   }
+  const trackedRolePids = context.resourceSampling === false
+    ? {}
+    : await resolveTrackedRolePids(artifactDir, authPolicy);
   const result = await runCommand(command, {
     timeoutMs: context.timeoutMs,
     env: {
@@ -66,6 +71,7 @@ async function runCommandWithContext(command, context, envName, artifactDir, pha
       intervalMs: context.resourceSampleIntervalMs,
       processRoles: context.processRoles ?? [],
       commandEnv: context.commandEnv,
+      trackedRolePids,
       artifactPath: join(collectorArtifactDirs(artifactDir).resourceSamples, `${safeSegment(phaseId)}-${commandIndex + 1}.jsonl`)
     }
   });
@@ -104,6 +110,21 @@ async function runCommandWithContext(command, context, envName, artifactDir, pha
     };
   }
   return result;
+}
+
+async function resolveTrackedRolePids(artifactDir, authPolicy) {
+  if (authPolicy?.mode !== "mock") {
+    return {};
+  }
+  const mockDir = join(artifactDir, "mock-openai");
+  const pid = await resolveOwnedMockProviderPid({
+    pidFile: join(mockDir, "pid"),
+    supervisorPath: join(repoRoot, "support/mock-ai-provider-supervisor.mjs"),
+    scriptPath: join(mockDir, "script.json"),
+    requestLog: join(mockDir, "requests.jsonl"),
+    serverLog: join(mockDir, "server.log")
+  });
+  return pid === null ? {} : { "mock-provider": pid };
 }
 
 async function ensureNetworkFrontageForProductCommand(command, context, envName, artifactDir, phase) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -220,6 +220,7 @@ import {
   mockProviderStopFile,
   mockProviderSupervisorArgs,
   positiveProcessId,
+  resolveOwnedMockProviderPid,
   stopOwnedMockProvider
 } from "./process-safety.mjs";
 import { envNameFor, maxOcmEnvNameLength } from "./run/env-name.mjs";
@@ -2673,13 +2674,13 @@ function gatewayProcessResourceRoleCheck() {
     );
     assertEqual(
       gatewayRecord.violations.some((violation) => violation.metric === "resourceByRole.gateway.peakRssMb"),
-      true,
-      "gateway role RSS threshold sees final process"
+      false,
+      "gateway role RSS threshold is not duplicated"
     );
     assertEqual(
       gatewayRecord.violations.some((violation) => violation.metric === "resourceByRole.gateway.maxCpuPercent"),
-      true,
-      "gateway role CPU threshold sees final process"
+      false,
+      "gateway role CPU threshold is not duplicated"
     );
 
     const pluginRecord = buildRecord();
@@ -13016,6 +13017,25 @@ async function mockProviderProcessSafetyCheck(tmp) {
       "trailing legacy arguments do not authenticate a different invocation"
     );
 
+    await writeFile(pidFile, ownerText(12345), "utf8");
+    assertEqual(
+      await resolveOwnedMockProviderPid({
+        ...stopOptions,
+        inspectProcess: async () => expectedCommand
+      }),
+      12345,
+      "resource sampler resolves the validated mock provider owner"
+    );
+    assertEqual(
+      await resolveOwnedMockProviderPid({
+        ...stopOptions,
+        inspectProcess: async () => "node unrelated.mjs"
+      }),
+      null,
+      "resource sampler rejects a recycled mock provider PID"
+    );
+    await rm(pidFile, { force: true });
+
     await writeFile(pidFile, "12345\n", "utf8");
     let legacyInspections = 0;
     let legacySignal = null;
@@ -19329,6 +19349,7 @@ function resourceConfiguredRoleMissingCheck() {
         resourcePrimaryRole: "mcp-runtime",
         thresholds: {},
         roleThresholds: {
+          "mcp-runtime": { peakRssMb: 400, maxCpuPercent: 60 },
           gateway: { peakRssMb: 850 },
           "tool-runtime": { peakRssMb: 500 }
         },
@@ -19350,6 +19371,16 @@ function resourceConfiguredRoleMissingCheck() {
       record.violations?.some((violation) => violation.metric === "peakRssMb"),
       false,
       "aggregate RSS is not reported as component RSS"
+    );
+    assertEqual(
+      record.violations?.some((violation) => violation.metric === "cpuPercentMax"),
+      false,
+      "aggregate CPU is not judged against the missing primary role"
+    );
+    assertEqual(
+      record.violations?.some((violation) => violation.metric === "resourceByRole.mcp-runtime.maxCpuPercent"),
+      false,
+      "missing primary role does not suppress or fabricate a role CPU measurement"
     );
     return {
       id: "resource-configured-role-missing",
@@ -19436,6 +19467,42 @@ async function resourceRolePollutionCheck() {
         existingRoles: ["command-tree"]
       }
     );
+    const openclawWrapperRoles = classifyRegistryRolesForProcess(
+      { command: "openclaw" },
+      {
+        processRoles,
+        rootCommand: "ocm @kova -- agent --local --message hi",
+        existingRoles: ["command-tree"]
+      }
+    );
+    const openclawSessionCliRoles = classifyRegistryRolesForProcess(
+      { command: "openclaw agent --session-id kova-agent" },
+      {
+        processRoles,
+        rootCommand: "ocm @kova -- agent --session-id kova-agent --message hi",
+        existingRoles: ["command-tree"]
+      }
+    );
+    const openclawMessageSessionRoles = classifyRegistryRolesForProcess(
+      { command: "openclaw agent --message session" },
+      {
+        processRoles,
+        rootCommand: "ocm @kova -- agent --message session",
+        existingRoles: ["command-tree"]
+      }
+    );
+    const openclawAgentSessionRoles = classifyRegistryRolesForProcess(
+      { command: "openclaw-agent --session-id kova-agent" },
+      {
+        processRoles,
+        rootCommand: "ocm @kova -- agent --session-id kova-agent --message hi",
+        existingRoles: ["command-tree"]
+      }
+    );
+    const trackedProvider = startResourceSampler(process.pid, {
+      trackedRolePids: { "mock-provider": process.pid }
+    });
+    const trackedProviderSummary = await trackedProvider.stop();
     const resourceSummary = summarizeResourceSamples([{
       timestamp: "2026-05-07T00:00:00.000Z",
       elapsedMs: 1000,
@@ -19465,8 +19532,21 @@ async function resourceRolePollutionCheck() {
     assertEqual(mockProviderRoles.includes("browser-sidecar"), false, "browser env name must not imply browser-sidecar");
     assertEqual(envNameRoles.includes("runtime-management"), false, "mcp-runtime env name must not imply runtime-management");
     assertEqual(envNameRoles.includes("model-cli"), false, "configure-openclaw fixture helper must not imply model-cli");
-    assertEqual(openclawAgentRoles.includes("agent-cli"), true, "openclaw-agent process must imply agent-cli");
+    assertEqual(openclawAgentRoles.includes("agent-cli"), false, "openclaw-agent process must not imply agent-cli");
     assertEqual(openclawAgentRoles.includes("agent-process"), true, "openclaw-agent process must imply agent-process");
+    assertEqual(openclawWrapperRoles.includes("agent-cli"), true, "generic OpenClaw wrapper inherits agent CLI command role");
+    assertEqual(openclawWrapperRoles.includes("agent-process"), false, "generic OpenClaw wrapper must not imply agent process");
+    assertEqual(openclawSessionCliRoles.includes("agent-cli"), true, "agent session-id CLI remains attributed to agent CLI");
+    assertEqual(openclawSessionCliRoles.includes("agent-process"), false, "session-id option must not imply agent process");
+    assertEqual(openclawMessageSessionRoles.includes("agent-cli"), true, "agent message CLI remains attributed to agent CLI");
+    assertEqual(openclawMessageSessionRoles.includes("agent-process"), false, "session message text must not imply agent process");
+    assertEqual(openclawAgentSessionRoles.includes("agent-cli"), false, "agent process pattern outranks session-id command text");
+    assertEqual(openclawAgentSessionRoles.includes("agent-process"), true, "agent process with session-id remains attributed");
+    assertEqual(
+      Boolean(trackedProviderSummary.byRole?.["mock-provider"]),
+      true,
+      "explicit mock provider owner PID is sampled outside command matching"
+    );
     assertEqual(resourceSummary.peakGatewayRssMb, 700, "gateway-session-client role must not inflate gateway RSS");
     assertEqual(resourceSummary.peakCommandTreeRssMb, 60, "gateway-session-client remains command-tree RSS");
     return {
@@ -19739,6 +19819,7 @@ async function officialPluginInstallSurfaceContractCheck() {
 async function agentCliLocalTurnSurfaceContractCheck() {
   try {
     const surface = await readSelfCheckJson("surfaces", "agent-cli-local-turn.json");
+    const networkOfflineSurface = await readSelfCheckJson("surfaces", "network-offline.json");
     const releaseProfile = await readSelfCheckJson("profiles", "release.json");
     const scenario = await readSelfCheckJson("scenarios", "agent-cold-warm-message.json");
     const policy = resolveThresholdPolicy({
@@ -19761,6 +19842,8 @@ async function agentCliLocalTurnSurfaceContractCheck() {
       assertEqual(expectedSpans.includes(span), false, `agent CLI surface must not require stale ${span} span`);
     }
     assertEqual(expectedSpans.includes("plugins.metadata.scan"), true, "agent CLI surface requires plugin metadata scan timeline span");
+    assertEqual(surface.resourcePrimaryRole, "agent-process", "local agent surface headlines the agent process");
+    assertEqual(networkOfflineSurface.resourcePrimaryRole, "agent-process", "offline agent surface headlines the agent process");
     assertEqual(surface.thresholds?.peakRssMb, 1000, "agent CLI surface owns primary RSS cap");
     assertEqual(surface.roleThresholds?.["agent-cli"]?.peakRssMb, 1000, "agent CLI surface owns agent CLI RSS cap");
     assertEqual(surface.roleThresholds?.["agent-process"]?.peakRssMb, 1000, "agent CLI surface owns agent process RSS cap");
@@ -19799,6 +19882,7 @@ async function agentGatewayRpcTurnSurfaceContractCheck() {
     for (const span of staleSpans) {
       assertEqual(expectedSpans.includes(span), false, `agent Gateway RPC surface must not require stale ${span} span`);
     }
+    assertEqual(surface.resourcePrimaryRole, "agent-cli", "Gateway RPC surface headlines the client process");
     assertEqual(expectedSpans.includes("gateway.ready"), true, "agent Gateway RPC surface requires gateway.ready timeline span");
     assertEqual(expectedSpans.includes("plugins.metadata.scan"), true, "agent Gateway RPC surface requires plugin metadata scan timeline span");
     return {
@@ -19971,7 +20055,8 @@ async function processSnapshotCheck(tmp, scope) {
     assertEqual(unrelatedBrowserRoles.includes("browser-sidecar"), false, "unrelated browser process excluded from snapshot role");
     assertEqual(scopedBrowserRoles.includes("browser-sidecar"), true, "scoped browser process retained");
     assertEqual(gatewayBrowserRoles.includes("browser-sidecar"), true, "gateway child browser process retained");
-    assertEqual(scopedAgentRoles.includes("agent-cli"), true, "scoped agent process retained");
+    assertEqual(scopedAgentRoles.includes("agent-cli"), false, "scoped agent process is not attributed to the CLI wrapper");
+    assertEqual(scopedAgentRoles.includes("agent-process"), true, "scoped agent process retained");
     const retainedCommands = before.processes.map((process) => process.command).join("\n");
     for (const value of [customValue, flagValue, headerValue, urlValue]) {
       assertEqual(retainedCommands.includes(value), false, `process snapshot redacts ${value}`);
@@ -19998,7 +20083,7 @@ async function processSnapshotCheck(tmp, scope) {
 
 function roleThresholdEvaluationCheck() {
   try {
-    const record = {
+    const sourceRecord = {
       scenario: "synthetic-role-threshold",
       title: "Synthetic Role Threshold",
       status: "PASS",
@@ -20041,6 +20126,7 @@ function roleThresholdEvaluationCheck() {
         logs: zeroLogMetrics()
       }
     };
+    const record = structuredClone(sourceRecord);
     evaluateRecord(record, { thresholds: {} }, {
       surface: {
         thresholds: {},
@@ -20069,6 +20155,78 @@ function roleThresholdEvaluationCheck() {
     const gatewayRow = reportScenarios[0]?.metrics?.find((metric) => metric.key === "peakRssMb#gateway");
     assertEqual(peakRow?.status, "FAIL", "parent RSS row inherits failed role child status");
     assertEqual(gatewayRow?.status, "FAIL", "gateway role child row fails");
+
+    const deduplicatedRecord = structuredClone(sourceRecord);
+    evaluateRecord(deduplicatedRecord, {
+      thresholds: {
+        peakRssMb: 100,
+        cpuPercentMax: 50
+      }
+    }, {
+      surface: {
+        resourcePrimaryRole: "gateway",
+        thresholds: {},
+        roleThresholds: {
+          gateway: { peakRssMb: 50, maxCpuPercent: 40 }
+        }
+      }
+    });
+    const deduplicatedMetrics = deduplicatedRecord.violations.map((violation) => violation.metric);
+    assertEqual(deduplicatedMetrics.includes("peakRssMb"), true, "primary RSS threshold remains active");
+    assertEqual(deduplicatedMetrics.includes("cpuPercentMax"), true, "primary CPU threshold remains active");
+    assertEqual(
+      deduplicatedRecord.violations.find((violation) => violation.metric === "peakRssMb")?.expected,
+      "<= 50",
+      "headline RSS enforces the stricter primary-role threshold"
+    );
+    assertEqual(
+      deduplicatedRecord.violations.find((violation) => violation.metric === "cpuPercentMax")?.expected,
+      "<= 40",
+      "headline CPU enforces the stricter primary-role threshold"
+    );
+    assertEqual(
+      deduplicatedMetrics.includes("resourceByRole.gateway.peakRssMb"),
+      false,
+      "primary RSS role threshold is not duplicated"
+    );
+    assertEqual(
+      deduplicatedMetrics.includes("resourceByRole.gateway.maxCpuPercent"),
+      false,
+      "primary CPU role threshold is not duplicated"
+    );
+
+    const malformedPrimaryRoleRecord = structuredClone(sourceRecord);
+    evaluateRecord(malformedPrimaryRoleRecord, {
+      thresholds: {
+        peakRssMb: 100,
+        cpuPercentMax: 50
+      }
+    }, {
+      surface: {
+        resourcePrimaryRole: "gateway",
+        thresholds: {},
+        roleThresholds: {
+          gateway: { peakRssMb: "invalid", maxCpuPercent: "invalid" }
+        }
+      }
+    });
+    const malformedPrimaryRoleViolations = malformedPrimaryRoleRecord.violations.filter(
+      (violation) => violation.failureDomain === "kova-harness"
+    );
+    assertEqual(
+      malformedPrimaryRoleViolations.some(
+        (violation) => violation.metric === "resourceByRole.gateway.peakRssMb"
+      ),
+      true,
+      "deduplicated primary RSS threshold remains validated"
+    );
+    assertEqual(
+      malformedPrimaryRoleViolations.some(
+        (violation) => violation.metric === "resourceByRole.gateway.maxCpuPercent"
+      ),
+      true,
+      "deduplicated primary CPU threshold remains validated"
+    );
     return {
       id: "resource-role-thresholds",
       status: "PASS",

--- a/surfaces/agent-cli-local-turn.json
+++ b/surfaces/agent-cli-local-turn.json
@@ -10,7 +10,7 @@
     "agent-process",
     "mock-provider"
   ],
-  "resourcePrimaryRole": "agent-cli",
+  "resourcePrimaryRole": "agent-process",
   "thresholds": {
     "agentTurnMs": 45000,
     "coldAgentTurnMs": 45000,

--- a/surfaces/network-offline.json
+++ b/surfaces/network-offline.json
@@ -9,7 +9,7 @@
     "agent-cli",
     "agent-process"
   ],
-  "resourcePrimaryRole": "agent-cli",
+  "resourcePrimaryRole": "agent-process",
   "thresholds": {
     "networkFailureObserved": 1,
     "networkStatusAfterFailureMs": 10000,

--- a/tests/snapshots/matrix-run-receipt-dry-json.snap
+++ b/tests/snapshots/matrix-run-receipt-dry-json.snap
@@ -36,7 +36,7 @@
     "unstableGroupCount": 0,
     "profiledRunCount": 0,
     "resourceMeasurementScope": "product",
-    "resourceHeadlineContract": "primary-role-product-scope-v2",
+    "resourceHeadlineContract": "primary-role-product-scope-v3",
     "baselineRegressionCount": null,
     "missingBaselineCount": null,
     "skippedMetricCount": null,

--- a/tests/snapshots/matrix-run-receipt-dry.snap
+++ b/tests/snapshots/matrix-run-receipt-dry.snap
@@ -9,7 +9,7 @@
 
 ─── resource contract ──────────────────────────────────────────────────────────
   Scope      product
-  Headline   primary-role-product-scope-v2
+  Headline   primary-role-product-scope-v3
 
 ─── artifacts ──────────────────────────────────────────────────────────────────
   ◆ markdown    <kova-home>/reports/kova-<runId>-smoke.md

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -92,7 +92,7 @@
         "agent-process",
         "mock-provider"
       ],
-      "resourcePrimaryRole": "agent-cli",
+      "resourcePrimaryRole": "agent-process",
       "thresholds": {
         "agentTurnMs": 45000,
         "coldAgentTurnMs": 45000,
@@ -1510,7 +1510,7 @@
         "agent-cli",
         "agent-process"
       ],
-      "resourcePrimaryRole": "agent-cli",
+      "resourcePrimaryRole": "agent-process",
       "thresholds": {
         "networkFailureObserved": 1,
         "networkStatusAfterFailureMs": 10000,
@@ -2901,21 +2901,16 @@
         "run-concurrent-agent-turns.mjs"
       ],
       "processPatterns": [
-        "(^|\\s|/)openclaw\\s+.*\\bagent\\b",
-        "(^|\\s|/)openclaw-agent(\\s|$)"
+        "(^|\\s|/)openclaw\\s+.*\\bagent\\b"
       ]
     },
     {
       "id": "agent-process",
       "title": "Agent Process",
       "description": "Longer-running agent execution work spawned by OpenClaw while processing a turn.",
-      "commandPatterns": [
-        "(^|\\s)agent(\\s|$)"
-      ],
+      "commandPatterns": [],
       "processPatterns": [
-        "(^|\\s|/)openclaw-agent(\\s|$)",
-        "(^|\\s|/)openclaw\\s+.*\\bsession\\b",
-        "(^|\\s|/)openclaw\\s+.*\\bagent\\b"
+        "(^|\\s|/)openclaw-agent(\\s|$)"
       ]
     },
     {

--- a/tests/snapshots/run-receipt-dry-json.snap
+++ b/tests/snapshots/run-receipt-dry-json.snap
@@ -21,7 +21,7 @@
     "unstableGroupCount": 0,
     "profiledRunCount": 0,
     "resourceMeasurementScope": "product",
-    "resourceHeadlineContract": "primary-role-product-scope-v2",
+    "resourceHeadlineContract": "primary-role-product-scope-v3",
     "baselineRegressionCount": null,
     "missingBaselineCount": null,
     "skippedMetricCount": null,

--- a/tests/snapshots/run-receipt-dry.snap
+++ b/tests/snapshots/run-receipt-dry.snap
@@ -9,7 +9,7 @@
 
 ─── resource contract ──────────────────────────────────────────────────────────
   Scope      product
-  Headline   primary-role-product-scope-v2
+  Headline   primary-role-product-scope-v3
 
 ─── artifacts ──────────────────────────────────────────────────────────────────
   ◆ markdown    <kova-home>/reports/kova-<runId>.md


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Kova agent-turn runs reported the agent CLI wrapper, agent runtime, and mock provider under overlapping resource roles, causing identical RSS values and duplicate threshold failures instead of identifying the process that owned the memory.

## Why This Change Was Made

Resource classification now prefers process-specific roles over inherited command roles, validates and tracks the owned mock-provider PID directly, and uses the agent runtime as the primary resource role for local agent surfaces. Primary-role threshold findings are deduplicated without suppressing threshold validation or applying role limits to another gate.

## User Impact

Kova reports separate, attributable RSS and CPU measurements for the agent CLI, agent runtime, and mock provider. Performance failures now point at the owning process once, making OpenClaw regressions actionable.

## Evidence

- `npm run check`: 271/271 passed
- `npm run test:snapshots`: 21/21 passed
- `git diff --check`: passed
- autoreview: clean, no accepted/actionable findings
- TruffleHog pre-review scan: clean
- Exact release-shaped workflow: [OpenClaw Performance run 30620388830](https://github.com/openclaw/openclaw/actions/runs/30620388830)
  - OpenClaw: `a550827dad3006cb461a89402080638545454818`
  - Kova: `12f19139a0a0f784b7d189ffc43fe79d5bc40b0e`
  - Result: 5/5 scenarios passed with zero violations
  - Agent turn: `agent-cli` 509.7 MB, `agent-process` 849.6 MB, `mock-provider` 72.4 MB
  - Primary gate: `agent-process`, one RSS headline at 849.6 MB
  - Cold/warm turns: 4859/4591 ms; pre-provider: 4652/4452 ms

### Report Contract Assessment

`resourceHeadlineContract` is consumed by Kova's own report, comparison, gate, and baseline code. OpenClaw `main` has no source consumer of the field. Kova already treats a v2/v3 mismatch as an intentional compatibility boundary: resource RSS/CPU deltas become non-comparable and are skipped, while status and non-resource regressions continue to be evaluated. Existing v2 baselines therefore remain readable and fail closed for resource comparisons instead of producing misleading deltas.
