### PR TITLE
fix: local agent startup time appears as unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
-- Attribute OpenClaw CLI and agent startup spans in local agent pre-provider timing, retaining stage identity instead of reporting measured work as unknown.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Attribute OpenClaw CLI and agent startup spans in local agent pre-provider timing, retaining stage identity instead of reporting measured work as unknown.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -398,6 +398,15 @@ metrics such as `coldPreProviderAttributedMs`,
 `coldPreProviderUnattributedMs`, `warmPreProviderAttributedMs`, and
 `warmPreProviderUnattributedMs`.
 
+Local agent CLI turns expose the same fields under
+`records[*].measurements.agentCliPreProviderAttribution`. Kova attributes
+OpenClaw spans in the `cli.startup`, `cli.command-startup`, and `agent.startup`
+phases, together with agent preparation, model discovery, plugin metadata, and
+channel capability spans. Overlapping startup spans are unioned before Kova
+calculates known and unattributed time. Span summaries retain stage breakdowns
+such as `config-ready`, `plugin-registry`, and `command-prepare` so the JSON
+evidence identifies the owning startup work.
+
 Aggregate fields are also exposed on `measurements` for comparison and
 performance summaries:
 

--- a/src/collectors/agent-cli-attribution.mjs
+++ b/src/collectors/agent-cli-attribution.mjs
@@ -23,7 +23,7 @@ export function buildAgentCliPreProviderAttribution({
     activeFinishedAtEpochMs,
     attribution,
     timelineSummary,
-    isAttributedSpanName: isAgentCliAttributedSpanName,
+    isAttributedSpan: isAgentCliAttributedSpan,
     missingEventsError: "timeline contains no agent CLI attribution events"
   });
 }
@@ -44,14 +44,18 @@ export function agentCliPreProviderMarkdownRows(turns) {
   });
 }
 
