### PR TITLE
fix(release): use PR and exact-SHA gates

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -18,7 +18,21 @@ concurrency:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
-    if: ${{ !(endsWith(github.actor, '[bot]') && (github.event.action == 'labeled' || github.event.action == 'unlabeled')) }}
+    if: >-
+      ${{
+        !(endsWith(github.actor, '[bot]') && (github.event.action == 'labeled' || github.event.action == 'unlabeled')) &&
+        (
+          github.event_name != 'issue_comment' ||
+          contains(github.event.comment.body, '@clawsweeper') ||
+          contains(github.event.comment.body, '@openclaw-clawsweeper') ||
+          contains(github.event.comment.body, '/clawsweeper') ||
+          contains(github.event.comment.body, '/review') ||
+          contains(github.event.comment.body, '/autoclose') ||
+          contains(github.event.comment.body, '/automerge') ||
+          contains(github.event.comment.body, '/auto-merge') ||
+          contains(github.event.comment.body, '/auto merge')
+        )
+      }}
     env:
       HAS_CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY != '' }}
       CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
@@ -27,17 +41,6 @@ jobs:
       - name: Debounce bursty metadata events
         if: ${{ github.event.action == 'labeled' || github.event.action == 'unlabeled' }}
         run: sleep 20
-
-      - name: Create ClawSweeper dispatch token
-        id: token
-        if: ${{ env.HAS_CLAWSWEEPER_APP_PRIVATE_KEY == 'true' }}
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: openclaw
-          repositories: clawsweeper
-          permission-contents: write
 
       - name: Pre-filter ClawSweeper comment
         id: comment_filter
@@ -51,6 +54,24 @@ jobs:
           else
             echo "is_command=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Create ClawSweeper dispatch token
+        id: token
+        if: >-
+          ${{
+            env.HAS_CLAWSWEEPER_APP_PRIVATE_KEY == 'true' &&
+            (
+              github.event_name != 'issue_comment' ||
+              steps.comment_filter.outputs.is_command == 'true'
+            )
+          }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: clawsweeper
+          permission-contents: write
 
       - name: Create target comment token
         id: target_token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,15 @@ jobs:
     name: Build release archive
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Verify release ref
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           package_version="$(node -p 'require("./package.json").version')"
@@ -27,6 +30,23 @@ jobs:
             -c gpg.ssh.allowedSignersFile=.github/release-allowed-signers \
             verify-tag "${GITHUB_REF_NAME}"
           git merge-base --is-ancestor "${GITHUB_SHA}" origin/main
+          ci_runs="$(
+            gh run list \
+              --workflow ci.yml \
+              --branch main \
+              --event push \
+              --commit "$GITHUB_SHA" \
+              --limit 20 \
+              --json headSha,status,conclusion,databaseId
+          )"
+          CI_RUNS_JSON="$ci_runs" node <<'NODE'
+          const runs = JSON.parse(process.env.CI_RUNS_JSON || "[]");
+          const run = runs.find((candidate) => candidate.headSha === process.env.GITHUB_SHA);
+          if (!run || run.status !== "completed" || run.conclusion !== "success") {
+            throw new Error(`exact-SHA main CI has not passed for ${process.env.GITHUB_SHA}`);
+          }
+          console.log(`verified exact-SHA CI run ${run.databaseId}`);
+          NODE
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
@@ -37,8 +57,6 @@ jobs:
           "$HOME/.local/bin/ocm" --version
       - name: Install dependencies
         run: npm ci
-      - name: Run checks
-        run: npm run check:full
       - name: Package release archive
         run: ./scripts/package-release.sh --output-dir ./dist
       - name: Smoke install archive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.
 - Calibrate the bundled-plugin restart overlap RSS budget against repeated OpenClaw main release runs.

--- a/scripts/check-release-contracts.sh
+++ b/scripts/check-release-contracts.sh
@@ -4,25 +4,25 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"
 tmp="$(mktemp -d)"
-agent_pid=""
 cleanup() {
-  if [[ -n "$agent_pid" ]]; then
-    kill "$agent_pid" >/dev/null 2>&1 || true
-  fi
   rm -rf "$tmp"
 }
 trap cleanup EXIT
 
 release_workflow="${repo_root}/.github/workflows/release.yml"
+tag_fetch_pattern="\"refs/tags/\${GITHUB_REF_NAME}:refs/tags/\${GITHUB_REF_NAME}\""
+tag_commit_pattern="test \"\$(git rev-parse \"\${GITHUB_REF_NAME}^{commit}\")\" = \"\${GITHUB_SHA}\""
+tag_verify_pattern="verify-tag \"\${GITHUB_REF_NAME}\""
+ci_commit_pattern="--commit \"\$GITHUB_SHA\""
 tag_fetch_line="$(
-  grep -nF '"refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"' "$release_workflow" |
+  grep -nF "$tag_fetch_pattern" "$release_workflow" |
     cut -d: -f1
 )"
 tag_commit_line="$(
-  grep -nF 'test "$(git rev-parse "${GITHUB_REF_NAME}^{commit}")" = "${GITHUB_SHA}"' "$release_workflow" |
+  grep -nF "$tag_commit_pattern" "$release_workflow" |
     cut -d: -f1
 )"
