### PR TITLE
fix: keep deep profiles scoped to product commands

### DIFF
--- a/docs/AGENT_USAGE.md
+++ b/docs/AGENT_USAGE.md
@@ -104,7 +104,10 @@ node bin/kova.mjs matrix run --profile release \
 ```
 
 Matrix runs emit a bundle path in the JSON receipt. Bundles include
-`artifact-index.json` with relative paths, byte sizes, and SHA-256 hashes.
+`artifact-index.json` with relative paths, byte sizes, and SHA-256 hashes. If
+the full bundle would exceed publication limits, Kova excludes the complete
+`node-profiles/node-trace-*.json` and `.log` class from the published bundle,
+records every omission in the index, and leaves the source artifacts intact.
 
 The `exhaustive` profile requires `--allow-exhaustive`. Use plan or filtered
 dry-runs first.

--- a/docs/DIAGNOSTICS_CONTRACT.md
+++ b/docs/DIAGNOSTICS_CONTRACT.md
@@ -21,16 +21,19 @@ OPENCLAW_DIAGNOSTICS_TIMELINE_PATH=<artifact-dir>/openclaw/timeline.jsonl
 OPENCLAW_DIAGNOSTICS_EVENT_LOOP=1
 ```
 
-When `--deep-profile` is enabled, Kova also launches OpenClaw commands with
-Node/V8 diagnostic flags through `NODE_OPTIONS`:
+When `--deep-profile` is enabled, Kova also launches bounded product-scope
+OpenClaw commands with Node/V8 diagnostic flags through `NODE_OPTIONS`.
+Harness, cleanup, and persistent service-launch commands keep timeline
+diagnostics but do not inherit these profiler flags:
 
 ```sh
 --cpu-prof
 --heap-prof
 --trace-events-enabled
+--trace-event-categories=node.perf,node.async_hooks,v8
 --heapsnapshot-signal=SIGUSR2
 --report-on-signal
---report-signal=SIGUSR1
+--report-signal=SIGUSR2
 ```
 
 Kova stores the resulting raw profiles, trace events, diagnostic reports, and

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -83,7 +83,11 @@ Report bundles include `artifact-index.json` at the archive root. The index
 lists every file staged into the bundle with its original relative `path`,
 portable `archivePath`, byte size, and SHA-256 digest. Kova maps names that
 USTAR cannot represent to deterministic archive paths while preserving the
-original evidence name in the index.
+original evidence name in the index. `publicationOmissions` records omitted
+path, bytes, SHA-256, and reason when the complete raw
+`artifacts/node-profiles/node-trace-*.json` and `.log` class must be excluded
+to satisfy publication limits. CPU profiles, heap profiles, and similarly
+named files outside that exact class remain included.
 
 `outputPaths` records the Markdown, full JSON, and compact summary JSON paths
 for the report itself. The matrix receipt also includes bundle and checksum
@@ -960,6 +964,19 @@ table. Status transitions and non-resource metric regressions remain active.
   "outputPath": "/path/to/bundle.tar.gz",
   "checksumPath": "/path/to/bundle.tar.gz.sha256",
   "sha256": "...",