-function isAgentCliAttributedSpanName(name) {
-  const text = String(name ?? "");
-  return text === "agent.prepare" ||
-    text === "plugins.metadata.scan" ||
-    text === "runtimeDeps.stage" ||
-    text === "channel.capabilities" ||
-    text === "models.catalog" ||
-    text.startsWith("models.catalog.") ||
-    text.startsWith("models.discovery") ||
-    text.startsWith("channel.plugin.");
+function isAgentCliAttributedSpan(event) {
+  const name = String(event?.name ?? "");
+  const phase = String(event?.phase ?? "");
+  return phase === "cli.startup" ||
+    phase === "cli.command-startup" ||
+    phase === "agent.startup" ||
+    name === "agent.prepare" ||
+    name === "plugins.metadata.scan" ||
+    name === "runtimeDeps.stage" ||
+    name === "channel.capabilities" ||
+    name === "models.catalog" ||
+    name.startsWith("models.catalog.") ||
+    name.startsWith("models.discovery") ||
+    name.startsWith("channel.plugin.");
 }

--- a/src/collectors/gateway-session-turn-attribution.mjs
+++ b/src/collectors/gateway-session-turn-attribution.mjs
@@ -24,7 +24,7 @@ export function buildGatewaySessionPreProviderAttribution({
     activeFinishedAtEpochMs,
     attribution,
     timelineSummary,
-    isAttributedSpanName: isGatewaySessionAttributedSpanName,
+    isAttributedSpan: isGatewaySessionAttributedSpan,
     shouldIncludeSpan: includeGatewaySessionSpanInWindow,
     missingEventsError: "timeline contains no Gateway session turn attribution events"
   });
@@ -47,15 +47,15 @@ export function gatewaySessionPreProviderMarkdownRows(turns) {
 }
 
 export function attributedSpanIntervals(events) {
-  return collectAttributedSpanIntervals(events, isGatewaySessionAttributedSpanName);
+  return collectAttributedSpanIntervals(events, isGatewaySessionAttributedSpan);
 }
 
-function isGatewaySessionAttributedSpanName(name) {
-  const text = String(name ?? "");
-  return text === "plugins.metadata.scan" ||
-    text.startsWith("gateway.chat_send") ||
-    text.startsWith("auto_reply") ||
-    text.startsWith("reply.");
+function isGatewaySessionAttributedSpan(event) {
+  const name = String(event?.name ?? "");
+  return name === "plugins.metadata.scan" ||
+    name.startsWith("gateway.chat_send") ||
+    name.startsWith("auto_reply") ||
+    name.startsWith("reply.");
 }
 
 function includeGatewaySessionSpanInWindow(span, { windowStartEpochMs, windowEndEpochMs }) {

--- a/src/collectors/pre-provider-attribution.mjs
+++ b/src/collectors/pre-provider-attribution.mjs
@@ -1,4 +1,5 @@
 import { markdownInline, markdownTableCodeSpan } from "../reporting/markdown.mjs";
+import { matchSpanStarts } from "./timeline.mjs";
 
 export function buildPreProviderAttribution({
   schemaVersion,
@@ -149,22 +150,20 @@ export function preProviderMarkdownRows({ title, turns, fieldName }) {
 }
 
 export function attributedSpanIntervals(events, isAttributedSpan) {
-  const startsById = new Map();
+  const { startByTerminal } = matchSpanStarts(events ?? []);
   const intervals = [];
 
   for (const event of events ?? []) {
-    if (event?.type === "span.start" && isAttributedSpan(event)) {
-      const key = spanKey(event);
-      if (key) {
-        startsById.set(key, event);
-      }
+    if (event?.type !== "span.end" && event?.type !== "span.error") {
       continue;
     }
-    if ((event?.type === "span.end" || event?.type === "span.error") && isAttributedSpan(event)) {
-      const terminal = spanIntervalFromTerminal(event, startsById.get(spanKey(event)));
-      if (terminal) {
-        intervals.push(terminal);
-      }
+    const startEvent = startByTerminal.get(event);
+    if (!isAttributedSpan(event) && !(startEvent && isAttributedSpan(startEvent))) {
+      continue;
+    }
+    const terminal = spanIntervalFromTerminal(event, startEvent);
+    if (terminal) {
+      intervals.push(terminal);
     }
   }
 
@@ -370,12 +369,6 @@ function timelineArtifacts(timelineSummary) {
     ...(timelineSummary?.artifacts ?? []),
     ...(timelineSummary?.timelineArtifacts ?? [])
   ].filter(Boolean));
-}
-
-function spanKey(event) {
-  return event?.spanId === undefined || event?.spanId === null || String(event.spanId).length === 0
-    ? null
-    : String(event.spanId);
 }
 
 function eventEpochMs(event) {

--- a/src/collectors/pre-provider-attribution.mjs
+++ b/src/collectors/pre-provider-attribution.mjs
@@ -8,7 +8,7 @@ export function buildPreProviderAttribution({
   activeFinishedAtEpochMs,
   attribution,
   timelineSummary,
-  isAttributedSpanName,
+  isAttributedSpan,
   shouldIncludeSpan,
   missingEventsError
 }) {
@@ -74,7 +74,7 @@ export function buildPreProviderAttribution({
     };
   }
 
-  const intervals = attributedSpanIntervals(events, isAttributedSpanName)
+  const intervals = attributedSpanIntervals(events, isAttributedSpan)
     .filter((span) => shouldIncludeSpan ? shouldIncludeSpan(span, { windowStartEpochMs, windowEndEpochMs }) : true)
     .map((span) => clipSpanToWindow(span, windowStartEpochMs, windowEndEpochMs))
     .filter(Boolean);
@@ -120,7 +120,7 @@ export function preProviderMarkdownRows({ title, turns, fieldName }) {
 
   const lines = [
     `- ${markdownInline(title)}:`,
-    "  - Spans are selected by active turn timestamp window; timeline phase is descriptive, not a startup/turn classifier.",
+    "  - Spans are clipped to the active turn timestamp window; collector-specific name and phase rules select attributed work.",
     "",
     "  | turn | pre-provider | known | unattributed | provider | timeline |",
     "  |---|---:|---:|---:|---:|---|"
@@ -148,19 +148,19 @@ export function preProviderMarkdownRows({ title, turns, fieldName }) {
   return lines;
 }
 
-export function attributedSpanIntervals(events, isAttributedSpanName) {
+export function attributedSpanIntervals(events, isAttributedSpan) {
   const startsById = new Map();
   const intervals = [];
 
   for (const event of events ?? []) {
-    if (event?.type === "span.start" && isAttributedSpanName(event.name)) {
+    if (event?.type === "span.start" && isAttributedSpan(event)) {
       const key = spanKey(event);
       if (key) {
         startsById.set(key, event);
       }
       continue;
     }
-    if ((event?.type === "span.end" || event?.type === "span.error") && isAttributedSpanName(event.name)) {
+    if ((event?.type === "span.end" || event?.type === "span.error") && isAttributedSpan(event)) {
       const terminal = spanIntervalFromTerminal(event, startsById.get(spanKey(event)));
       if (terminal) {
         intervals.push(terminal);
@@ -188,6 +188,7 @@ function spanIntervalFromTerminal(event, startEvent) {
     rawDurationMs: durationMs,
     spanId: event.spanId ?? null,
     phase: event.phase ?? startEvent?.phase ?? null,
+    stage: event.stage ?? startEvent?.stage ?? null,
     errorName: event.errorName ?? null,
     errorMessage: event.errorMessage ?? null
   };
@@ -218,7 +219,8 @@ function summarizeAttributedSpans(intervals) {
       maxClippedDurationMs: null,
       totalRawDurationMs: 0,
       maxRawDurationMs: null,
-      phases: []
+      phases: [],
+      stages: []
     };
     current.count += 1;
     if (interval.type === "span.error") {
@@ -230,7 +232,8 @@ function summarizeAttributedSpans(intervals) {
       current.totalRawDurationMs = round(current.totalRawDurationMs + interval.rawDurationMs);
       current.maxRawDurationMs = maxNullable(current.maxRawDurationMs, interval.rawDurationMs);
     }
-    current.phases = mergePhaseSummary(current.phases, interval.phase, interval.clippedDurationMs);
+    current.phases = mergeDimensionSummary(current.phases, "phase", interval.phase, interval.clippedDurationMs);
+    current.stages = mergeDimensionSummary(current.stages, "stage", interval.stage, interval.clippedDurationMs);
     byName.set(interval.name, current);
   }
   return [...byName.values()].toSorted((left, right) =>
@@ -239,24 +242,24 @@ function summarizeAttributedSpans(intervals) {
   );
 }
 
-function mergePhaseSummary(phases, phase, clippedDurationMs) {
-  const label = String(phase ?? "unknown");
-  const existing = phases.find((item) => item.phase === label);
+function mergeDimensionSummary(items, field, value, clippedDurationMs) {
+  const label = String(value ?? "unknown");
+  const existing = items.find((item) => item[field] === label);
   if (existing) {
     existing.count += 1;
     existing.totalClippedDurationMs = round(existing.totalClippedDurationMs + clippedDurationMs);
-    return phases;
+    return items;
   }
   return [
-    ...phases,
+    ...items,
     {
-      phase: label,
+      [field]: label,
       count: 1,
       totalClippedDurationMs: round(clippedDurationMs)
     }
   ].toSorted((left, right) =>
     (right.totalClippedDurationMs - left.totalClippedDurationMs) ||
-    left.phase.localeCompare(right.phase)
+    left[field].localeCompare(right[field])
   );
 }
 

--- a/src/collectors/timeline.mjs
+++ b/src/collectors/timeline.mjs
@@ -489,6 +489,7 @@ function compactTimedEvent(event) {
     durationMs: event.durationMs ?? null,
     timestamp: event.timestamp ?? null,
     phase: event.phase ?? null,
+    stage: event.stage ?? event.attributes?.stage ?? null,
     provider: event.provider ?? event.attributes?.provider ?? null,
     operation: event.operation ?? event.attributes?.operation ?? null,
     pluginId: event.pluginId ?? event.attributes?.pluginId ?? null,
@@ -510,7 +511,10 @@ function isTurnAttributionEvent(event) {
   if (event.type !== "span.start" && event.type !== "span.end" && event.type !== "span.error") {
     return false;
   }
-  return event.name === "plugins.metadata.scan" ||
+  return event.phase === "cli.startup" ||
+    event.phase === "cli.command-startup" ||
+    event.phase === "agent.startup" ||
+    event.name === "plugins.metadata.scan" ||
     event.name === "plugins.load" ||
     event.name === "provider.request" ||
     event.name === "agent.prepare" ||
@@ -538,6 +542,7 @@ function compactAttributionEvent(event) {
     spanId: event.spanId ?? null,
     parentSpanId: event.parentSpanId ?? null,
     phase: event.phase ?? null,
+    stage: event.stage ?? event.attributes?.stage ?? null,
     pid: event.pid ?? null,
     provider: event.provider ?? event.attributes?.provider ?? null,
     operation: event.operation ?? event.attributes?.operation ?? null,

--- a/src/collectors/timeline.mjs
+++ b/src/collectors/timeline.mjs
@@ -126,7 +126,8 @@ export function summarizeTimeline(events, parseErrors = []) {
   const providerRequests = events.filter((event) => event.type === "provider.request");
   const childProcesses = events.filter((event) => event.type === "childProcess.exit");
   const spanTotals = summarizeSpans(spanEvents);
-  const openSpansAll = summarizeOpenSpans(events);
+  const spanMatches = matchSpanStarts(events);
+  const openSpansAll = summarizeOpenSpans(spanMatches.unmatchedStarts, latestEventTimestamp(events));
   const openSpans = openSpansAll.slice(0, 25);
   const gatewayPids = gatewayProcessPids(events);
   const runtimeDeps = summarizeRuntimeDeps(spanEvents);
@@ -161,7 +162,7 @@ export function summarizeTimeline(events, parseErrors = []) {
     eventLoop: summarizeEventLoop(eventLoopSamples),
     providers: summarizeTimedCollection(providerRequests),
     childProcesses: summarizeChildProcesses(childProcesses),
-    turnAttributionEvents: events.filter(isTurnAttributionEvent).map(compactAttributionEvent),
+    turnAttributionEvents: selectTurnAttributionEvents(events, spanMatches.startByTerminal).map(compactAttributionEvent),
     events: events.slice(0, 200)
   };
 }
@@ -309,11 +310,11 @@ function summarizeRuntimeDeps(events) {
   };
 }
 
-function summarizeOpenSpans(events) {
+export function matchSpanStarts(events) {
   const starts = [];
   const matched = new Set();
   const buckets = new Map();
-  const latestTimestamp = latestEventTimestamp(events);
+  const startByTerminal = new Map();
 
   // Consume the append-only stream in order. Per-identity stacks keep matching
   // amortized linear while newest-first wildcard matching handles reused span IDs.
@@ -342,22 +343,30 @@ function summarizeOpenSpans(events) {
         popUnmatched(bucket.byPid.get(UNKNOWN_PID_KEY), matched);
     if (index !== null) {
       matched.add(index);
+      startByTerminal.set(event, starts[index]);
     }
   }
 
-  return starts.flatMap((start, index) => matched.has(index) ? [] : [{
-      type: start.type,
-      name: start.name,
-      spanId: start.spanId ?? null,
-      parentSpanId: start.parentSpanId ?? null,
-      timestamp: start.timestamp ?? null,
-      ageMs: spanAgeMs(start, latestTimestamp),
-      phase: start.phase ?? null,
-      provider: start.provider ?? start.attributes?.provider ?? null,
-      operation: start.operation ?? start.attributes?.operation ?? null,
-      pluginId: start.pluginId ?? start.attributes?.pluginId ?? null,
-      pid: start.pid ?? null
-    }]).toSorted((left, right) => (right.ageMs ?? -1) - (left.ageMs ?? -1));
+  return {
+    startByTerminal,
+    unmatchedStarts: starts.filter((_, index) => !matched.has(index))
+  };
+}
+
+function summarizeOpenSpans(starts, latestTimestamp) {
+  return starts.map((start) => ({
+    type: start.type,
+    name: start.name,
+    spanId: start.spanId ?? null,
+    parentSpanId: start.parentSpanId ?? null,
+    timestamp: start.timestamp ?? null,
+    ageMs: spanAgeMs(start, latestTimestamp),
+    phase: start.phase ?? null,
+    provider: start.provider ?? start.attributes?.provider ?? null,
+    operation: start.operation ?? start.attributes?.operation ?? null,
+    pluginId: start.pluginId ?? start.attributes?.pluginId ?? null,
+    pid: start.pid ?? null
+  })).toSorted((left, right) => (right.ageMs ?? -1) - (left.ageMs ?? -1));
 }
 
 const UNKNOWN_PID_KEY = "<unknown>";
@@ -530,6 +539,20 @@ function isTurnAttributionEvent(event) {
     event.name.startsWith("models.discovery") ||
     event.name.startsWith("channel.plugin.") ||
     keySpanMatches("reply", event.name);
+}
+
+function selectTurnAttributionEvents(events, startByTerminal) {
+  return events.filter((event) => {
+    if (isTurnAttributionEvent(event)) {
+      return true;
+    }
+    if (event.type !== "span.end" && event.type !== "span.error") {
+      return false;
+    }
+    const start = startByTerminal.get(event);
+    // Terminal phase is optional, so attribution selection follows its matched start.
+    return Boolean(start && isTurnAttributionEvent(start));
+  });
 }
 
 function compactAttributionEvent(event) {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -12695,7 +12695,7 @@ function agentCliPreProviderAttributionCheck() {
     const timelineText = [
       timelineEvent({ type: "span.start", name: "agent.turn", timestamp: base + 1000, spanId: "cold-turn" }),
       timelineEvent({ type: "span.start", name: "cli.main.core-imports", phase: "cli.startup", timestamp: base + 1000, spanId: "cold-cli-main" }),
-      timelineEvent({ type: "span.end", name: "cli.main.core-imports", phase: "cli.startup", timestamp: base + 1040, spanId: "cold-cli-main", durationMs: 40 }),
+      timelineEvent({ type: "span.end", name: "cli.main.core-imports", timestamp: base + 1040, spanId: "cold-cli-main", durationMs: 40 }),
       timelineEvent({ type: "span.start", name: "cli.command-startup", phase: "cli.command-startup", timestamp: base + 1040, spanId: "cold-cli-command", attributes: { stage: "agent-action-imports" } }),
       timelineEvent({ type: "span.end", name: "cli.command-startup", phase: "cli.command-startup", timestamp: base + 1080, spanId: "cold-cli-command", durationMs: 40, attributes: { stage: "agent-action-imports" } }),
       timelineEvent({ type: "span.start", name: "agent.startup", phase: "agent.startup", timestamp: base + 1080, spanId: "cold-agent-startup", attributes: { stage: "command-prepare" } }),
@@ -12718,6 +12718,11 @@ function agentCliPreProviderAttributionCheck() {
     ].join("\n");
     const parsed = parseTimelineText(timelineText);
     assertEqual(parsed.turnAttributionEvents.length, 22, "agent CLI turn attribution events retain startup phases");
+    assertEqual(
+      parsed.turnAttributionEvents.find((event) => event.spanId === "cold-cli-main" && event.type === "span.end")?.phase,
+      null,
+      "phase-less terminal paired to selected startup span is retained"
+    );
 
     const coldAttribution = buildAgentCliPreProviderAttribution({
       label: "cold",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -12668,7 +12668,7 @@ function gatewaySessionPreProviderAttributionCheck() {
       summary: { statuses: { PASS: 1 } }
     });
     assertEqual(rendered.includes("Gateway session pre-provider attribution:"), true, "markdown includes gateway session attribution table");
-    assertEqual(rendered.includes("Spans are selected by active turn timestamp window"), true, "markdown describes timestamp-window attribution");
+    assertEqual(rendered.includes("Spans are clipped to the active turn timestamp window"), true, "markdown describes timestamp-window attribution");
     assertEqual(rendered.includes("`agent-turn`"), true, "markdown includes metadata scan phase as descriptive context");
     assertEqual(rendered.includes("`reply.ensure_workspace`"), true, "markdown includes span table");
 
@@ -12694,6 +12694,12 @@ function agentCliPreProviderAttributionCheck() {
     const base = 1777536000000;
     const timelineText = [
       timelineEvent({ type: "span.start", name: "agent.turn", timestamp: base + 1000, spanId: "cold-turn" }),
+      timelineEvent({ type: "span.start", name: "cli.main.core-imports", phase: "cli.startup", timestamp: base + 1000, spanId: "cold-cli-main" }),
+      timelineEvent({ type: "span.end", name: "cli.main.core-imports", phase: "cli.startup", timestamp: base + 1040, spanId: "cold-cli-main", durationMs: 40 }),
+      timelineEvent({ type: "span.start", name: "cli.command-startup", phase: "cli.command-startup", timestamp: base + 1040, spanId: "cold-cli-command", attributes: { stage: "agent-action-imports" } }),
+      timelineEvent({ type: "span.end", name: "cli.command-startup", phase: "cli.command-startup", timestamp: base + 1080, spanId: "cold-cli-command", durationMs: 40, attributes: { stage: "agent-action-imports" } }),
+      timelineEvent({ type: "span.start", name: "agent.startup", phase: "agent.startup", timestamp: base + 1080, spanId: "cold-agent-startup", attributes: { stage: "command-prepare" } }),
+      timelineEvent({ type: "span.end", name: "agent.startup", phase: "agent.startup", timestamp: base + 1150, spanId: "cold-agent-startup", durationMs: 70, attributes: { stage: "command-prepare" } }),
       timelineEvent({ type: "span.start", name: "agent.prepare", timestamp: base + 1020, spanId: "cold-prepare" }),
       timelineEvent({ type: "span.end", name: "agent.prepare", timestamp: base + 1120, spanId: "cold-prepare", durationMs: 100 }),
       timelineEvent({ type: "span.start", name: "models.catalog.gateway", timestamp: base + 1080, spanId: "cold-models" }),
@@ -12711,7 +12717,7 @@ function agentCliPreProviderAttributionCheck() {
       timelineEvent({ type: "eventLoop.sample", name: "eventLoop.sample", timestamp: base + 11250, maxMs: 6 })
     ].join("\n");
     const parsed = parseTimelineText(timelineText);
-    assertEqual(parsed.turnAttributionEvents.length, 16, "agent CLI turn attribution events retained");
+    assertEqual(parsed.turnAttributionEvents.length, 22, "agent CLI turn attribution events retain startup phases");
 
     const coldAttribution = buildAgentCliPreProviderAttribution({
       label: "cold",
@@ -12730,8 +12736,13 @@ function agentCliPreProviderAttributionCheck() {
       }
     });
     assertEqual(coldAttribution.available, true, "agent CLI cold attribution available");
-    assertEqual(coldAttribution.knownAttributedMs, 170, "agent CLI overlap-safe cold known attribution");
-    assertEqual(coldAttribution.unattributedMs, 30, "agent CLI cold unattributed remainder");
+    assertEqual(coldAttribution.knownAttributedMs, 190, "agent CLI overlap-safe cold known attribution");
+    assertEqual(coldAttribution.unattributedMs, 10, "agent CLI cold unattributed remainder");
+    assertEqual(coldAttribution.spanSummaries.find((span) => span.name === "cli.main.core-imports")?.phases?.[0]?.phase, "cli.startup", "agent CLI startup span attributed by phase");
+    assertEqual(coldAttribution.spanSummaries.find((span) => span.name === "cli.command-startup")?.phases?.[0]?.phase, "cli.command-startup", "command startup span attributed by phase");
+    assertEqual(coldAttribution.spanSummaries.find((span) => span.name === "agent.startup")?.phases?.[0]?.phase, "agent.startup", "agent startup span attributed by phase");
+    assertEqual(coldAttribution.spanSummaries.find((span) => span.name === "cli.command-startup")?.stages?.[0]?.stage, "agent-action-imports", "command startup stage retained");
+    assertEqual(coldAttribution.spanSummaries.find((span) => span.name === "agent.startup")?.stages?.[0]?.stage, "command-prepare", "agent startup stage retained");
     assertEqual(coldAttribution.spanSummaries.some((span) => span.name === "agent.turn"), false, "agent.turn parent span is not counted as pre-provider work");
     assertEqual(coldAttribution.spanSummaries.find((span) => span.name === "channel.plugin.load")?.errorCount, 1, "agent CLI error span summary");
 
@@ -12754,7 +12765,7 @@ function agentCliPreProviderAttributionCheck() {
     }, { surface: { thresholds: {} }, targetPlan: { kind: "runtime" } });
     assertEqual(record.measurements.agentCliPreProviderAttribution.count, 2, "record agent CLI attribution count");
     assertEqual(record.measurements.gatewaySessionPreProviderAttribution.count, 0, "record gateway session attribution stays empty for CLI turns");
-    assertEqual(record.measurements.coldPreProviderAttributedMs, 170, "record agent CLI cold attributed metric");
+    assertEqual(record.measurements.coldPreProviderAttributedMs, 190, "record agent CLI cold attributed metric");
     assertEqual(record.measurements.warmPreProviderAttributedMs, 80, "record agent CLI warm attributed metric");
     assertEqual(record.measurements.warmPreProviderUnattributedMs, 120, "record agent CLI warm unattributed metric");
     assertEqual(record.measurements.agentTurns[0].agentCliPreProviderAttribution.timelineArtifacts[0], "/tmp/kova/openclaw/timeline.jsonl", "record agent CLI timeline artifact");
@@ -12769,7 +12780,8 @@ function agentCliPreProviderAttributionCheck() {
       summary: { statuses: { PASS: 1 } }
     });
     assertEqual(rendered.includes("Agent CLI pre-provider attribution:"), true, "markdown includes agent CLI attribution table");
-    assertEqual(rendered.includes("`channel.plugin.load`"), true, "markdown includes agent CLI span table");
+    assertEqual(rendered.includes("`cli.startup`"), true, "markdown includes CLI startup attribution phase");
+    assertEqual(rendered.includes("`cli.command-startup`"), true, "markdown includes agent CLI startup span table");
 
     return {
       id: "agent-cli-pre-provider-attribution",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Kova reported most local agent pre-provider time as unknown even though OpenClaw emitted startup spans covering that work.

## Why This Change Was Made

Kova now retains and attributes spans in the `cli.startup`, `cli.command-startup`, and `agent.startup` phases. The shared interval selector receives complete events, stage identity is preserved in compact JSON evidence, and the existing overlap-safe union remains the source of `knownAttributedMs`.

Gateway-session attribution keeps its existing name-based selection. The schema names remain at v1 because this corrects attribution semantics and adds optional evidence fields without changing the output structure or compatibility contract.

## User Impact

Operators can distinguish measured OpenClaw startup work from the remaining unattributed window and see the exact owning stages in JSON reports. OpenClaw runtime behavior is unchanged.

## Evidence

- `npm run test:selfcheck-isolation`: pass
- `node bin/kova.mjs self-check`: 274/274 pass
- `npm run test:snapshots`: 21/21 pass
- `npm run check:web-payload`: 1/1 pass
- `npm run test:release-contracts`: pass
- Exact-head OpenClaw run with this Kova commit:
  - Run: https://github.com/openclaw/openclaw/actions/runs/30871084445
  - OpenClaw: `b1e923cd6d48b6d67a68881a5ce0c1320f3078cd`
  - Kova: `c11dd7346c757022f78c1b8cb13b984512db7544`
  - Four selected cold/warm diagnostic records passed with no blocking findings, warnings, or regressions.
  - The filtered diagnostic slice reports gate `PARTIAL` because required full-release scenarios were intentionally excluded; this is not a full release-gate pass.
  - Cold known attribution: 2,315-2,438 ms; unattributed: 1,499-1,550 ms.
  - Warm known attribution: 2,354-2,818 ms; unattributed: 1,811-2,023 ms.
  - Preserved stages show the cold migration scan and its warm-process checkpoint skip instead of collapsing both into unknown time.
- Earlier artifact replay at OpenClaw `bf61c4c581f3545b672817731950232bebebd4e2`:
  - Known attribution: 234-257 ms (6-7%) -> 2,268-2,354 ms (60-62%).
  - Unattributed time: 3,455-3,561 ms -> 1,421-1,541 ms.
  - Dominant preserved stage: `doctor.config-preflight.legacy-state-migrations` at 1,128-1,208 ms.
  - Next preserved stage: `plugin-registry` at 324-336 ms.