-tag_verify_line="$(grep -nF 'verify-tag "${GITHUB_REF_NAME}"' "$release_workflow" | cut -d: -f1)"
+tag_verify_line="$(grep -nF "$tag_verify_pattern" "$release_workflow" | cut -d: -f1)"
 if [[ -z "$tag_fetch_line" ||
   -z "$tag_commit_line" ||
   -z "$tag_verify_line" ||
@@ -31,9 +31,92 @@ if [[ -z "$tag_fetch_line" ||
   echo "error: release workflow must bind the fetched annotated tag to the event commit before verifying it" >&2
   exit 1
 fi
+if grep -qF 'npm run check:full' "$release_workflow"; then
+  echo "error: tag builds must not repeat the exact-SHA CI check suite" >&2
+  exit 1
+fi
+if ! grep -qF 'gh run list' "$release_workflow" ||
+  ! grep -qF -- "$ci_commit_pattern" "$release_workflow"; then
+  echo "error: tag builds must verify exact-SHA main CI before packaging" >&2
+  exit 1
+fi
+
+clawsweeper_workflow="${repo_root}/.github/workflows/clawsweeper-dispatch.yml"
+comment_filter_line="$(grep -nF -- '- name: Pre-filter ClawSweeper comment' "$clawsweeper_workflow" | cut -d: -f1)"
+dispatch_token_line="$(grep -nF -- '- name: Create ClawSweeper dispatch token' "$clawsweeper_workflow" | cut -d: -f1)"
+if [[ -z "$comment_filter_line" ||
+  -z "$dispatch_token_line" ||
+  "$comment_filter_line" -ge "$dispatch_token_line" ]]; then
+  echo "error: ClawSweeper comments must be filtered before dispatch token creation" >&2
+  exit 1
+fi
+if ! sed -n "${dispatch_token_line},$((dispatch_token_line + 12))p" "$clawsweeper_workflow" |
+  grep -qF "steps.comment_filter.outputs.is_command == 'true'"; then
+  echo "error: ClawSweeper dispatch token must be gated by the comment filter" >&2
+  exit 1
+fi
+if ! grep -qF "contains(github.event.comment.body, '/clawsweeper')" "$clawsweeper_workflow"; then
+  echo "error: ordinary issue comments must skip the ClawSweeper dispatch job" >&2
+  exit 1
+fi
 
 ssh-keygen -q -t ed25519 -N "" -f "${tmp}/release-signing-key"
 release_public_key="$(cat "${tmp}/release-signing-key.pub")"
+
+mock_gh="${tmp}/mock-gh"
+cat >"$mock_gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${1:-}"
+subcommand="${2:-}"
+shift 2
+
+case "${command_name}:${subcommand}" in
+  pr:view)
+    [[ -s "$KOVA_MOCK_PR_JSON" ]] || exit 1
+    cat "$KOVA_MOCK_PR_JSON"
+    ;;
+  pr:create)
+    if [[ "${KOVA_MOCK_PR_CREATE_FAIL:-0}" == "1" ]]; then
+      exit 1
+    fi
+    body_file=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --body-file)
+          shift
+          body_file="${1:-}"
+          ;;
+      esac
+      shift
+    done
+    [[ -n "$body_file" && -s "$body_file" ]]
+    cp "$body_file" "$KOVA_MOCK_PR_BODY"
+    PR_BODY="$(cat "$body_file")" node - <<'NODE'
+const fs = require("node:fs");
+fs.writeFileSync(
+  process.env.KOVA_MOCK_PR_JSON,
+  JSON.stringify({
+    url: "https://github.com/openclaw/Kova/pull/999",
+    state: "OPEN",
+    baseRefName: "main",
+    body: process.env.PR_BODY,
+  }),
+);
+NODE
+    printf '%s\n' "https://github.com/openclaw/Kova/pull/999"
+    ;;
+  run:list)
+    cat "$KOVA_MOCK_RUNS_JSON"
+    ;;
+  *)
+    echo "unexpected mock gh command: ${command_name} ${subcommand}" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$mock_gh"
 
 make_repo() {
   local name="$1"
@@ -44,20 +127,13 @@ make_repo() {
   git init --bare --quiet --initial-branch=main "$remote"
   git init --quiet --initial-branch=main "$repo"
   mkdir -p "${repo}/.github" "${repo}/scripts"
-  printf 'release@openclaw.invalid namespaces="git" %s\n' "$release_public_key" > "${repo}/.github/release-allowed-signers"
+  printf 'release@openclaw.invalid namespaces="git" %s\n' "$release_public_key" >"${repo}/.github/release-allowed-signers"
   cp "${repo_root}/package.json" "${repo}/package.json"
   cp "${repo_root}/package-lock.json" "${repo}/package-lock.json"
   cp "${script_dir}/release.sh" "${repo}/scripts/release.sh"
   cp "${script_dir}/update-version.sh" "${repo}/scripts/update-version.sh"
   cp "${script_dir}/validate-version.mjs" "${repo}/scripts/validate-version.mjs"
   cp "${script_dir}/validate-version-metadata.mjs" "${repo}/scripts/validate-version-metadata.mjs"
-  cat > "${repo}/scripts/package-release.sh" <<'EOF'
-#!/bin/sh
-set -eu
-if [ -n "${KOVA_RELEASE_ARCHIVE_PROOF:-}" ]; then
-  git rev-parse HEAD > "$KOVA_RELEASE_ARCHIVE_PROOF"
-fi
-EOF
   chmod +x "${repo}/scripts/"*
   git -C "$repo" config user.name "Kova release contract"
   git -C "$repo" config user.email "kova-release-contract@example.invalid"
@@ -68,7 +144,58 @@ EOF
   git -C "$repo" commit --quiet -m "test: initial release state"
   git -C "$repo" remote add origin "$remote"
   git -C "$repo" push --quiet -u origin main
+  : >"${root}/pr.json"
+  printf '[]\n' >"${root}/runs.json"
   printf '%s\n' "$repo"
+}
+
+run_release() {
+  local repo="$1"
+  local version="$2"
+  local root
+  shift 2
+  root="$(dirname "$repo")"
+  (
+    cd "$repo"
+    KOVA_GH_BIN="$mock_gh" \
+      KOVA_GITHUB_REPOSITORY="openclaw/Kova" \
+      KOVA_MOCK_PR_JSON="${root}/pr.json" \
+      KOVA_MOCK_PR_BODY="${root}/pr-body.md" \
+      KOVA_MOCK_RUNS_JSON="${root}/runs.json" \
+      scripts/release.sh "$version" "$@"
+  )
+}
+
+record_successful_ci() {
+  local repo="$1"
+  local root head_sha
+  root="$(dirname "$repo")"
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+  node - "${root}/runs.json" "$head_sha" <<'NODE'
+const fs = require("node:fs");
+const [path, headSha] = process.argv.slice(2);
+fs.writeFileSync(
+  path,
+  `${JSON.stringify([{
+    databaseId: 12345,
+    headSha,
+    status: "completed",
+    conclusion: "success",
+    url: "https://github.com/openclaw/Kova/actions/runs/12345",
+  }])}\n`,
+);
+NODE
+}
+
+squash_release_to_main() {
+  local repo="$1"
+  local version="$2"
+  local release_branch="release/v${version}"
+  git -C "$repo" switch --quiet main
+  git -C "$repo" reset --quiet --hard origin/main
+  git -C "$repo" merge --quiet --squash "$release_branch"
+  git -C "$repo" commit --quiet -m "chore(release): bump version to ${version} (#999)"
+  git -C "$repo" push --quiet origin main
 }
 
 current_version="$(node -p 'require("./package.json").version')"
@@ -77,106 +204,87 @@ if [[ "$current_version" == "0.0.0-release-contract" ]]; then
 else
   test_version="0.0.0-release-contract"
 fi
+tag="v${test_version}"
+release_branch="release/${tag}"
 
 fresh_repo="$(make_repo fresh-release)"
-fresh_bin="${tmp}/fresh-release/bin"
-real_npm="$(command -v npm)"
-mkdir -p "$fresh_bin"
-cat > "${fresh_bin}/npm" <<'EOF'
-#!/bin/sh
-case "$1:$2" in
-  version:*)
-    exec "$KOVA_REAL_NPM" "$@"
-    ;;
-  run:check:full)
-    if [ -n "${KOVA_RELEASE_CHECK_COUNT:-}" ]; then
-      count=0
-      if [ -f "$KOVA_RELEASE_CHECK_COUNT" ]; then
-        count="$(cat "$KOVA_RELEASE_CHECK_COUNT")"
-      fi
-      printf '%s\n' "$((count + 1))" > "$KOVA_RELEASE_CHECK_COUNT"
-    fi
-    exit 0
-    ;;
-esac
-exec "$KOVA_REAL_NPM" "$@"
-EOF
-chmod +x "${fresh_bin}/npm"
-(
-  cd "$fresh_repo"
-  archive_proof="${tmp}/fresh-release-archive-head"
-  check_count="${tmp}/fresh-release-check-count"
-  PATH="${fresh_bin}:$PATH" KOVA_REAL_NPM="$real_npm" KOVA_RELEASE_ARCHIVE_PROOF="$archive_proof" KOVA_RELEASE_CHECK_COUNT="$check_count" scripts/release.sh "$test_version" >/dev/null
-  test "$(cat "$check_count")" = "1"
-  test "$(git diff-tree --no-commit-id --name-only -r HEAD | sort -u)" = $'package-lock.json\npackage.json'
-  test "$(node -p 'require("./package.json").version')" = "$test_version"
-  test "$(node -p 'require("./package-lock.json").version')" = "$test_version"
-  test "$(node -p 'require("./package-lock.json").packages[""].version')" = "$test_version"
-  test "$(cat "$archive_proof")" = "$(git rev-parse HEAD)"
-  test -z "$(git status --porcelain=v1)"
-  test "$(git rev-parse HEAD)" = "$(git ls-remote origin refs/heads/main | awk '{ print $1 }')"
-  test "$(git rev-parse HEAD)" = "$(git ls-remote origin "refs/tags/v${test_version}^{}" | awk '{ print $1 }')"
-  scripts/release.sh "$test_version" --skip-checks >/dev/null
-)
+fresh_root="$(dirname "$fresh_repo")"
+fresh_main="$(git -C "$fresh_repo" rev-parse HEAD)"
+run_release "$fresh_repo" "$test_version" >/dev/null
+test "$(git -C "$fresh_repo" branch --show-current)" = "$release_branch"
+test "$(git -C "$fresh_repo" ls-remote origin refs/heads/main | awk '{ print $1 }')" = "$fresh_main"
+test "$(git -C "$fresh_repo" ls-remote origin "refs/heads/${release_branch}" | awk '{ print $1 }')" = "$(git -C "$fresh_repo" rev-parse HEAD)"
+test -z "$(git -C "$fresh_repo" ls-remote origin "refs/tags/${tag}")"
+test "$(git -C "$fresh_repo" diff-tree --no-commit-id --name-only -r HEAD | sort -u)" = $'package-lock.json\npackage.json'
+grep -qF "Squash-merge it" "${fresh_root}/pr-body.md"
+run_release "$fresh_repo" "$test_version" >/dev/null
+test -z "$(git -C "$fresh_repo" status --porcelain=v1)"
 