+  "publicationOmissions": {
+    "fileCount": 0,
+    "totalBytes": 0
+  },
+  "artifactIndex": {
+    "path": "artifact-index.json",
+    "fileCount": 5,
+    "totalBytes": 12345,
+    "publicationOmissions": {
+      "fileCount": 0,
+      "totalBytes": 0
+    }
+  },
   "included": {
     "reportJson": true,
     "reportMarkdown": true,
@@ -968,3 +985,8 @@ table. Status transitions and non-resource metric regressions remain active.
   }
 }
 ```
+
+Kova stages and preflights the complete artifact set before publication. It
+omits raw Node traces only when a bundle limit would otherwise be exceeded,
+never publishes an arbitrary subset of that class, and fails closed if the
+remaining mandatory artifacts still exceed a limit.

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -33,6 +33,10 @@ const READ_ONLY_NONBLOCK =
   fsConstants.O_RDONLY |
   (fsConstants.O_NONBLOCK ?? 0) |
   (fsConstants.O_NOFOLLOW ?? 0);
+const RAW_NODE_TRACE_EXCLUSION_REASON =
+  "raw-node-trace-excluded-for-publication-limit";
+const BUNDLE_PUBLICATION_LIMIT_ERROR =
+  "ERR_KOVA_BUNDLE_PUBLICATION_LIMIT";
 
 export async function bundleReport(reportPath, options = {}) {
   const sourceJsonPath = resolve(reportPath);
@@ -114,7 +118,7 @@ export async function bundleReport(reportPath, options = {}) {
         included.runArtifacts = true;
       }
 
-      const manifest = {
+      const manifestBase = {
         schemaVersion: "kova.artifact.manifest.v1",
         generatedAt: new Date().toISOString(),
         runId,
@@ -131,24 +135,71 @@ export async function bundleReport(reportPath, options = {}) {
         },
         included
       };
-      await writeFile(
-        join(stage, "manifest.json"),
-        `${JSON.stringify(manifest, null, 2)}\n`,
-        "utf8"
+      const initialEntries = await listFiles(stage, stage);
+      const initialPlan = planBundlePublication(initialEntries, bundleName);
+      let omissions = await hashPublicationOmissions(
+        stage,
+        initialPlan.omissions
       );
-      const artifactIndex = await buildArtifactIndex(stage, bundleName);
-      await writeFile(
-        join(stage, "artifact-index.json"),
-        `${JSON.stringify(artifactIndex, null, 2)}\n`,
-        "utf8"
-      );
-      await writeUstarArchive(stage, bundleName, stagedArchivePath);
+      if (omissions.length > 0) {
+        await removePublicationOmissions(stage, omissions);
+      }
 
-      const archive = await readStableRegularFile(
-        stagedArchivePath,
-        "generated report bundle",
-        MAX_BUNDLE_COMPRESSED_BYTES
-      );
+      let artifactIndex;
+      try {
+        artifactIndex = await writeBundleMetadata(
+          stage,
+          bundleName,
+          manifestBase,
+          omissions
+        );
+      } catch (error) {
+        if (!isBundlePublicationLimitError(error) || omissions.length > 0) {
+          throw error;
+        }
+        omissions = await rawNodeTraceEntries(stage);
+        if (omissions.length === 0) {
+          throw error;
+        }
+        await removePublicationOmissions(stage, omissions);
+        artifactIndex = await writeBundleMetadata(
+          stage,
+          bundleName,
+          manifestBase,
+          omissions
+        );
+      }
+
+      let archive;
+      for (;;) {
+        await rm(stagedArchivePath, { force: true });
+        await writeUstarArchive(stage, bundleName, stagedArchivePath);
+        const archiveInfo = await lstat(stagedArchivePath);
+        if (archiveInfo.size <= MAX_BUNDLE_COMPRESSED_BYTES) {
+          archive = await readStableRegularFile(
+            stagedArchivePath,
+            "generated report bundle",
+            MAX_BUNDLE_COMPRESSED_BYTES
+          );
+          break;
+        }
+        if (omissions.length > 0) {
+          throw bundlePublicationLimitError(stagedArchivePath);
+        }
+        omissions = await rawNodeTraceEntries(stage);
+        if (omissions.length === 0) {
+          throw bundlePublicationLimitError(stagedArchivePath);
+        }
+        await removePublicationOmissions(stage, omissions);
+        artifactIndex = await writeBundleMetadata(
+          stage,
+          bundleName,
+          manifestBase,
+          omissions
+        );
+      }
+
+      const publicationOmissions = summarizePublicationOmissions(omissions);
       const sha256 = createHash("sha256").update(archive).digest("hex");
       const outputPath = join(outputRoot, `${bundleName}-${sha256}.tar.gz`);
       const checksumPath = `${outputPath}.sha256`;
@@ -168,10 +219,12 @@ export async function bundleReport(reportPath, options = {}) {
         checksumPath,
         sha256,
         bytes: archive.length,
+        publicationOmissions,
         artifactIndex: {
           path: "artifact-index.json",
           fileCount: artifactIndex.fileCount,
-          totalBytes: artifactIndex.totalBytes
+          totalBytes: artifactIndex.totalBytes,
+          publicationOmissions
         },
         included
       };
@@ -253,7 +306,32 @@ function portableRetentionFilenameKey(value) {
   return value.toLowerCase();
 }
 
-async function buildArtifactIndex(stage, bundleName) {
+async function writeBundleMetadata(
+  stage,
+  bundleName,
+  manifestBase,
+  omissions
+) {
+  await rm(join(stage, "manifest.json"), { force: true });
+  await rm(join(stage, "artifact-index.json"), { force: true });
+  const publicationOmissions = summarizePublicationOmissions(omissions);
+  await writeDurableFile(
+    join(stage, "manifest.json"),
+    `${JSON.stringify({
+      ...manifestBase,
+      publicationOmissions
+    }, null, 2)}\n`
+  );
+  const artifactIndex = await buildArtifactIndex(stage, bundleName, omissions);
+  await writeDurableFile(
+    join(stage, "artifact-index.json"),
+    `${JSON.stringify(artifactIndex, null, 2)}\n`
+  );
+  await listBundleFiles(stage, bundleName);
+  return artifactIndex;
+}
+
+async function buildArtifactIndex(stage, bundleName, omissions = []) {
   const entries = await listBundleFiles(stage, bundleName);
   const totalBytes = entries.reduce((sum, entry) => sum + entry.bytes, 0);
   return {
@@ -262,52 +340,166 @@ async function buildArtifactIndex(stage, bundleName) {
     bundleRoot: bundleName,
     fileCount: entries.length,
     totalBytes,
+    publicationOmissions: {
+      ...summarizePublicationOmissions(omissions),
+      entries: omissions
+    },
     entries
   };
 }
 
 async function listBundleFiles(root, bundleName) {
-  const budget = {
-    entries: 0,
-    declaredBytes: 0,
-    unpackedBytes: 1024
-  };
-  const entries = await listFiles(root, root, budget);
-  return assignArchivePaths(entries, bundleName);
+  const entries = await listFiles(root, root);
+  assertBundleEntriesWithinLimits(entries);
+  return assignArchivePaths(await hashBundleEntries(root, entries), bundleName);
 }
 
-async function listFiles(root, dir, budget) {
+async function listFiles(root, dir) {
   const names = await readdir(dir, { withFileTypes: true });
   const entries = [];
   for (const name of names.toSorted((left, right) => left.name.localeCompare(right.name))) {
     const path = join(dir, name.name);
     if (name.isDirectory()) {
-      entries.push(...await listFiles(root, path, budget));
+      entries.push(...await listFiles(root, path));
       continue;
     }
     if (!name.isFile()) {
       throw new Error(`report bundle contains an unsupported filesystem entry: ${path}`);
     }
     const info = await lstat(path);
+    const bundlePath = relative(root, path).split(sep).join("/");
+    entries.push({
+      path: bundlePath,
+      bytes: info.size
+    });
+  }
+  return entries;
+}
+
+async function hashBundleEntries(root, entries) {
+  const hashed = [];
+  for (const entry of entries) {
+    const metadata = await hashFile(join(root, ...entry.path.split("/")));
+    hashed.push({
+      ...entry,
+      bytes: metadata.bytes,
+      sha256: metadata.sha256
+    });
+  }
+  return hashed;
+}
+
+export function planBundlePublication(entries, bundleName) {
+  const ordered = entries.toSorted((left, right) =>
+    left.path.localeCompare(right.path));
+  try {
+    assertBundleEntriesWithinLimits(ordered);
+    assignArchivePaths(ordered, bundleName);
+    return { omissions: [] };
+  } catch (error) {
+    if (!isBundlePublicationLimitError(error)) {
+      throw error;
+    }
+  }
+
+  const omissions = ordered
+    .filter((entry) => isRawNodeTracePublicationPath(entry.path))
+    .map((entry) => ({
+      path: entry.path,
+      bytes: entry.bytes,
+      sha256: entry.sha256,
+      reason: RAW_NODE_TRACE_EXCLUSION_REASON
+    }));
+  if (omissions.length === 0) {
+    throw bundlePublicationLimitError(ordered.at(-1)?.path ?? bundleName);
+  }
+
+  const omittedPaths = new Set(omissions.map((entry) => entry.path));
+  const retained = ordered.filter((entry) => !omittedPaths.has(entry.path));
+  assertBundleEntriesWithinLimits(retained);
+  assignArchivePaths(retained, bundleName);
+  return { omissions };
+}
+
+function assertBundleEntriesWithinLimits(entries) {
+  const budget = {
+    entries: 0,
+    declaredBytes: 0,
+    unpackedBytes: 1024
+  };
+  for (const entry of entries) {
     budget.entries += 1;
-    budget.declaredBytes += info.size;
-    budget.unpackedBytes += 512 + Math.ceil(info.size / 512) * 512;
+    budget.declaredBytes += entry.bytes;
+    budget.unpackedBytes += 512 + Math.ceil(entry.bytes / 512) * 512;
     if (
       budget.entries > MAX_BUNDLE_ENTRIES ||
       budget.declaredBytes > MAX_BUNDLE_DECLARED_BYTES ||
       budget.unpackedBytes > MAX_BUNDLE_UNPACKED_BYTES
     ) {
-      throw new Error(`report bundle content exceeds the publication size limit: ${path}`);
+      throw bundlePublicationLimitError(entry.path);
     }
-    const metadata = await hashFile(path);
-    const bundlePath = relative(root, path).split(sep).join("/");
-    entries.push({
-      path: bundlePath,
+  }
+}
+
+async function rawNodeTraceEntries(stage) {
+  const entries = await listFiles(stage, stage);
+  return hashPublicationOmissions(
+    stage,
+    entries
+    .filter((entry) => isRawNodeTracePublicationPath(entry.path))
+    .map((entry) => ({
+      path: entry.path,
+      bytes: entry.bytes,
+      reason: RAW_NODE_TRACE_EXCLUSION_REASON
+    }))
+  );
+}
+
+async function hashPublicationOmissions(stage, omissions) {
+  const hashed = [];
+  for (const omission of omissions) {
+    const metadata = await hashFile(
+      join(stage, ...omission.path.split("/"))
+    );
+    hashed.push({
+      ...omission,
       bytes: metadata.bytes,
       sha256: metadata.sha256
     });
   }
-  return entries;
+  return hashed;
+}
+
+async function removePublicationOmissions(stage, omissions) {
+  for (const omission of omissions) {
+    if (!isRawNodeTracePublicationPath(omission.path)) {
+      throw new Error(`unsupported publication omission: ${omission.path}`);
+    }
+    await rm(join(stage, ...omission.path.split("/")));
+  }
+}
+
+function isRawNodeTracePublicationPath(path) {
+  return /^artifacts\/node-profiles\/node-trace-[^/]+\.(?:json|log)$/.test(path);
+}
+
+function summarizePublicationOmissions(omissions) {
+  return {
+    fileCount: omissions.length,
+    totalBytes: omissions.reduce((sum, entry) => sum + entry.bytes, 0)
+  };
+}
+
+function bundlePublicationLimitError(path) {
+  const error = new Error(
+    `report bundle content exceeds the publication size limit: ${path}`
+  );
+  error.code = BUNDLE_PUBLICATION_LIMIT_ERROR;
+  return error;
+}
+
+function isBundlePublicationLimitError(error) {
+  return error?.code === BUNDLE_PUBLICATION_LIMIT_ERROR;
 }
 
 async function writeUstarArchive(stage, bundleName, destination) {

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -480,7 +480,9 @@ async function removePublicationOmissions(stage, omissions) {
 }
 
 function isRawNodeTracePublicationPath(path) {
-  return /^artifacts\/node-profiles\/node-trace-[^/]+\.(?:json|log)$/.test(path);
+  // Run artifacts group each scenario beneath artifacts/<run>/ before the
+  // node-profiles directory; direct roots remain valid for focused callers.
+  return /^artifacts\/(?:[^/]+\/)*node-profiles\/node-trace-[^/]+\.(?:json|log)$/.test(path);
 }
 
 function summarizePublicationOmissions(omissions) {

--- a/src/reporting/render-bundle.mjs
+++ b/src/reporting/render-bundle.mjs
@@ -26,6 +26,13 @@ export function renderBundleReceipt(receipt, flags = {}, env = process.env, stre
     ["size",    formatBytes(receipt.bytes)],
     ["files",   String(receipt.artifactIndex?.fileCount ?? receipt.included?.length ?? 0)],
   ];
+  const omitted = receipt.publicationOmissions;
+  if ((omitted?.fileCount ?? 0) > 0) {
+    rows.push([
+      "omitted",
+      `${omitted.fileCount} file${omitted.fileCount === 1 ? "" : "s"}, ${formatBytes(omitted.totalBytes)}`
+    ]);
+  }
 
   for (const [label, value] of rows) {
     if (!value) continue;

--- a/src/run/command-executor.mjs
+++ b/src/run/command-executor.mjs
@@ -61,7 +61,7 @@ async function runCommandWithContext(command, context, envName, artifactDir, pha
     timeoutMs: context.timeoutMs,
     env: {
       ...(context.commandEnv ?? {}),
-      ...diagnosticsEnv(context, envName, artifactDir),
+      ...buildDiagnosticsCommandEnv(context, envName, artifactDir, measurementScope),
       ...networkFrontageCommandEnv(context),
       ...(authPolicy?.commandEnv ?? {})
     },
@@ -179,7 +179,7 @@ function networkFrontageBlockedResult(command, allocation, stderr, phase) {
   return result;
 }
 
-function diagnosticsEnv(context, envName, artifactDir) {
+export function buildDiagnosticsCommandEnv(context, envName, artifactDir, measurementScope) {
   if (context.openclawDiagnostics === false) {
     return {};
   }
@@ -193,7 +193,7 @@ function diagnosticsEnv(context, envName, artifactDir) {
     OPENCLAW_DIAGNOSTICS_EVENT_LOOP: "1"
   };
 
-  if (context.nodeProfile === true) {
+  if (context.nodeProfile === true && measurementScope === "product") {
     const profileDir = artifactDirs.nodeProfiles;
     env.KOVA_NODE_PROFILE_DIR = profileDir;
     env.NODE_OPTIONS = mergeNodeOptions(process.env.NODE_OPTIONS, [

--- a/src/run/command-executor.mjs
+++ b/src/run/command-executor.mjs
@@ -61,7 +61,7 @@ async function runCommandWithContext(command, context, envName, artifactDir, pha
     timeoutMs: context.timeoutMs,
     env: {
       ...(context.commandEnv ?? {}),
-      ...buildDiagnosticsCommandEnv(context, envName, artifactDir, measurementScope),
+      ...buildDiagnosticsCommandEnv(context, envName, artifactDir, measurementScope, command),
       ...networkFrontageCommandEnv(context),
       ...(authPolicy?.commandEnv ?? {})
     },
@@ -179,7 +179,13 @@ function networkFrontageBlockedResult(command, allocation, stderr, phase) {
   return result;
 }
 
-export function buildDiagnosticsCommandEnv(context, envName, artifactDir, measurementScope) {
+export function buildDiagnosticsCommandEnv(
+  context,
+  envName,
+  artifactDir,
+  measurementScope,
+  command = ""
+) {
   if (context.openclawDiagnostics === false) {
     return {};
   }
@@ -193,7 +199,11 @@ export function buildDiagnosticsCommandEnv(context, envName, artifactDir, measur
     OPENCLAW_DIAGNOSTICS_EVENT_LOOP: "1"
   };
 
-  if (context.nodeProfile === true && measurementScope === "product") {
+  if (
+    context.nodeProfile === true &&
+    measurementScope === "product" &&
+    !startsPersistentService(command)
+  ) {
     const profileDir = artifactDirs.nodeProfiles;
     env.KOVA_NODE_PROFILE_DIR = profileDir;
     env.NODE_OPTIONS = mergeNodeOptions(process.env.NODE_OPTIONS, [
@@ -212,6 +222,12 @@ export function buildDiagnosticsCommandEnv(context, envName, artifactDir, measur
   }
 
   return env;
+}
+
+function startsPersistentService(command) {
+  // Service lifecycle commands can propagate NODE_OPTIONS into the managed
+  // gateway, turning bounded command profiles into unbounded daemon traces.
+  return /\bocm\s+service\s+(?:install|start|restart)\b/.test(String(command ?? ""));
 }
 
 function mergeNodeOptions(existing, additions) {

--- a/src/run/command-executor.mjs
+++ b/src/run/command-executor.mjs
@@ -227,7 +227,12 @@ export function buildDiagnosticsCommandEnv(
 function startsPersistentService(command) {
   // Service lifecycle commands can propagate NODE_OPTIONS into the managed
   // gateway, turning bounded command profiles into unbounded daemon traces.
-  return /\bocm\s+service\s+(?:install|start|restart)\b/.test(String(command ?? ""));
+  const text = String(command ?? "");
+  return /\bocm\s+service\s+(?:install|start|restart)\b/.test(text) ||
+    (
+      /\bocm\s+start\b/.test(text) &&
+      !/(?:^|\s)--no-service(?:\s|$)/.test(text)
+    );
 }
 
 function mergeNodeOptions(existing, additions) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -7162,7 +7162,7 @@ async function reportPublicationCheck(tmp) {
       )
     );
     const rawTraceEntries = [
-      syntheticEntry("artifacts/node-profiles/node-trace-100.json"),
+      syntheticEntry("artifacts/scenario-run/node-profiles/node-trace-100.json"),
       syntheticEntry("artifacts/node-profiles/node-trace-200.log")
     ];
     const similarlyNamedEntries = [
@@ -7308,7 +7308,10 @@ async function reportPublicationCheck(tmp) {
     }
     assertEqual(
       omissionIndex.entries.some(
-        (entry) => /^artifacts\/node-profiles\/node-trace-[^/]+\.(?:json|log)$/.test(entry.path)
+        (entry) =>
+          /^artifacts\/(?:[^/]+\/)*node-profiles\/node-trace-[^/]+\.(?:json|log)$/.test(
+            entry.path
+          )
       ),
       false,
       "publication omits no arbitrary raw trace subset"

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -62,7 +62,11 @@ import {
   validateChannelWorkflowCaseCatalogShape,
   validateChannelWorkflowCaseInventoryReferences
 } from "./registries/channel-workflow-cases.mjs";
-import { runAuthCommand, runScenarioCommand } from "./run/command-executor.mjs";
+import {
+  buildDiagnosticsCommandEnv,
+  runAuthCommand,
+  runScenarioCommand
+} from "./run/command-executor.mjs";
 import { runEntries } from "./run/engine.mjs";
 import { executeStateLifecycleSteps } from "./run/state-lifecycle.mjs";
 import { executeTargetSetup } from "./run/target-setup.mjs";
@@ -634,6 +638,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(ocmMissingResourceCheck());
     checks.push(await guardedTeardownStagesCheck());
     checks.push(measurementPhaseOwnershipCheck());
+    checks.push(diagnosticProfilerMeasurementScopeCheck(tmp));
     checks.push(envNameLengthCheck());
     checks.push(evaluationViolationHelpersCheck());
     checks.push(statusFoundationCheck());
@@ -14676,6 +14681,89 @@ function networkFrontageProductGuardCheck() {
       id: "network-frontage-product-guard",
       status: "FAIL",
       command: "verify network frontage guard applies only to product commands",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+function diagnosticProfilerMeasurementScopeCheck(tmp) {
+  try {
+    const context = {
+      runId: "self-check-profile-scope",
+      nodeProfile: true
+    };
+    const artifactDir = join(tmp, "diagnostic-profile-scope");
+    const product = buildDiagnosticsCommandEnv(
+      context,
+      "profile-product",
+      artifactDir,
+      "product"
+    );
+    const harness = buildDiagnosticsCommandEnv(
+      context,
+      "profile-harness",
+      artifactDir,
+      "harness"
+    );
+    const cleanup = buildDiagnosticsCommandEnv(
+      context,
+      "profile-cleanup",
+      artifactDir,
+      "cleanup"
+    );
+
+    assertEqual(
+      product.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH.endsWith("timeline.jsonl"),
+      true,
+      "product diagnostics keep timeline output"
+    );
+    assertEqual(
+      harness.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH.endsWith("timeline.jsonl"),
+      true,
+      "harness diagnostics keep timeline output"
+    );
+    assertEqual(
+      cleanup.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH.endsWith("timeline.jsonl"),
+      true,
+      "cleanup diagnostics keep timeline output"
+    );
+    assertEqual(
+      product.NODE_OPTIONS.includes("--cpu-prof") &&
+        product.NODE_OPTIONS.includes("--heap-prof") &&
+        product.NODE_OPTIONS.includes("node.async_hooks"),
+      true,
+      "product diagnostics enable node profilers"
+    );
+    assertEqual(
+      typeof product.KOVA_NODE_PROFILE_DIR,
+      "string",
+      "product diagnostics expose node profile directory"
+    );
+    assertEqual(harness.NODE_OPTIONS, undefined, "harness diagnostics omit node profilers");
+    assertEqual(
+      harness.KOVA_NODE_PROFILE_DIR,
+      undefined,
+      "harness diagnostics omit node profile directory"
+    );
+    assertEqual(cleanup.NODE_OPTIONS, undefined, "cleanup diagnostics omit node profilers");
+    assertEqual(
+      cleanup.KOVA_NODE_PROFILE_DIR,
+      undefined,
+      "cleanup diagnostics omit node profile directory"
+    );
+
+    return {
+      id: "diagnostic-profiler-measurement-scope",
+      status: "PASS",
+      command: "verify node profilers apply only to product measurement phases",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "diagnostic-profiler-measurement-scope",
+      status: "FAIL",
+      command: "verify node profilers apply only to product measurement phases",
       durationMs: 0,
       message: error.message
     };

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -158,10 +158,15 @@ import { compareReports, renderCompareSummary } from "./reporting/compare.mjs";
 import {
   bundleReport,
   pathIsAtOrBelow,
+  planBundlePublication,
   publishBundlePair,
   retainedArtifactTreeDigest,
   retainGateArtifacts
 } from "./reporting/artifacts.mjs";
+import {
+  MAX_BUNDLE_DECLARED_BYTES,
+  MAX_BUNDLE_ENTRIES
+} from "./reporting/bundle-contract.mjs";
 import { pickAffectedScenarios, rollupScenarios, scenarioMetricRows } from "./reporting/compare-aggregate.mjs";
 import { renderCompareAssessment } from "./reporting/render-compare.mjs";
 import { renderAssessment } from "./reporting/render-assessment.mjs";
@@ -7144,6 +7149,183 @@ async function reportPublicationCheck(tmp) {
         "symlink-aliased artifact root cannot be used as bundle output"
       );
     }
+    const syntheticEntry = (path, bytes = 0) => ({
+      path,
+      bytes,
+      sha256: "0".repeat(64)
+    });
+    const mandatoryEntryCount = MAX_BUNDLE_ENTRIES - 2;
+    const mandatoryEntries = Array.from(
+      { length: mandatoryEntryCount },
+      (_, index) => syntheticEntry(
+        `artifacts/mandatory/file-${String(index).padStart(5, "0")}.txt`
+      )
+    );
+    const rawTraceEntries = [
+      syntheticEntry("artifacts/node-profiles/node-trace-100.json"),
+      syntheticEntry("artifacts/node-profiles/node-trace-200.log")
+    ];
+    const similarlyNamedEntries = [
+      syntheticEntry("artifacts/node-profiles/node-trace-summary.txt"),
+      syntheticEntry("artifacts/other/node-trace-300.json")
+    ];
+    const plannedOmissions = planBundlePublication(
+      [...mandatoryEntries, ...rawTraceEntries, ...similarlyNamedEntries],
+      `${publishedReport.runId}-bundle`
+    ).omissions;
+    assertEqual(plannedOmissions.length, 2, "bundle planning omits the full raw trace class");
+    assertEqual(
+      plannedOmissions.every(
+        (entry) => entry.reason === "raw-node-trace-excluded-for-publication-limit"
+      ),
+      true,
+      "bundle planning records the publication-limit reason"
+    );
+    assertEqual(
+      planBundlePublication(
+        [...rawTraceEntries, ...similarlyNamedEntries],
+        `${publishedReport.runId}-bundle`
+      ).omissions.length,
+      0,
+      "bundle planning retains raw traces while the bundle fits"
+    );
+    let mandatoryOverflowRejected = false;
+    try {
+      planBundlePublication(
+        [
+          ...Array.from(
+            { length: MAX_BUNDLE_ENTRIES + 1 },
+            (_, index) => syntheticEntry(
+              `artifacts/mandatory-overflow/file-${String(index).padStart(5, "0")}.txt`
+            )
+          ),
+          ...rawTraceEntries
+        ],
+        `${publishedReport.runId}-bundle`
+      );
+    } catch (error) {
+      mandatoryOverflowRejected = /publication size limit/.test(error.message);
+    }
+    assertEqual(
+      mandatoryOverflowRejected,
+      true,
+      "bundle planning fails closed when mandatory artifacts remain over limit"
+    );
+
+    const omissionRunId = createRunId();
+    const omissionOutputPaths = buildReportOutputPaths(publicationRoot, omissionRunId);
+    await writeReportOutputs(publicationRoot, {
+      ...report,
+      runId: omissionRunId,
+      outputPaths: omissionOutputPaths
+    });
+    const omissionArtifactsDir = join(tmp, "publication-omission-artifacts");
+    const omissionArtifactRoot = join(omissionArtifactsDir, omissionRunId);
+    const omissionProfileRoot = join(omissionArtifactRoot, "node-profiles");
+    await mkdir(omissionProfileRoot, { recursive: true });
+    await mkdir(join(omissionArtifactRoot, "other"), { recursive: true });
+    const rawTraceJsonPath = join(omissionProfileRoot, "node-trace-100.json");
+    const rawTraceLogPath = join(omissionProfileRoot, "node-trace-200.log");
+    await writeFile(rawTraceJsonPath, "");
+    await truncate(rawTraceJsonPath, MAX_BUNDLE_DECLARED_BYTES);
+    await writeFile(rawTraceLogPath, "raw trace log\n");
+    await writeFile(join(omissionProfileRoot, "CPU.100.cpuprofile"), "cpu profile\n");
+    await writeFile(join(omissionProfileRoot, "Heap.100.heapprofile"), "heap profile\n");
+    await writeFile(join(omissionProfileRoot, "node-trace-summary.txt"), "summary\n");
+    await writeFile(
+      join(omissionArtifactRoot, "other", "node-trace-300.json"),
+      "unrelated trace\n"
+    );
+    const omissionBundle = await bundleReport(omissionOutputPaths.json, {
+      outputDir: join(publicationRoot, "omission-bundles"),
+      artifactsDir: omissionArtifactsDir
+    });
+    assertEqual(
+      (await stat(rawTraceJsonPath)).size,
+      MAX_BUNDLE_DECLARED_BYTES,
+      "bundle omission leaves the source trace untouched"
+    );
+    assertEqual(
+      await fileExists(rawTraceLogPath),
+      true,
+      "bundle omission leaves every source trace untouched"
+    );
+    assertEqual(
+      omissionBundle.publicationOmissions?.fileCount,
+      2,
+      "bundle receipt summarizes omitted raw traces"
+    );
+    assertEqual(
+      omissionBundle.publicationOmissions?.totalBytes,
+      MAX_BUNDLE_DECLARED_BYTES + Buffer.byteLength("raw trace log\n"),
+      "bundle receipt summarizes omitted trace bytes"
+    );
+    const omissionArchiveEntries = readUstarEntries(
+      await readFile(omissionBundle.outputPath)
+    );
+    const omissionIndex = JSON.parse(
+      omissionArchiveEntries.find(
+        (entry) => entry.name === `${omissionRunId}-bundle/artifact-index.json`
+      ).content.toString("utf8")
+    );
+    const omissionManifest = JSON.parse(
+      omissionArchiveEntries.find(
+        (entry) => entry.name === `${omissionRunId}-bundle/manifest.json`
+      ).content.toString("utf8")
+    );
+    assertEqual(
+      omissionIndex.publicationOmissions?.fileCount,
+      2,
+      "artifact index summarizes omitted raw traces"
+    );
+    assertEqual(
+      omissionIndex.publicationOmissions?.entries.every(
+        (entry) =>
+          typeof entry.path === "string" &&
+          typeof entry.bytes === "number" &&
+          /^[a-f0-9]{64}$/.test(entry.sha256) &&
+          entry.reason === "raw-node-trace-excluded-for-publication-limit"
+      ),
+      true,
+      "artifact index records every omission with integrity metadata"
+    );
+    assertEqual(
+      omissionManifest.publicationOmissions?.fileCount,
+      2,
+      "bundle manifest summarizes omitted raw traces"
+    );
+    for (const retainedPath of [
+      "artifacts/node-profiles/CPU.100.cpuprofile",
+      "artifacts/node-profiles/Heap.100.heapprofile",
+      "artifacts/node-profiles/node-trace-summary.txt",
+      "artifacts/other/node-trace-300.json"
+    ]) {
+      assertEqual(
+        omissionIndex.entries.some((entry) => entry.path === retainedPath),
+        true,
+        `publication keeps ${retainedPath}`
+      );
+    }
+    assertEqual(
+      omissionIndex.entries.some(
+        (entry) => /^artifacts\/node-profiles\/node-trace-[^/]+\.(?:json|log)$/.test(entry.path)
+      ),
+      false,
+      "publication omits no arbitrary raw trace subset"
+    );
+    const renderedOmissionReceipt = renderBundleReceipt(
+      omissionBundle,
+      { color: "never" },
+      process.env,
+      process.stdout
+    );
+    assertEqual(
+      renderedOmissionReceipt.includes("omitted") &&
+        renderedOmissionReceipt.includes("2 files"),
+      true,
+      "rendered bundle receipt summarizes publication omissions"
+    );
+
     const markerlessBackupPath = join(
       publicationRoot,
       `.${basename(outputPaths.json)}.kova-backup`
@@ -14715,6 +14897,20 @@ function diagnosticProfilerMeasurementScopeCheck(tmp) {
       "product",
       "ocm service restart profile-service"
     );
+    const gatewayStart = buildDiagnosticsCommandEnv(
+      context,
+      "profile-service",
+      artifactDir,
+      "product",
+      "ocm start profile-service"
+    );
+    const noServiceStart = buildDiagnosticsCommandEnv(
+      context,
+      "profile-product",
+      artifactDir,
+      "product",
+      "ocm start profile-product --no-service"
+    );
     const harness = buildDiagnosticsCommandEnv(
       context,
       "profile-harness",
@@ -14746,9 +14942,12 @@ function diagnosticProfilerMeasurementScopeCheck(tmp) {
     assertEqual(
       product.NODE_OPTIONS.includes("--cpu-prof") &&
         product.NODE_OPTIONS.includes("--heap-prof") &&
-        product.NODE_OPTIONS.includes("node.async_hooks"),
+        product.NODE_OPTIONS.includes("--trace-events-enabled") &&
+        product.NODE_OPTIONS.includes(
+          "--trace-event-categories=node.perf,node.async_hooks,v8"
+        ),
       true,
-      "product diagnostics enable node profilers"
+      "product diagnostics enable bounded node profilers"
     );
     assertEqual(
       typeof product.KOVA_NODE_PROFILE_DIR,
@@ -14784,6 +14983,22 @@ function diagnosticProfilerMeasurementScopeCheck(tmp) {
       serviceRestart.KOVA_NODE_PROFILE_DIR,
       undefined,
       "service restart diagnostics omit node profile directory"
+    );
+    assertEqual(gatewayStart.NODE_OPTIONS, undefined, "gateway start diagnostics omit node profilers");
+    assertEqual(
+      gatewayStart.KOVA_NODE_PROFILE_DIR,
+      undefined,
+      "gateway start diagnostics omit node profile directory"
+    );
+    assertEqual(
+      noServiceStart.NODE_OPTIONS.includes("--cpu-prof"),
+      true,
+      "no-service product start keeps node profilers"
+    );
+    assertEqual(
+      typeof noServiceStart.KOVA_NODE_PROFILE_DIR,
+      "string",
+      "no-service product start keeps node profile directory"
     );
     assertEqual(harness.NODE_OPTIONS, undefined, "harness diagnostics omit node profilers");
     assertEqual(

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -14698,7 +14698,22 @@ function diagnosticProfilerMeasurementScopeCheck(tmp) {
       context,
       "profile-product",
       artifactDir,
-      "product"
+      "product",
+      "ocm @profile-product -- models list"
+    );
+    const serviceStart = buildDiagnosticsCommandEnv(
+      context,
+      "profile-service",
+      artifactDir,
+      "product",
+      "ocm service install profile-service --json || ocm service start profile-service --json"
+    );
+    const serviceRestart = buildDiagnosticsCommandEnv(
+      context,
+      "profile-service",
+      artifactDir,
+      "product",
+      "ocm service restart profile-service"
     );
     const harness = buildDiagnosticsCommandEnv(
       context,
@@ -14739,6 +14754,36 @@ function diagnosticProfilerMeasurementScopeCheck(tmp) {
       typeof product.KOVA_NODE_PROFILE_DIR,
       "string",
       "product diagnostics expose node profile directory"
+    );
+    assertEqual(
+      serviceStart.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH.endsWith("timeline.jsonl"),
+      true,
+      "service start diagnostics keep timeline output"
+    );
+    assertEqual(
+      serviceRestart.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH.endsWith("timeline.jsonl"),
+      true,
+      "service restart diagnostics keep timeline output"
+    );
+    assertEqual(
+      serviceStart.NODE_OPTIONS,
+      undefined,
+      "service start diagnostics omit node profilers"
+    );
+    assertEqual(
+      serviceStart.KOVA_NODE_PROFILE_DIR,
+      undefined,
+      "service start diagnostics omit node profile directory"
+    );
+    assertEqual(
+      serviceRestart.NODE_OPTIONS,
+      undefined,
+      "service restart diagnostics omit node profilers"
+    );
+    assertEqual(
+      serviceRestart.KOVA_NODE_PROFILE_DIR,
+      undefined,
+      "service restart diagnostics omit node profile directory"
     );
     assertEqual(harness.NODE_OPTIONS, undefined, "harness diagnostics omit node profilers");
     assertEqual(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where deep OpenClaw profiling could exceed the evidence-bundle size limit because heavyweight Node profilers were attached to harness, cleanup, and persistent service commands, while oversized publication fallback did not recognize scenario-nested raw trace paths.

## Why This Change Was Made

Kova now:

- keeps lightweight timeline diagnostics on every phase;
- attaches CPU, heap, and async-hooks profiling only to bounded product commands;
- excludes persistent service launches from Node profiling;
- omits the complete raw Node trace class only when required by publication limits, while retaining source artifacts and recording every omission with size and SHA-256.

## User Impact

Deep OpenClaw profiling now publishes a bounded evidence bundle without losing the retained product CPU, heap, timeline, provider, process, and resource evidence needed for diagnosis.

## Evidence

- Exact Kova head: `afaee01fd6d72c505410d2a775ec2b2494082008`.
- Kova CI: Ubuntu and macOS passed: https://github.com/openclaw/Kova/actions/runs/30702755987
- Full self-check: `npm run check` passed `274/274`.
- Syntax checks, `git diff --check`, and autoreview passed; final local patch review confidence was `0.99`.
- Release-shaped OpenClaw deep-profile proof against OpenClaw `8b52c585055614102ac1525de2321f1b3906968b`: https://github.com/openclaw/openclaw/actions/runs/30702891557
- The deep-profile lane and artifact-only report verification both passed.
- Published bundle receipt:
  - final archive: `2,786,342` bytes;
  - retained artifact index: `112` files / `43,172,524` bytes before compression;
  - omitted only `17` complete nested `node-trace-*.json` files / `515,662,014` bytes;
  - every omission records path, byte count, SHA-256, and `raw-node-trace-excluded-for-publication-limit`;
  - retained product artifacts include CPU profiles, heap profiles, OpenClaw timelines, provider evidence, process snapshots, and resource samples.

## Merge Gate

Do not merge until the durable exact-head ClawSweeper review has no unresolved `Before merge`, finding, security, or rank-up blocking item.