-autokey_repo="$(make_repo auto-release-key)"
-autokey_home="${tmp}/auto-release-key/home"
-mkdir -p "${autokey_home}/.ssh"
-cp "${tmp}/release-signing-key" "${autokey_home}/.ssh/id_ed25519"
-cp "${tmp}/release-signing-key.pub" "${autokey_home}/.ssh/id_ed25519.pub"
-ssh-keygen -q -t ed25519 -N "" -f "${tmp}/unrelated-signing-key"
-git -C "$autokey_repo" config user.signingkey "${tmp}/unrelated-signing-key"
-(
-  cd "$autokey_repo"
-  HOME="$autokey_home" PATH="${fresh_bin}:$PATH" KOVA_REAL_NPM="$real_npm" \
-    scripts/release.sh "$test_version" --skip-checks >/dev/null
-  test "$(git rev-parse HEAD)" = "$(git ls-remote origin "refs/tags/v${test_version}^{}" | awk '{ print $1 }')"
-)
+squash_release_to_main "$fresh_repo" "$test_version"
+fresh_release_sha="$(git -C "$fresh_repo" rev-parse HEAD)"
+if missing_ci_output="$(run_release "$fresh_repo" "$test_version" 2>&1)"; then
+  echo "error: release tag unexpectedly passed without exact-SHA CI" >&2
+  exit 1
+fi
+grep -qF "no main-branch CI push run exists for exact commit ${fresh_release_sha}" <<<"$missing_ci_output"
+test -z "$(git -C "$fresh_repo" tag --list "$tag")"
 
-tildekey_repo="$(make_repo tilde-release-key)"
-git -C "$tildekey_repo" config user.signingkey "~/.ssh/id_ed25519"
-(
-  cd "$tildekey_repo"
-  HOME="$autokey_home" PATH="${fresh_bin}:$PATH" KOVA_REAL_NPM="$real_npm" \
-    scripts/release.sh "$test_version" --skip-checks >/dev/null
-  test "$(git rev-parse HEAD)" = "$(git ls-remote origin "refs/tags/v${test_version}^{}" | awk '{ print $1 }')"
-)
+record_successful_ci "$fresh_repo"
+run_release "$fresh_repo" "$test_version" >/dev/null
+test "$(git -C "$fresh_repo" rev-list -n1 "$tag")" = "$fresh_release_sha"
+test "$(git -C "$fresh_repo" ls-remote origin "refs/tags/${tag}^{}" | awk '{ print $1 }')" = "$fresh_release_sha"
+git -C "$fresh_repo" -c gpg.format=ssh \
+  -c gpg.ssh.allowedSignersFile="${fresh_repo}/.github/release-allowed-signers" \
+  verify-tag "$tag" >/dev/null
+git -C "$fresh_repo" tag -d "$tag" >/dev/null
+run_release "$fresh_repo" "$test_version" >/dev/null
+test "$(git -C "$fresh_repo" rev-list -n1 "$tag")" = "$fresh_release_sha"
 
-agentkey_repo="$(make_repo agent-release-key)"
-git -C "$agentkey_repo" config user.signingkey "key::${release_public_key}"
-agent_environment="$(ssh-agent -s)"
-eval "$agent_environment" >/dev/null
-agent_pid="$SSH_AGENT_PID"
-ssh-add "${tmp}/release-signing-key" >/dev/null
-(
-  cd "$agentkey_repo"
-  HOME="${tmp}/agent-release-key/home" PATH="${fresh_bin}:$PATH" KOVA_REAL_NPM="$real_npm" \
-    scripts/release.sh "$test_version" --skip-checks >/dev/null
-  test "$(git rev-parse HEAD)" = "$(git ls-remote origin "refs/tags/v${test_version}^{}" | awk '{ print $1 }')"
-)
-ssh-agent -k >/dev/null
-agent_pid=""
+stale_repo="$(make_repo stale-main)"
+git clone --quiet "$(dirname "$stale_repo")/remote.git" "${tmp}/stale-upstream"
+git -C "${tmp}/stale-upstream" config user.name "Kova upstream"
+git -C "${tmp}/stale-upstream" config user.email "kova-upstream@example.invalid"
+touch "${tmp}/stale-upstream/upstream-change"
+git -C "${tmp}/stale-upstream" add upstream-change
+git -C "${tmp}/stale-upstream" commit --quiet -m "test: advance remote"
+git -C "${tmp}/stale-upstream" push --quiet
+if stale_output="$(run_release "$stale_repo" "$test_version" 2>&1)"; then
+  echo "error: stale local main unexpectedly passed release validation" >&2
+  exit 1
+fi
+grep -qF "local main must exactly match origin/main" <<<"$stale_output"
+test "$(git -C "$stale_repo" branch --show-current)" = "main"
 
-prebumped_repo="$(make_repo prebumped-manifest)"
-(
-  cd "$prebumped_repo"
-  node - "$test_version" <<'NODE'
-  const fs = require("node:fs");
-  const path = "package.json";
-  const manifest = JSON.parse(fs.readFileSync(path, "utf8"));
-  manifest.version = process.argv[2];
-  fs.writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
-NODE
-  PATH="${fresh_bin}:$PATH" KOVA_REAL_NPM="$real_npm" scripts/release.sh "$test_version" --skip-checks >/dev/null
-  test "$(git diff-tree --no-commit-id --name-only -r HEAD | sort -u)" = $'package-lock.json\npackage.json'
-  test "$(node -p 'require("./package-lock.json").version')" = "$test_version"
-  test "$(node -p 'require("./package-lock.json").packages[""].version')" = "$test_version"
-  test -z "$(git status --porcelain=v1)"
-)
+wrong_base_repo="$(make_repo wrong-base-pr)"
+wrong_base_root="$(dirname "$wrong_base_repo")"
+printf '%s\n' '{"url":"https://github.com/openclaw/Kova/pull/998","state":"OPEN","baseRefName":"develop","body":"wrong base"}' >"${wrong_base_root}/pr.json"
+if wrong_base_output="$(run_release "$wrong_base_repo" "$test_version" 2>&1)"; then
+  echo "error: wrong-base release pull request unexpectedly passed" >&2
+  exit 1
+fi
+grep -qF "with base develop" <<<"$wrong_base_output"
+test -z "$(git -C "$wrong_base_repo" ls-remote origin "refs/tags/${tag}")"
 
-poisoned_lockfile_repo="$(make_repo poisoned-lockfile)"
-poisoned_lockfile_head="$(git -C "$poisoned_lockfile_repo" rev-parse HEAD)"
-node - "$poisoned_lockfile_repo" "$test_version" <<'NODE'
+failed_pr_repo="$(make_repo failed-pr-create)"
+failed_pr_root="$(dirname "$failed_pr_repo")"
+if failed_pr_output="$(
+  cd "$failed_pr_repo"
+  KOVA_GH_BIN="$mock_gh" \
+    KOVA_GITHUB_REPOSITORY="openclaw/Kova" \
+    KOVA_MOCK_PR_JSON="${failed_pr_root}/pr.json" \
+    KOVA_MOCK_PR_BODY="${failed_pr_root}/pr-body.md" \
+    KOVA_MOCK_RUNS_JSON="${failed_pr_root}/runs.json" \
+    KOVA_MOCK_PR_CREATE_FAIL=1 \
+    scripts/release.sh "$test_version" 2>&1
+)"; then
+  echo "error: failed pull request creation unexpectedly passed" >&2
+  exit 1
+fi
+grep -qF "failed to create the release pull request" <<<"$failed_pr_output"
+
+poisoned_repo="$(make_repo poisoned-lockfile)"
+git -C "$poisoned_repo" switch --quiet -c "$release_branch"
+node - "$poisoned_repo" "$test_version" <<'NODE'
 const fs = require("node:fs");
 const [repo, version] = process.argv.slice(2);
 for (const path of ["package.json", "package-lock.json"]) {
@@ -190,116 +298,45 @@ for (const path of ["package.json", "package-lock.json"]) {
   fs.writeFileSync(absolutePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 NODE
-if poisoned_lockfile_output="$(cd "$poisoned_lockfile_repo" && scripts/release.sh "$test_version" --skip-checks 2>&1)"; then
+if poisoned_output="$(run_release "$poisoned_repo" "$test_version" 2>&1)"; then
   echo "error: poisoned lockfile unexpectedly passed release validation" >&2
   exit 1
 fi
-grep -q "package-lock.json contains changes outside version fields" <<<"$poisoned_lockfile_output"
-test "$(git -C "$poisoned_lockfile_repo" rev-parse HEAD)" = "$poisoned_lockfile_head"
-test "$(git -C "$poisoned_lockfile_repo" ls-remote origin refs/heads/main | awk '{ print $1 }')" = "$poisoned_lockfile_head"
-
-poisoned_commit_repo="$(make_repo poisoned-release-commit)"
-(
-  cd "$poisoned_commit_repo"
-  npm version "$test_version" --no-git-tag-version --ignore-scripts >/dev/null
-  node - <<'NODE'
-const fs = require("node:fs");
-const path = "package-lock.json";
-const value = JSON.parse(fs.readFileSync(path, "utf8"));
-value.packages["node_modules/json5"].integrity = "sha512-forged";
-fs.writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
-NODE
-  git add package.json package-lock.json
-  git commit --quiet -m "chore: bump version to ${test_version}"
-)
-poisoned_commit_head="$(git -C "$poisoned_commit_repo" rev-parse HEAD)"
-if poisoned_commit_output="$(cd "$poisoned_commit_repo" && scripts/release.sh "$test_version" --skip-checks 2>&1)"; then
-  echo "error: poisoned release commit unexpectedly passed release validation" >&2
-  exit 1
-fi
-grep -q "package-lock.json contains changes outside version fields" <<<"$poisoned_commit_output"
-test "$(git -C "$poisoned_commit_repo" rev-parse HEAD)" = "$poisoned_commit_head"
-test "$(git -C "$poisoned_commit_repo" ls-remote origin refs/heads/main | awk '{ print $1 }')" = "$(git -C "$poisoned_commit_repo" rev-parse HEAD^)"
-test -z "$(git -C "$poisoned_commit_repo" tag --list "v${test_version}")"
-
-stale_repo="$(make_repo stale-main)"
-git clone --quiet "${tmp}/stale-main/remote.git" "${tmp}/stale-main/upstream"
-git -C "${tmp}/stale-main/upstream" config user.name "Kova upstream"
-git -C "${tmp}/stale-main/upstream" config user.email "kova-upstream@example.invalid"
-touch "${tmp}/stale-main/upstream/upstream-change"
-git -C "${tmp}/stale-main/upstream" add upstream-change
-git -C "${tmp}/stale-main/upstream" commit --quiet -m "test: advance remote"
-git -C "${tmp}/stale-main/upstream" push --quiet
-stale_before="$(git -C "$stale_repo" status --porcelain=v1)"
-if stale_output="$(cd "$stale_repo" && scripts/release.sh "$test_version" --skip-checks 2>&1)"; then
-  echo "error: stale local main unexpectedly passed release validation" >&2
-  exit 1
-fi
-grep -q "local main is not current" <<<"$stale_output"
-test "$(git -C "$stale_repo" status --porcelain=v1)" = "$stale_before"
+grep -qF "package-lock.json contains changes outside version fields" <<<"$poisoned_output"
+test -z "$(git -C "$poisoned_repo" ls-remote origin "refs/tags/${tag}")"
 
 unsigned_repo="$(make_repo unsigned-tag)"
-(
-  cd "$unsigned_repo"
-  npm version "$test_version" --no-git-tag-version --ignore-scripts >/dev/null
-  git add package.json package-lock.json
-  git commit --quiet -m "chore: bump version to ${test_version}"
-  git push --quiet origin main
-  git -c tag.gpgSign=false tag -a "v${test_version}" -m "v${test_version}"
-)
-if unsigned_output="$(cd "$unsigned_repo" && scripts/release.sh "$test_version" --skip-checks 2>&1)"; then
-  echo "error: unsigned release tag unexpectedly passed validation" >&2
+run_release "$unsigned_repo" "$test_version" >/dev/null
+squash_release_to_main "$unsigned_repo" "$test_version"
+git -C "$unsigned_repo" -c tag.gpgSign=false tag -a "$tag" -m "$tag"
+git -C "$unsigned_repo" push --quiet origin "$tag"
+if unsigned_output="$(run_release "$unsigned_repo" "$test_version" 2>&1)"; then
+  echo "error: unsigned remote tag unexpectedly passed validation" >&2
   exit 1
 fi
-grep -q "existing tag v${test_version} is not signed" <<<"$unsigned_output"
+grep -qF "remote tag ${tag} is not signed by a repository-authorized signer" <<<"$unsigned_output"
 
-partial_repo="$(make_repo partial-remote)"
+auto_key_repo="$(make_repo auto-signing-key)"
+auto_key_root="$(dirname "$auto_key_repo")"
+auto_key_home="${auto_key_root}/home"
+mkdir -p "${auto_key_home}/.ssh"
+cp "${tmp}/release-signing-key" "${auto_key_home}/.ssh/id_ed25519"
+cp "${tmp}/release-signing-key.pub" "${auto_key_home}/.ssh/id_ed25519.pub"
+ssh-keygen -q -t ed25519 -N "" -f "${auto_key_root}/unrelated-signing-key"
+git -C "$auto_key_repo" config user.signingkey "${auto_key_root}/unrelated-signing-key"
+run_release "$auto_key_repo" "$test_version" >/dev/null
+squash_release_to_main "$auto_key_repo" "$test_version"
+record_successful_ci "$auto_key_repo"
 (
-  cd "$partial_repo"
-  npm version "$test_version" --no-git-tag-version --ignore-scripts >/dev/null
-  git add package.json package-lock.json
-  git commit --quiet -m "chore: bump version to ${test_version}"
-  git -c tag.gpgSign=false tag -a "v${test_version}" -m "v${test_version}"
-  git push --quiet origin "v${test_version}"
+  cd "$auto_key_repo"
+  HOME="$auto_key_home" \
+    KOVA_GH_BIN="$mock_gh" \
+    KOVA_GITHUB_REPOSITORY="openclaw/Kova" \
+    KOVA_MOCK_PR_JSON="${auto_key_root}/pr.json" \
+    KOVA_MOCK_PR_BODY="${auto_key_root}/pr-body.md" \
+    KOVA_MOCK_RUNS_JSON="${auto_key_root}/runs.json" \
+    scripts/release.sh "$test_version" >/dev/null
 )
-if partial_output="$(cd "$partial_repo" && scripts/release.sh "$test_version" --skip-checks 2>&1)"; then
-  echo "error: partial remote release state unexpectedly passed validation" >&2
-  exit 1
-fi
-grep -q "remote tag v${test_version} is not signed by a repository-authorized signer" <<<"$partial_output"
-if grep -q "push main explicitly" <<<"$partial_output"; then
-  echo "error: untrusted partial remote release recommended advancing main" >&2
-  exit 1
-fi
-
-signed_partial_repo="$(make_repo signed-partial-remote)"
-(
-  cd "$signed_partial_repo"
-  npm version "$test_version" --no-git-tag-version --ignore-scripts >/dev/null
-  git add package.json package-lock.json
-  git commit --quiet -m "chore: bump version to ${test_version}"
-  git tag -s "v${test_version}" -m "v${test_version}"
-  git push --quiet origin "v${test_version}"
-)
-if signed_partial_output="$(cd "$signed_partial_repo" && scripts/release.sh "$test_version" --skip-checks 2>&1)"; then
-  echo "error: signed partial remote release state unexpectedly passed validation" >&2
-  exit 1
-fi
-grep -q "remote tag v${test_version} exists while origin/main is still at the release parent" <<<"$signed_partial_output"
-grep -q "push main explicitly" <<<"$signed_partial_output"
-
-retry_repo="$(make_repo remote-tag-retry)"
-(
-  cd "$retry_repo"
-  npm version "$test_version" --no-git-tag-version --ignore-scripts >/dev/null
-  git add package.json package-lock.json
-  git commit --quiet -m "chore: bump version to ${test_version}"
-  git push --quiet origin main
-  git tag -s "v${test_version}" -m "v${test_version}"
-  git push --quiet origin "v${test_version}"
-  git tag -d "v${test_version}" >/dev/null
-)
-(cd "$retry_repo" && scripts/release.sh "$test_version" --skip-checks >/dev/null)
-test "$(git -C "$retry_repo" rev-parse "v${test_version}^{commit}")" = "$(git -C "$retry_repo" rev-parse HEAD)"
+test "$(git -C "$auto_key_repo" rev-list -n1 "$tag")" = "$(git -C "$auto_key_repo" rev-parse HEAD)"
 
 echo "release contract checks passed"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,14 +25,15 @@ run_step() {
 
 usage() {
   cat <<'EOF'
-Prepare or resume a signed Kova release from the current main branch.
+Prepare or finish a signed Kova release through a pull request.
 
 Usage:
-  scripts/release.sh <version> [--remote <name>] [--skip-checks]
+  scripts/release.sh <version> [--remote <name>]
 
-Examples:
-  scripts/release.sh 0.2.0
-  scripts/release.sh 1.0.0-beta.1 --remote upstream
+Run the same command twice:
+  1. From current main, create the release branch and pull request.
+  2. After squash-merging that pull request, update main and rerun to verify
+     exact-SHA CI, sign the tag, and push it.
 EOF
 }
 
@@ -40,12 +41,13 @@ package_version() {
   node -p 'require("./package.json").version'
 }
 
-ref_commit() {
-  git rev-list -n1 "$1" 2>/dev/null || true
+version_at_ref() {
+  git show "$1:package.json" |
+    node -e 'let input=""; process.stdin.on("data", chunk => input += chunk); process.stdin.on("end", () => console.log(JSON.parse(input).version));'
 }
 
 remote_ref_commit() {
-  git ls-remote "$remote" "$1" | awk 'NR==1 { print $1 }'
+  git ls-remote "$remote" "$1" | awk 'NR == 1 { print $1 }'
 }
 
 remote_tag_object() {
@@ -63,7 +65,7 @@ remote_tag_commit() {
 normalize_signing_key() {
   case "$1" in
     key::*|ssh-*|ecdsa-*|sk-*) printf '%s\n' "$1" ;;
-    "~/"*) printf '%s/%s\n' "$HOME" "${1:2}" ;;
+    \~/*) printf '%s/%s\n' "$HOME" "${1:2}" ;;
     *) printf '%s\n' "$1" ;;
   esac
 }
@@ -191,64 +193,294 @@ remote_tag_signature_valid() {
   [[ "$valid" -eq 1 ]]
 }
 
-refresh_dirty_files() {
-  dirty_files=()
-  while IFS= read -r file; do
-    [[ -n "$file" ]] || continue
-    dirty_files+=("$file")
-  done < <(
-    {
-      git diff --name-only --ignore-submodules --
-      git diff --cached --name-only --ignore-submodules --
-    } | sort -u
-  )
+tracked_dirty_files() {
+  {
+    git diff --name-only --ignore-submodules --
+    git diff --cached --name-only --ignore-submodules --
+  } | sort -u
 }
 
-only_version_files_dirty() {
-  local file
-  [[ "${#dirty_files[@]}" -gt 0 ]] || return 1
-  for file in "${dirty_files[@]}"; do
-    case "$file" in
-      package.json|package-lock.json)
-        ;;
-      *)
-        return 1
-        ;;
-    esac
-  done
-  "${script_dir}/validate-version-metadata.mjs" "$version"
-}
-
-is_release_commit() {
-  [[ "$(git log -1 --pretty=%s 2>/dev/null || true)" == "$release_commit_message" ]] || return 1
-  [[ "$(git diff-tree --no-commit-id --name-only -r HEAD | sort -u)" == $'package-lock.json\npackage.json' ]] || return 1
-  if ! "${script_dir}/validate-version-metadata.mjs" "$version" --commit HEAD; then
-    echo "error: release commit contains changes outside the expected version bump" >&2
+require_clean_checkout() {
+  local dirty
+  dirty="$(tracked_dirty_files)"
+  if [[ -n "$dirty" ]]; then
+    echo "error: tracked changes are present; commit or stash them before running scripts/release.sh" >&2
+    printf '%s\n' "$dirty" >&2
     exit 1
   fi
 }
 
-log_resume_state() {
-  log_step "resume state: $*"
+release_commit_is_version_only() {
+  local changed
+  changed="$(git diff-tree --no-commit-id --name-only -r HEAD | sort -u)"
+  [[ "$changed" == $'package-lock.json\npackage.json' ]] || return 1
+  "${script_dir}/validate-version-metadata.mjs" "$version" --commit HEAD
 }
 
-log_skip() {
-  log_step "skip: $*"
+release_commit_subject_matches() {
+  local subject="$1"
+  local suffix
+  if [[ "$subject" == "$release_commit_message" ]]; then
+    return 0
+  fi
+  suffix="${subject#"$release_commit_message"}"
+  [[ "$suffix" =~ ^\ \(#[0-9]+\)$ ]]
+}
+
+release_branch_is_version_only() {
+  local remote_main_sha release_base_sha commit_count changed
+  remote_main_sha="$(remote_ref_commit "refs/heads/main")"
+  [[ -n "$remote_main_sha" ]] || {
+    echo "error: could not resolve ${remote}/main" >&2
+    return 1
+  }
+  git fetch --quiet "$remote" main
+  release_base_sha="$(git merge-base HEAD "$remote_main_sha")"
+  commit_count="$(git rev-list --count "${release_base_sha}..HEAD")"
+  changed="$(git diff --name-only "${release_base_sha}..HEAD" | sort -u)"
+  if [[ "$commit_count" != "1" || "$changed" != $'package-lock.json\npackage.json' ]]; then
+    echo "error: ${release_branch} must contain exactly one version-only commit" >&2
+    return 1
+  fi
+  release_commit_subject_matches "$(git log -1 --pretty=%s)" &&
+    release_commit_is_version_only
+}
+
+github() {
+  if [[ -n "${KOVA_GH_BIN:-}" ]]; then
+    "$KOVA_GH_BIN" "$@"
+  elif command -v ghx >/dev/null 2>&1; then
+    ghx --no-cache "$@"
+  elif command -v gh >/dev/null 2>&1; then
+    gh "$@"
+  else
+    echo "error: ghx or gh is required for release pull requests and CI verification" >&2
+    return 1
+  fi
+}
+
+github_repository() {
+  local remote_url repository
+  if [[ -n "${KOVA_GITHUB_REPOSITORY:-}" ]]; then
+    repository="$KOVA_GITHUB_REPOSITORY"
+  else
+    remote_url="$(git remote get-url "$remote")"
+    case "$remote_url" in
+      https://github.com/*)
+        repository="${remote_url#https://github.com/}"
+        ;;
+      git@github.com:*)
+        repository="${remote_url#git@github.com:}"
+        ;;
+      ssh://git@github.com/*)
+        repository="${remote_url#ssh://git@github.com/}"
+        ;;
+      *)
+        echo "error: cannot derive a GitHub repository from remote ${remote}; set KOVA_GITHUB_REPOSITORY" >&2
+        return 1
+        ;;
+    esac
+    repository="${repository%.git}"
+  fi
+  if [[ ! "$repository" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+    echo "error: invalid GitHub repository: ${repository}" >&2
+    return 1
+  fi
+  printf '%s\n' "$repository"
+}
+
+release_pr_details() {
+  local repository="$1"
+  local response
+  response="$(
+    github pr view "$release_branch" \
+      --repo "$repository" \
+      --json url,state,baseRefName,body \
+      2>/dev/null || true
+  )"
+  [[ -n "$response" ]] || return 1
+  PR_JSON="$response" node <<'NODE'
+const value = JSON.parse(process.env.PR_JSON);
+console.log([
+  value.url || "",
+  value.state || "",
+  value.baseRefName || "",
+  typeof value.body === "string" && value.body.trim() ? "body-ok" : "body-empty",
+].join("\t"));
+NODE
+}
+
+ensure_release_pr() {
+  local repository details pr_url pr_state pr_base pr_body_state body_file
+  repository="$(github_repository)"
+  details="$(release_pr_details "$repository" || true)"
+  if [[ -n "$details" ]]; then
+    IFS=$'\t' read -r pr_url pr_state pr_base pr_body_state <<<"$details"
+    if [[ "$pr_state" != "OPEN" || "$pr_base" != "main" ]]; then
+      echo "error: existing pull request for ${release_branch} is ${pr_state:-unknown} with base ${pr_base:-unknown}" >&2
+      return 1
+    fi
+    if [[ "$pr_body_state" != "body-ok" ]]; then
+      echo "error: existing pull request for ${release_branch} has an empty body" >&2
+      return 1
+    fi
+    printf '%s\n' "$pr_url"
+    return
+  fi
+
+  body_file="$(mktemp "${TMPDIR:-/tmp}/kova-release-pr.XXXXXX")"
+  cat >"$body_file" <<EOF
+## What Problem This Solves
+
+Prepares the version metadata for ${tag} through the normal review and CI path.
+
+## Why This Change Was Made
+
+This pull request contains only the package version bump. Squash-merge it so the exact merge commit can pass the main-branch CI gate before the signed release tag is created.
+
+## User Impact
+
+No runtime behavior changes. Release metadata is reviewed and validated before publication.
+
+## Evidence
+
+- Version metadata is limited to \`package.json\` and \`package-lock.json\`.
+- Pull-request CI is the validation gate.
+- After merge, rerun \`scripts/release.sh ${version} --remote ${remote}\`.
+EOF
+  if ! pr_url="$(
+    github pr create \
+      --repo "$repository" \
+      --base main \
+      --head "$release_branch" \
+      --title "$release_commit_message" \
+      --body-file "$body_file"
+  )" || [[ -z "$pr_url" ]]; then
+    rm -f "$body_file"
+    echo "error: failed to create the release pull request" >&2
+    return 1
+  fi
+  rm -f "$body_file"
+
+  details="$(release_pr_details "$repository" || true)"
+  if [[ -z "$details" ]]; then
+    echo "error: created release pull request could not be read back" >&2
+    return 1
+  fi
+  IFS=$'\t' read -r pr_url pr_state pr_base pr_body_state <<<"$details"
+  if [[ "$pr_state" != "OPEN" || "$pr_base" != "main" || "$pr_body_state" != "body-ok" ]]; then
+    echo "error: created release pull request failed live verification" >&2
+    return 1
+  fi
+  printf '%s\n' "$pr_url"
+}
+
+verify_exact_main_ci() {
+  local head_sha="$1"
+  local repository runs_json result state run_id run_url
+  repository="$(github_repository)"
+  if ! runs_json="$(
+    github run list \
+      --repo "$repository" \
+      --workflow ci.yml \
+      --branch main \
+      --event push \
+      --commit "$head_sha" \
+      --limit 20 \
+      --json databaseId,headSha,status,conclusion,url
+  )"; then
+    echo "error: could not query CI for ${head_sha}" >&2
+    return 1
+  fi
+  result="$(
+    CI_RUNS_JSON="$runs_json" node - "$head_sha" <<'NODE'
+const headSha = process.argv[2];
+const runs = JSON.parse(process.env.CI_RUNS_JSON || "[]");
+const run = runs.find((candidate) => candidate.headSha === headSha);
+if (!run) {
+  console.log("missing\t\t");
+} else if (run.status !== "completed") {
+  console.log(`pending\t${run.databaseId || ""}\t${run.url || ""}`);
+} else if (run.conclusion !== "success") {
+  console.log(`failed\t${run.databaseId || ""}\t${run.url || ""}`);
+} else {
+  console.log(`success\t${run.databaseId || ""}\t${run.url || ""}`);
+}
+NODE
+  )"
+  IFS=$'\t' read -r state run_id run_url <<<"$result"
+  case "$state" in
+    success)
+      log_step "Exact-SHA CI passed in run ${run_id}"
+      ;;
+    pending)
+      echo "error: CI run ${run_id} for ${head_sha} is still in progress" >&2
+      [[ -n "$run_url" ]] && echo "run: ${run_url}" >&2
+      return 1
+      ;;
+    failed)
+      echo "error: CI run ${run_id} for ${head_sha} did not succeed" >&2
+      [[ -n "$run_url" ]] && echo "run: ${run_url}" >&2
+      return 1
+      ;;
+    *)
+      echo "error: no main-branch CI push run exists for exact commit ${head_sha}" >&2
+      echo "hint: wait for CI to start and finish, then rerun this command" >&2
+      return 1
+      ;;
+  esac
+}
+
+verify_existing_remote_tag() {
+  local remote_main_sha remote_tag_commit_sha remote_tag_object_sha local_tag_object_sha tagged_version
+  remote_tag_commit_sha="$(remote_tag_commit)"
+  [[ -n "$remote_tag_commit_sha" ]] || return 1
+  remote_tag_object_sha="$(remote_tag_object)"
+  if ! remote_tag_signature_valid "$remote_tag_object_sha"; then
+    echo "error: remote tag ${tag} is not signed by a repository-authorized signer" >&2
+    exit 1
+  fi
+
+  local_tag_object_sha="$(git rev-parse --verify "refs/tags/${tag}" 2>/dev/null || true)"
+  if [[ -n "$local_tag_object_sha" && "$local_tag_object_sha" != "$remote_tag_object_sha" ]]; then
+    echo "error: local and remote tag objects differ for ${tag}" >&2
+    exit 1
+  fi
+  if [[ -z "$local_tag_object_sha" ]]; then
+    run_step "Adopting verified remote tag ${tag}" \
+      git fetch --quiet --force --no-tags "$remote" "refs/tags/${tag}:refs/tags/${tag}"
+  fi
+
+  tagged_version="$(version_at_ref "$tag")"
+  if [[ "$tagged_version" != "$version" ]]; then
+    echo "error: remote tag ${tag} contains package version ${tagged_version:-unknown}" >&2
+    exit 1
+  fi
+  remote_main_sha="$(remote_ref_commit "refs/heads/main")"
+  run_step "Fetching ${remote}/main for ancestry verification" git fetch --quiet "$remote" main
+  if ! git merge-base --is-ancestor "$remote_tag_commit_sha" "$remote_main_sha"; then
+    echo "error: remote tag ${tag} is not reachable from ${remote}/main" >&2
+    exit 1
+  fi
+
+  cat <<EOF
+Release tag ${tag} is already published from verified commit ${remote_tag_commit_sha}.
+The tag-triggered workflows own archive validation and publication.
+EOF
 }
 
 version=""
 remote="origin"
-skip_checks=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --remote)
       shift
-      [[ $# -gt 0 ]] || { echo "error: --remote requires a value" >&2; exit 1; }
+      [[ $# -gt 0 ]] || {
+        echo "error: --remote requires a value" >&2
+        exit 1
+      }
       remote="$1"
-      ;;
-    --skip-checks)
-      skip_checks=1
       ;;
     --help|-h)
       usage
@@ -282,214 +514,131 @@ cd "$repo_root"
 
 "${script_dir}/validate-version.mjs" "$version"
 
-branch="$(git symbolic-ref --quiet --short HEAD || true)"
-if [[ "$branch" != "main" ]]; then
-  echo "error: releases must be prepared from the main branch (current: ${branch:-detached})" >&2
-  exit 1
-fi
-
 if ! git remote get-url "$remote" >/dev/null 2>&1; then
   echo "error: git remote not found: $remote" >&2
   exit 1
 fi
 
 tag="v${version}"
-release_commit_message="chore: bump version to ${version}"
-current_version="$(package_version)"
+release_branch="release/${tag}"
+release_commit_message="chore(release): bump version to ${version}"
+branch="$(git symbolic-ref --quiet --short HEAD || true)"
 
+if verify_existing_remote_tag; then
+  exit 0
+fi
+
+current_version="$(package_version)"
 if [[ -z "$current_version" ]]; then
   echo "error: could not read Kova version from package.json" >&2
   exit 1
 fi
+"${script_dir}/validate-version-metadata.mjs" "$current_version"
 
-refresh_dirty_files
-
-head_sha="$(git rev-parse HEAD)"
-head_is_release_commit=0
-if is_release_commit; then
-  head_is_release_commit=1
-fi
-
-local_tag_commit_sha="$(ref_commit "$tag")"
-local_tag_object_sha="$(git rev-parse --verify "refs/tags/${tag}" 2>/dev/null || true)"
-remote_tag_object_sha="$(remote_tag_object)"
-remote_tag_commit_sha="$(remote_tag_commit)"
-remote_main_sha="$(remote_ref_commit "refs/heads/main")"
-
-if [[ -z "$remote_main_sha" ]]; then
-  echo "error: could not resolve ${remote}/main" >&2
-  exit 1
-fi
-
-if [[ -n "$local_tag_commit_sha" && "$local_tag_commit_sha" != "$head_sha" ]]; then
-  echo "error: local tag ${tag} already exists and does not point at HEAD" >&2
-  exit 1
-fi
-
-if [[ -n "$remote_tag_commit_sha" && "$remote_tag_commit_sha" != "$head_sha" ]]; then
-  echo "error: remote tag ${tag} already exists on ${remote} and does not point at HEAD" >&2
-  exit 1
-fi
-
-if [[ -n "$remote_tag_object_sha" ]]; then
-  if ! remote_tag_signature_valid "$remote_tag_object_sha"; then
-    echo "error: remote tag ${tag} is not signed by a repository-authorized signer" >&2
-    exit 1
-  fi
-  if [[ -n "$local_tag_object_sha" && "$local_tag_object_sha" != "$remote_tag_object_sha" ]]; then
-    echo "error: local and remote tag objects differ for ${tag}; reconcile them before retrying" >&2
-    exit 1
-  fi
-  if [[ -z "$local_tag_object_sha" ]]; then
-    run_step "Adopting verified remote tag ${tag}" \
-      git fetch --quiet --force --no-tags "$remote" "refs/tags/${tag}:refs/tags/${tag}"
-    local_tag_object_sha="$(git rev-parse --verify "refs/tags/${tag}")"
-    local_tag_commit_sha="$(ref_commit "$tag")"
-  fi
-fi
-
-if [[ "$head_is_release_commit" -eq 1 ]]; then
-  release_base_sha="$(git rev-parse HEAD^)"
-  if [[ "$remote_main_sha" == "$release_base_sha" && "$remote_tag_commit_sha" == "$head_sha" ]]; then
-    echo "error: remote tag ${tag} exists while ${remote}/main is still at the release parent" >&2
-    echo "error: push main explicitly, then rerun the failed Release Build workflow for ${tag}" >&2
-    exit 1
-  fi
-  if [[ "$remote_main_sha" != "$release_base_sha" && "$remote_main_sha" != "$head_sha" ]]; then
-    echo "error: ${remote}/main moved since the release commit was created; reconcile before retrying" >&2
-    exit 1
-  fi
-elif [[ "$remote_main_sha" != "$head_sha" ]]; then
-  echo "error: local main is not current with ${remote}/main; pull or reconcile before releasing" >&2
-  exit 1
-fi
-
-need_update_version=0
-need_checks=0
-need_commit=0
-
-log_step "Preparing release ${tag} from branch ${branch} using remote ${remote}"
-
-if [[ "$current_version" == "$version" ]]; then
-  if [[ "${#dirty_files[@]}" -gt 0 ]]; then
-    if ! only_version_files_dirty; then
-      echo "error: tracked changes are present; commit or stash them before running scripts/release.sh" >&2
+case "$branch" in
+  main)
+    require_clean_checkout
+    remote_main_sha="$(remote_ref_commit "refs/heads/main")"
+    head_sha="$(git rev-parse HEAD)"
+    if [[ -z "$remote_main_sha" || "$head_sha" != "$remote_main_sha" ]]; then
+      echo "error: local main must exactly match ${remote}/main before release work" >&2
       exit 1
     fi
-    if [[ "$head_is_release_commit" -eq 1 || -n "$local_tag_commit_sha" || -n "$remote_tag_commit_sha" ]]; then
-      echo "error: package.json is dirty for ${version}, but a release commit or tag already exists; clean up release state before retrying" >&2
+
+    if [[ "$current_version" == "$version" ]]; then
+      if ! release_commit_subject_matches "$(git log -1 --pretty=%s)" ||
+        ! release_commit_is_version_only; then
+        echo "error: ${version} is on main, but HEAD is not the expected squash-merged release commit" >&2
+        exit 1
+      fi
+      verify_exact_main_ci "$head_sha"
+
+      local_tag_object_sha="$(git rev-parse --verify "refs/tags/${tag}" 2>/dev/null || true)"
+      if [[ -n "$local_tag_object_sha" ]]; then
+        log_step "Using existing local tag ${tag}"
+      else
+        release_signing_key="$(resolve_release_signing_key)"
+        log_step "Using repository-authorized release key"
+        log_step "Creating signed tag ${tag}; git signing may prompt here"
+        git -c gpg.format=ssh -c user.signingkey="$release_signing_key" tag -s "$tag" -m "$tag"
+      fi
+      if [[ "$(git rev-list -n1 "$tag")" != "$head_sha" ]]; then
+        echo "error: local tag ${tag} does not point at the release commit" >&2
+        exit 1
+      fi
+      if ! tag_signature_valid "$tag"; then
+        echo "error: local tag ${tag} is not signed by a repository-authorized signer" >&2
+        exit 1
+      fi
+      run_step "Pushing signed tag ${tag}" git push "$remote" "$tag"
+      cat <<EOF
+Release tag ${tag} pushed from ${head_sha}.
+The tag-triggered workflows will validate the archive and publish the release.
+EOF
+      exit 0
+    fi
+
+    if git show-ref --verify --quiet "refs/heads/${release_branch}"; then
+      echo "error: local branch ${release_branch} already exists; switch to it and rerun" >&2
       exit 1
     fi
-    need_update_version=1
-    need_checks=1
-    need_commit=1
-    log_resume_state "package metadata is partially or fully updated to ${version}"
-  else
-    if [[ "$head_is_release_commit" -ne 1 ]]; then
-      echo "error: Kova is already on ${version}, but HEAD is not the expected release commit; clean up or finish that release state manually" >&2
-      exit 1
-    fi
-    log_resume_state "release commit already exists at ${head_sha:0:7}"
-  fi
-else
-  if [[ "${#dirty_files[@]}" -gt 0 ]]; then
-    echo "error: tracked changes are present; commit or stash them before running scripts/release.sh" >&2
+    run_step "Creating ${release_branch}" git switch -c "$release_branch"
+    ;;
+  "$release_branch")
+    ;;
+  *)
+    echo "error: run from main or ${release_branch} (current: ${branch:-detached})" >&2
+    exit 1
+    ;;
+esac
+
+dirty="$(tracked_dirty_files)"
+if [[ -n "$dirty" && "$dirty" != $'package-lock.json\npackage.json' ]]; then
+  echo "error: release branches may contain only package.json and package-lock.json changes" >&2
+  printf '%s\n' "$dirty" >&2
+  exit 1
+fi
+
+if [[ "$current_version" != "$version" ]]; then
+  if [[ -n "$dirty" ]]; then
+    echo "error: package metadata is already dirty but does not contain ${version}" >&2
     exit 1
   fi
-  if [[ -n "$local_tag_commit_sha" || -n "$remote_tag_commit_sha" ]]; then
-    echo "error: release tag ${tag} already exists, but package.json is still on ${current_version}" >&2
-    exit 1
-  fi
-  need_update_version=1
-  need_checks=1
-  need_commit=1
+  run_step "Updating package metadata to ${version}" "${script_dir}/update-version.sh" "$version"
+fi
+"${script_dir}/validate-version-metadata.mjs" "$version"
+
+release_commit_ready=0
+if [[ "$(git log -1 --pretty=%s)" == "$release_commit_message" ]] &&
+  release_commit_is_version_only &&
+  [[ -z "$(tracked_dirty_files)" ]]; then
+  release_commit_ready=1
 fi
 
-if [[ "$skip_checks" -eq 0 ]]; then
-  if [[ "$need_checks" -eq 1 ]]; then
-    log_step "Local checks are enabled"
-  else
-    log_skip "local checks already passed before this resume point"
-  fi
-else
-  log_step "Local checks are skipped"
-  need_checks=0
-fi
-
-if [[ "$need_update_version" -eq 1 ]]; then
-  run_step "Updating package.json to ${version}" "${script_dir}/update-version.sh" "$version"
-else
-  log_skip "package.json is already set to ${version}"
-fi
-
-if [[ "$need_checks" -eq 1 ]]; then
-  run_step "Running Kova check suite" npm run check:full
-fi
-
-if [[ "$need_commit" -eq 1 ]]; then
+if [[ "$release_commit_ready" -eq 0 ]]; then
   run_step "Staging package metadata" git add package.json package-lock.json
-  if git diff --cached --quiet --ignore-submodules -- package.json package-lock.json; then
-    echo "error: no staged version change remains for ${version}; cannot create release commit" >&2
+  if git diff --cached --quiet -- package.json package-lock.json; then
+    echo "error: no version changes remain to commit" >&2
     exit 1
   fi
   run_step "Creating release commit" git commit -m "$release_commit_message"
-  head_sha="$(git rev-parse HEAD)"
+elif [[ -n "$(tracked_dirty_files)" ]]; then
+  echo "error: release commit exists but package metadata is still dirty" >&2
+  exit 1
 else
-  log_skip "release commit already exists"
+  log_step "Release commit already exists"
 fi
 
-if [[ "$skip_checks" -eq 0 && -z "$local_tag_commit_sha" ]]; then
-  run_step "Building release archive" "${script_dir}/package-release.sh" --output-dir ./dist
-elif [[ "$skip_checks" -eq 1 ]]; then
-  log_skip "release archive build is skipped"
-else
-  log_skip "release archive was validated before the existing tag was created"
-fi
-
-if [[ -z "$local_tag_commit_sha" ]]; then
-  release_signing_key="$(resolve_release_signing_key)"
-  log_step "Using repository-authorized release key"
-  log_step "Creating signed tag ${tag}; git signing may prompt here"
-  if ! git -c gpg.format=ssh -c user.signingkey="$release_signing_key" tag -s "$tag" -m "$tag"; then
-    echo "error: failed to create signed tag ${tag}; make sure git tag signing is configured" >&2
-    exit 1
-  fi
-  if ! tag_signature_valid "$tag"; then
-    git tag -d "$tag" >/dev/null 2>&1 || true
-    echo "error: created tag ${tag} was not signed; configure git tag signing before retrying" >&2
-    exit 1
-  fi
-  log_step "done: Creating signed tag ${tag}"
-  local_tag_commit_sha="$(ref_commit "$tag")"
-else
-  if ! tag_signature_valid "$tag"; then
-    echo "error: existing tag ${tag} is not signed" >&2
-    exit 1
-  fi
-  log_skip "local tag ${tag} already exists"
-fi
-
-remote_main_sha="$(remote_ref_commit "refs/heads/main")"
-remote_tag_commit_sha="$(remote_tag_commit)"
-
-push_targets=()
-if [[ "$remote_main_sha" != "$head_sha" ]]; then
-  push_targets+=("main")
-fi
-if [[ "$remote_tag_commit_sha" != "$head_sha" ]]; then
-  push_targets+=("$tag")
-fi
-
-if [[ "${#push_targets[@]}" -gt 0 ]]; then
-  run_step "Atomically pushing ${push_targets[*]} to ${remote}" git push --atomic "$remote" "${push_targets[@]}"
-else
-  log_skip "main and ${tag} are already pushed to ${remote}"
-fi
+release_branch_is_version_only
+run_step "Pushing ${release_branch}" git push --set-upstream "$remote" "$release_branch"
+pr_url="$(ensure_release_pr)"
 
 cat <<EOF
-Release prep complete for ${tag}.
+Release pull request ready: ${pr_url}
 
 Next:
-  1. The tag-triggered release workflow will build and smoke-test the archive
-  2. GitHub Releases will be published only after those checks pass
+  1. Squash-merge ${release_branch} into main.
+  2. Update local main to the merged commit.
+  3. Wait for the exact main-branch CI run to pass.
+  4. Rerun: scripts/release.sh ${version} --remote ${remote}
 EOF


### PR DESCRIPTION
Closes #84

## What Problem This Solves

Fixes an issue where preparing a Kova release could push `main` and its tag directly while running the full check suite locally and then repeating it in the tag build.

It also stops ordinary issue comments from allocating a ClawSweeper runner or creating an app token when they are not supported commands.

## Why This Change Was Made

Release preparation now creates a version-only `release/v<version>` pull request. After squash merge, the release command requires a successful `CI` push run for the exact `main` SHA before signing and pushing the tag; the tag workflow independently enforces the same gate, then performs archive packaging and install smoke validation without repeating `check:full`.

The ClawSweeper workflow uses a cheap job-level command marker filter, retains the precise shell filter, and creates tokens only after both gates pass.

## User Impact

Release version bumps follow normal review and CI, tag publication cannot outrun exact-commit validation, and the tag build avoids a redundant full-suite run. Routine issue comments no longer consume ClawSweeper runner time or token requests.

## Evidence

- `scripts/check-release-contracts.sh`
- `shellcheck scripts/release.sh scripts/check-release-contracts.sh scripts/update-version.sh`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/release.yml .github/workflows/clawsweeper-dispatch.yml`
- `npm run check:full`: 274/274 self-checks, 21/21 snapshots, web payload check, and release contracts passed
- Autoreview: clean, no accepted or actionable findings
