### PR TITLE
fix: many-plugin pressure state covers cold startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to Kova are documented in this file.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.
-- Make the many-plugin pressure state prepare 80 synthetic plugins only inside its disposable environment, migrate them before cold startup, and verify canonical registry and plugin-list visibility.
+- Make the many-plugin pressure state prepare 80 synthetic plugins only inside its disposable environment, require OpenClaw 2026.6.1 or newer, migrate them before cold startup, and verify canonical registry and plugin-list visibility.
 - Calibrate the bundled-plugin restart overlap RSS budget against repeated OpenClaw main release runs.
 - Calibrate the fresh-install status CLI RSS budget against repeated release-run evidence.
 - Calibrate the gateway pressure scenario's status CLI RSS budget against repeated release-run evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Kova are documented in this file.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.
+- Make the many-plugin pressure state migrate 80 synthetic plugins before cold startup and verify canonical registry and plugin-list visibility.
 - Calibrate the bundled-plugin restart overlap RSS budget against repeated OpenClaw main release runs.
 - Calibrate the fresh-install status CLI RSS budget against repeated release-run evidence.
 - Calibrate the gateway pressure scenario's status CLI RSS budget against repeated release-run evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ All notable changes to Kova are documented in this file.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.
-- Make the many-plugin pressure state prepare 80 synthetic plugins only inside its disposable environment, require OpenClaw 2026.6.1 or newer, migrate them before cold startup, and verify canonical registry and plugin-list visibility.
 - Calibrate the bundled-plugin restart overlap RSS budget against repeated OpenClaw main release runs.
 - Calibrate the fresh-install status CLI RSS budget against repeated release-run evidence.
 - Calibrate the gateway pressure scenario's status CLI RSS budget against repeated release-run evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to Kova are documented in this file.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.
-- Make the many-plugin pressure state migrate 80 synthetic plugins before cold startup and verify canonical registry and plugin-list visibility.
+- Make the many-plugin pressure state prepare 80 synthetic plugins only inside its disposable environment, migrate them before cold startup, and verify canonical registry and plugin-list visibility.
 - Calibrate the bundled-plugin restart overlap RSS budget against repeated OpenClaw main release runs.
 - Calibrate the fresh-install status CLI RSS budget against repeated release-run evidence.
 - Calibrate the gateway pressure scenario's status CLI RSS budget against repeated release-run evidence.

--- a/src/run/state-lifecycle.mjs
+++ b/src/run/state-lifecycle.mjs
@@ -28,7 +28,11 @@ export async function executeStateLifecycleSteps(context, envName, scenario, kin
   const commands = phase.commands;
 
   for (const [commandIndex, command] of commands.entries()) {
-    results.push(await runScenarioCommand(command, context, envName, artifactDir, phase, commandIndex, authPolicy));
+    const result = await runScenarioCommand(command, context, envName, artifactDir, phase, commandIndex, authPolicy);
+    results.push(result);
+    if (result.status !== 0) {
+      break;
+    }
   }
 
   return {

--- a/src/runner.mjs
+++ b/src/runner.mjs
@@ -125,7 +125,7 @@ export async function executeScenario(scenario, context) {
         record.phases.push(preparePhase);
         if (preparePhase.results.some((result) => result.status !== 0)) {
           scenarioFailed = true;
-          record.status = "FAIL";
+          record.status = classifyLifecycleFailure(preparePhase.results);
         }
       }
     }
@@ -178,7 +178,7 @@ export async function executeScenario(scenario, context) {
           record.phases.push(statePhase);
           if (statePhase.results.some((result) => result.status !== 0)) {
             scenarioFailed = true;
-            record.status = "FAIL";
+            record.status = classifyLifecycleFailure(statePhase.results);
           }
         }
 
@@ -278,7 +278,12 @@ function summarizeOfficialPlugins(plugins) {
   }));
 }
 
-function classifyCommandFailure(result) {
+function classifyLifecycleFailure(results) {
+  const failed = results.find((result) => result.status !== 0);
+  return failed ? classifyCommandFailure(failed) : "FAIL";
+}
+
+export function classifyCommandFailure(result) {
   if (result.harnessBlocker) {
     return "BLOCKED";
   }

--- a/src/safety.mjs
+++ b/src/safety.mjs
@@ -10,6 +10,7 @@ const delegatedCommandNodeScripts = new Set([
 const allowedNodeScenarioScripts = new Set([
   "scripts/large-session-fixture.mjs",
   "support/agent-network-offline.mjs",
+  "support/assert-many-plugin-pressure-state.mjs",
   "support/assert-command-output.mjs",
   "support/browser-automation-smoke.mjs",
   "support/channel-conformance/run.mjs",
@@ -19,6 +20,7 @@ const allowedNodeScenarioScripts = new Set([
   "support/mcp-bridge-smoke.mjs",
   "support/mcp-tool-call-smoke.mjs",
   "support/media-understanding-timeout.mjs",
+  "support/prepare-many-plugin-pressure-state.mjs",
   "support/restore-first-ocm-upgrade-snapshot.mjs",
   "support/run-adversarial-inputs.mjs",
   "support/run-channel-adapter-conformance.mjs",

--- a/src/safety.mjs
+++ b/src/safety.mjs
@@ -20,7 +20,6 @@ const allowedNodeScenarioScripts = new Set([
   "support/mcp-bridge-smoke.mjs",
   "support/mcp-tool-call-smoke.mjs",
   "support/media-understanding-timeout.mjs",
-  "support/prepare-many-plugin-pressure-state.mjs",
   "support/restore-first-ocm-upgrade-snapshot.mjs",
   "support/run-adversarial-inputs.mjs",
   "support/run-channel-adapter-conformance.mjs",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -9401,6 +9401,7 @@ function safetyGuardCheck() {
       "timeout 30 ocm env destroy Violet --yes",
       "node -e 'require(\"node:child_process\").execFileSync(\"ocm\", [\"env\", \"destroy\", \"Violet\", \"--yes\"])'",
       "node /tmp/support/run-soak-loop.mjs --env kova-safe-test",
+      "node support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
       "node support/run-openclaw-release-age-upgrade.mjs --env Violet --age day --json",
       "node support/run-openclaw-release-age-upgrade.mjs --env=Violet --age day --json",
       "node support/run-doctor-repair.mjs --env kova-safe-test --env Violet",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -68,6 +68,7 @@ import {
   runScenarioCommand
 } from "./run/command-executor.mjs";
 import { runEntries } from "./run/engine.mjs";
+import { materializeLifecycleStepCommands } from "./run/phase-commands.mjs";
 import { executeStateLifecycleSteps } from "./run/state-lifecycle.mjs";
 import { executeTargetSetup } from "./run/target-setup.mjs";
 import { classifyCommandFailure } from "./runner.mjs";
@@ -5660,17 +5661,39 @@ async function pluginInstallIndexFixturesCheck(tmp) {
     const manyPluginStep = manyPluginState.setup?.[0];
     assertEqual(manyPluginStep?.afterPhases?.includes("env-create"), true, "many-plugin setup precedes startup");
     assertEqual(manyPluginStep?.afterPhases?.includes("cold-start"), false, "many-plugin setup does not follow cold start");
-    assertEqual(manyPluginStep?.commands?.length, 2, "many-plugin setup command count");
+    assertEqual(manyPluginStep?.commands?.length, 3, "many-plugin setup command count");
     assertEqual(
       manyPluginStep.commands[0],
-      "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1 --version-only && ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
-      "many-plugin prepare command"
+      "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1 --version-only",
+      "many-plugin version preflight command"
     );
     assertEqual(
       manyPluginStep.commands[1],
+      "ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
+      "many-plugin prepare command"
+    );
+    assertEqual(
+      manyPluginStep.commands[2],
       "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1",
       "many-plugin assertion command"
     );
+    const safetyArtifactDir = join(tmp, "many-bundled-plugins-safety");
+    const materializedCommands = materializeLifecycleStepCommands(
+      manyPluginStep,
+      {
+        sourceEnv: "",
+        targetPlan: {
+          repoPath: "",
+          startSelector: "stable",
+          upgradeSelector: "stable"
+        }
+      },
+      "kova-safe-test",
+      safetyArtifactDir
+    );
+    for (const command of materializedCommands) {
+      assertSafeScenarioCommand(command, {}, "kova-safe-test", safetyArtifactDir);
+    }
 
     const manyPluginHome = join(tmp, "many-bundled-plugins-home");
     const prepareResult = await runCommand(

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -5651,86 +5651,167 @@ async function stateLifecycleCommandIndexesCheck(tmp) {
 }
 
 async function pluginInstallIndexFixturesCheck(tmp) {
-  const fixtures = [
-    {
-      id: "many-bundled-plugins",
-      expectedIds: Array.from({ length: 80 }, (_, index) => `kova-plugin-${index}`)
-    },
-    {
-      id: "plugin-index",
-      expectedIds: ["kova-index-alpha", "kova-index-beta", "kova-index-gamma"]
-    }
-  ];
-
   return inlineCheck("plugin-install-index-fixtures", async () => {
-    for (const fixture of fixtures) {
-      const state = JSON.parse(await readFile(join(repoRoot, "states", `${fixture.id}.json`), "utf8"));
-      const commands = state.setup?.flatMap((step) => step.commands ?? []) ?? [];
-      assertEqual(commands.length, 1, `${fixture.id} setup command count`);
+    const manyPluginIds = Array.from({ length: 80 }, (_, index) => `kova-plugin-${index}`);
+    const manyPluginState = JSON.parse(
+      await readFile(join(repoRoot, "states", "many-bundled-plugins.json"), "utf8")
+    );
+    const manyPluginStep = manyPluginState.setup?.[0];
+    assertEqual(manyPluginStep?.afterPhases?.includes("env-create"), true, "many-plugin setup precedes startup");
+    assertEqual(manyPluginStep?.afterPhases?.includes("cold-start"), false, "many-plugin setup does not follow cold start");
+    assertEqual(manyPluginStep?.commands?.length, 2, "many-plugin setup command count");
+    assertEqual(
+      manyPluginStep.commands[0],
+      "ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
+      "many-plugin prepare command"
+    );
+    assertEqual(
+      manyPluginStep.commands[1],
+      "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80",
+      "many-plugin assertion command"
+    );
 
-      const prefix = "ocm env exec {env} -- node -e '";
-      const command = commands[0];
-      if (!command.startsWith(prefix) || !command.endsWith("'")) {
-        throw new Error(`${fixture.id} setup command is not an embedded Node script`);
+    const manyPluginHome = join(tmp, "many-bundled-plugins-home");
+    const prepareResult = await runCommand(
+      `${quoteShell(process.execPath)} ${quoteShell(join(repoRoot, "support", "prepare-many-plugin-pressure-state.mjs"))} --expected-count 80`,
+      {
+        env: { OPENCLAW_STATE_DIR: manyPluginHome },
+        timeoutMs: 30000,
+        maxOutputChars: 100000
       }
-
-      const home = join(tmp, `${fixture.id}-home`);
-      const script = command.slice(prefix.length, -1);
-      const result = await runCommand(
-        `${quoteShell(process.execPath)} -e ${quoteShell(script)}`,
-        {
-          env: { OPENCLAW_HOME: home },
-          timeoutMs: 30000,
-          maxOutputChars: 100000
-        }
+    );
+    if (prepareResult.status !== 0) {
+      throw new Error(
+        `many-bundled-plugins setup failed: ${prepareResult.stderr.trim() || prepareResult.stdout.trim() || `exit ${prepareResult.status}`}`
       );
-      if (result.status !== 0) {
-        throw new Error(
-          `${fixture.id} setup failed: ${result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`}`
-        );
-      }
+    }
+    await assertPluginFixtureFiles(
+      manyPluginHome,
+      "plugins/installs.json",
+      "many-bundled-plugins",
+      manyPluginIds
+    );
+    await assertManyPluginPressureHelper(tmp, manyPluginIds);
 
-      for (const relativePath of ["plugins/installs.json", ".openclaw/plugins/installs.json"]) {
-        const index = JSON.parse(await readFile(join(home, relativePath), "utf8"));
-        assertEqual(Array.isArray(index.plugins), false, `${fixture.id} omits private plugins array`);
-        const records = index.installRecords;
-        if (!records || typeof records !== "object" || Array.isArray(records)) {
-          throw new Error(`${fixture.id} ${relativePath} has no installRecords object`);
-        }
-        assertEqual(
-          Object.keys(records).sort().join("\n"),
-          [...fixture.expectedIds].sort().join("\n"),
-          `${fixture.id} install record ids`
-        );
-        for (const id of fixture.expectedIds) {
-          const pluginDir = join(home, "fixture-plugins", id);
-          assertEqual(records[id]?.source, "path", `${fixture.id} ${id} source`);
-          assertEqual(records[id]?.sourcePath, pluginDir, `${fixture.id} ${id} source path`);
-          assertEqual(records[id]?.installPath, pluginDir, `${fixture.id} ${id} install path`);
-          assertEqual(records[id]?.version, "0.0.0", `${fixture.id} ${id} version`);
-          assertEqual(records[id]?.spec, undefined, `${fixture.id} ${id} has no package spec`);
+    const pluginIndexState = JSON.parse(
+      await readFile(join(repoRoot, "states", "plugin-index.json"), "utf8")
+    );
+    const pluginIndexCommands = pluginIndexState.setup?.flatMap((step) => step.commands ?? []) ?? [];
+    assertEqual(pluginIndexCommands.length, 1, "plugin-index setup command count");
+    const prefix = "ocm env exec {env} -- node -e '";
+    const command = pluginIndexCommands[0];
+    if (!command.startsWith(prefix) || !command.endsWith("'")) {
+      throw new Error("plugin-index setup command is not an embedded Node script");
+    }
 
-          const packageJson = JSON.parse(await readFile(join(pluginDir, "package.json"), "utf8"));
-          assertEqual(packageJson.name, `@kova/${id}`, `${fixture.id} ${id} package name`);
-          assertEqual(packageJson.version, "0.0.0", `${fixture.id} ${id} package version`);
-          assertEqual(
-            packageJson.openclaw?.extensions?.join("\n"),
-            "./index.js",
-            `${fixture.id} ${id} package entry`
-          );
-          const manifest = JSON.parse(
-            await readFile(join(pluginDir, "openclaw.plugin.json"), "utf8")
-          );
-          assertEqual(manifest.id, id, `${fixture.id} ${id} manifest id`);
-          assertEqual(
-            (await readFile(join(pluginDir, "index.js"), "utf8")).includes(`id: ${JSON.stringify(id)}`),
-            true,
-            `${fixture.id} ${id} runtime entry`
-          );
-        }
+    const pluginIndexHome = join(tmp, "plugin-index-home");
+    const pluginIndexResult = await runCommand(
+      `${quoteShell(process.execPath)} -e ${quoteShell(command.slice(prefix.length, -1))}`,
+      {
+        env: { OPENCLAW_HOME: pluginIndexHome },
+        timeoutMs: 30000,
+        maxOutputChars: 100000
       }
+    );
+    if (pluginIndexResult.status !== 0) {
+      throw new Error(
+        `plugin-index setup failed: ${pluginIndexResult.stderr.trim() || pluginIndexResult.stdout.trim() || `exit ${pluginIndexResult.status}`}`
+      );
+    }
+    for (const relativePath of ["plugins/installs.json", ".openclaw/plugins/installs.json"]) {
+      await assertPluginFixtureFiles(
+        pluginIndexHome,
+        relativePath,
+        "plugin-index",
+        ["kova-index-alpha", "kova-index-beta", "kova-index-gamma"]
+      );
     }
   });
+}
+
+async function assertPluginFixtureFiles(home, relativePath, fixtureId, expectedIds) {
+  const index = JSON.parse(await readFile(join(home, relativePath), "utf8"));
+  assertEqual(Array.isArray(index.plugins), false, `${fixtureId} omits private plugins array`);
+  const records = index.installRecords;
+  if (!records || typeof records !== "object" || Array.isArray(records)) {
+    throw new Error(`${fixtureId} ${relativePath} has no installRecords object`);
+  }
+  assertEqual(
+    Object.keys(records).sort().join("\n"),
+    [...expectedIds].sort().join("\n"),
+    `${fixtureId} install record ids`
+  );
+  for (const id of expectedIds) {
+    const pluginDir = join(home, "fixture-plugins", id);
+    assertEqual(records[id]?.source, "path", `${fixtureId} ${id} source`);
+    assertEqual(records[id]?.sourcePath, pluginDir, `${fixtureId} ${id} source path`);
+    assertEqual(records[id]?.installPath, pluginDir, `${fixtureId} ${id} install path`);
+    assertEqual(records[id]?.version, "0.0.0", `${fixtureId} ${id} version`);
+    assertEqual(records[id]?.spec, undefined, `${fixtureId} ${id} has no package spec`);
+
+    const packageJson = JSON.parse(await readFile(join(pluginDir, "package.json"), "utf8"));
+    assertEqual(packageJson.name, `@kova/${id}`, `${fixtureId} ${id} package name`);
+    assertEqual(packageJson.version, "0.0.0", `${fixtureId} ${id} package version`);
+    assertEqual(
+      packageJson.openclaw?.extensions?.join("\n"),
+      "./index.js",
+      `${fixtureId} ${id} package entry`
+    );
+    const manifest = JSON.parse(await readFile(join(pluginDir, "openclaw.plugin.json"), "utf8"));
+    assertEqual(manifest.id, id, `${fixtureId} ${id} manifest id`);
+    assertEqual(
+      (await readFile(join(pluginDir, "index.js"), "utf8")).includes(`id: ${JSON.stringify(id)}`),
+      true,
+      `${fixtureId} ${id} runtime entry`
+    );
+  }
+}
+
+async function assertManyPluginPressureHelper(tmp, expectedIds) {
+  const binDir = join(tmp, "many-plugin-pressure-bin");
+  const fakeOcm = join(binDir, "ocm");
+  await mkdir(binDir, { recursive: true });
+  await writeFile(
+    fakeOcm,
+    [
+      "#!/usr/bin/env node",
+      `const ids = ${JSON.stringify(expectedIds)};`,
+      'const command = process.argv.slice(2).join(" ");',
+      'if (command === "@kova-self-check -- doctor --fix --non-interactive") {',
+      '  console.log("doctor repair complete");',
+      "  process.exit(0);",
+      "}",
+      'if (command === "@kova-self-check -- plugins registry --refresh --json") {',
+      "  console.log(JSON.stringify({ refreshed: true, registry: { installRecords: Object.fromEntries(ids.map((id) => [id, { source: \"path\" }])), plugins: ids.map((pluginId) => ({ pluginId })) } }));",
+      "  process.exit(0);",
+      "}",
+      'if (command === "@kova-self-check -- plugins list --json") {',
+      "  console.log(JSON.stringify({ plugins: ids.map((id) => ({ id })) }));",
+      "  process.exit(0);",
+      "}",
+      'console.error(`unexpected fake ocm command: ${command}`);',
+      "process.exit(1);"
+    ].join("\n")
+  );
+  await chmod(fakeOcm, 0o755);
+
+  const result = await runCommand(
+    `${quoteShell(process.execPath)} ${quoteShell(join(repoRoot, "support", "assert-many-plugin-pressure-state.mjs"))} --env kova-self-check --expected-count 80`,
+    {
+      env: { PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      timeoutMs: 30000,
+      maxOutputChars: 100000
+    }
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `many-plugin assertion helper failed: ${result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`}`
+    );
+  }
+  const payload = JSON.parse(result.stdout);
+  assertEqual(payload.canonicalInstallRecordCount, 80, "many-plugin canonical record count");
+  assertEqual(payload.registryPluginCount, 80, "many-plugin registry count");
+  assertEqual(payload.listedPluginCount, 80, "many-plugin listed count");
 }
 
 async function matrixWorkerRejectionCheck() {

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -1251,6 +1251,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       }
     ));
     checks.push(await stateLifecycleCommandIndexesCheck(tmp));
+    checks.push(await stateLifecycleFailureShortCircuitCheck(tmp));
     checks.push(await pluginInstallIndexFixturesCheck(tmp));
     checks.push(await jsonCommandCheck(
       "allowlisted-scenario-omitted-state-falls-back-json",
@@ -5646,6 +5647,63 @@ async function stateLifecycleCommandIndexesCheck(tmp) {
       id: "state-lifecycle-command-indexes",
       status: "FAIL",
       command: "execute multi-step state lifecycle with phase-wide command indexes",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
+async function stateLifecycleFailureShortCircuitCheck(tmp) {
+  const artifactDir = join(tmp, "state-lifecycle-failure-short-circuit");
+  const markerPath = join(artifactDir, "unexpected-preparer");
+  try {
+    const phase = await executeStateLifecycleSteps(
+      {
+        target: "runtime:stable",
+        targetPlan: {
+          kind: "runtime",
+          value: "stable",
+          startSelector: "stable",
+          upgradeSelector: "stable"
+        },
+        state: { id: "failed-preflight-state" },
+        timeoutMs: 30000,
+        resourceSampleIntervalMs: 250,
+        processRoles: []
+      },
+      "kova-self-check",
+      {
+        id: "state-lifecycle-failure-short-circuit-check",
+        surface: "fresh-install"
+      },
+      "prepare",
+      [
+        {
+          commands: [
+            `node ${quoteShell(join(repoRoot, "support", "tui-smoke.mjs"))}`,
+            `node ${quoteShell(join(repoRoot, "scripts", "large-session-fixture.mjs"))} prepare --root ${quoteShell(markerPath)} --shape valid`
+          ],
+          evidence: [],
+          collectionIntent: "skip-env"
+        }
+      ],
+      artifactDir
+    );
+    assertEqual(phase.commands.length, 2, "state lifecycle planned command count");
+    assertEqual(phase.results.length, 1, "state lifecycle stops after failed preflight");
+    assertEqual(phase.results[0]?.status, 2, "state lifecycle preserves failed preflight status");
+    await assertPathMissing(markerPath, "state lifecycle skipped command marker");
+    return {
+      id: "state-lifecycle-failure-short-circuit",
+      status: "PASS",
+      command: "stop state lifecycle after a failed preflight",
+      durationMs: phase.results[0]?.durationMs ?? 0
+    };
+  } catch (error) {
+    return {
+      id: "state-lifecycle-failure-short-circuit",
+      status: "FAIL",
+      command: "stop state lifecycle after a failed preflight",
       durationMs: 0,
       message: error.message
     };

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -70,6 +70,7 @@ import {
 import { runEntries } from "./run/engine.mjs";
 import { executeStateLifecycleSteps } from "./run/state-lifecycle.mjs";
 import { executeTargetSetup } from "./run/target-setup.mjs";
+import { classifyCommandFailure } from "./runner.mjs";
 import { classifyRetentionProtection, runGuardedTeardownStages } from "./run/teardown.mjs";
 import { runWithTargetRuntimeCleanup } from "./run/target-cleanup.mjs";
 import { loadProcessRoles } from "./registries/process-roles.mjs";
@@ -5662,12 +5663,12 @@ async function pluginInstallIndexFixturesCheck(tmp) {
     assertEqual(manyPluginStep?.commands?.length, 2, "many-plugin setup command count");
     assertEqual(
       manyPluginStep.commands[0],
-      "ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
+      "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1 --version-only && ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
       "many-plugin prepare command"
     );
     assertEqual(
       manyPluginStep.commands[1],
-      "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80",
+      "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1",
       "many-plugin assertion command"
     );
 
@@ -5777,6 +5778,10 @@ async function assertManyPluginPressureHelper(tmp, expectedIds) {
       "#!/usr/bin/env node",
       `const ids = ${JSON.stringify(expectedIds)};`,
       'const command = process.argv.slice(2).join(" ");',
+      'if (command === "@kova-self-check -- --version") {',
+      '  console.log("OpenClaw 2026.6.1 (selfcheck)");',
+      "  process.exit(0);",
+      "}",
       'if (command === "@kova-self-check -- doctor --fix --non-interactive") {',
       '  console.log("doctor repair complete");',
       "  process.exit(0);",
@@ -5795,8 +5800,23 @@ async function assertManyPluginPressureHelper(tmp, expectedIds) {
   );
   await chmod(fakeOcm, 0o755);
 
+  const versionOnly = await runCommand(
+    `${quoteShell(process.execPath)} ${quoteShell(join(repoRoot, "support", "assert-many-plugin-pressure-state.mjs"))} --env kova-self-check --expected-count 80 --minimum-openclaw-version 2026.6.1 --version-only`,
+    {
+      env: { PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      timeoutMs: 30000,
+      maxOutputChars: 100000
+    }
+  );
+  assertEqual(versionOnly.status, 0, "many-plugin release preflight succeeds at the floor");
+  const versionPayload = JSON.parse(versionOnly.stdout);
+  assertEqual(versionPayload.ok, true, "many-plugin release preflight accepts the floor");
+  assertEqual(versionPayload.doctorStatus, null, "many-plugin release preflight skips doctor");
+  assertEqual(versionPayload.registryStatus, null, "many-plugin release preflight skips registry");
+  assertEqual(versionPayload.listStatus, null, "many-plugin release preflight skips plugin list");
+
   const result = await runCommand(
-    `${quoteShell(process.execPath)} ${quoteShell(join(repoRoot, "support", "assert-many-plugin-pressure-state.mjs"))} --env kova-self-check --expected-count 80`,
+    `${quoteShell(process.execPath)} ${quoteShell(join(repoRoot, "support", "assert-many-plugin-pressure-state.mjs"))} --env kova-self-check --expected-count 80 --minimum-openclaw-version 2026.6.1`,
     {
       env: { PATH: `${binDir}:${process.env.PATH ?? ""}` },
       timeoutMs: 30000,
@@ -5809,9 +5829,31 @@ async function assertManyPluginPressureHelper(tmp, expectedIds) {
     );
   }
   const payload = JSON.parse(result.stdout);
+  assertEqual(payload.ok, true, "many-plugin assertion succeeds at the minimum release");
+  assertEqual(payload.openclawVersion, "2026.6.1", "many-plugin target version");
+  assertEqual(payload.minimumOpenClawVersion, "2026.6.1", "many-plugin minimum target version");
   assertEqual(payload.canonicalInstallRecordCount, 80, "many-plugin canonical record count");
   assertEqual(payload.registryPluginCount, 80, "many-plugin registry count");
   assertEqual(payload.listedPluginCount, 80, "many-plugin listed count");
+
+  const belowFloor = await runCommand(
+    `${quoteShell(process.execPath)} ${quoteShell(join(repoRoot, "support", "assert-many-plugin-pressure-state.mjs"))} --env kova-self-check --expected-count 80 --minimum-openclaw-version 2026.6.2`,
+    {
+      env: { PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      timeoutMs: 30000,
+      maxOutputChars: 100000
+    }
+  );
+  assertEqual(belowFloor.status, 1, "many-plugin unsupported release exits nonzero");
+  const blocked = JSON.parse(belowFloor.stdout);
+  assertEqual(blocked.ok, false, "many-plugin unsupported release is not accepted");
+  assertEqual(blocked.failureDomain, "kova-harness", "many-plugin release floor is harness-owned");
+  assertEqual(blocked.recordStatus, "BLOCKED", "many-plugin unsupported release blocks the record");
+  assertEqual(blocked.openclawVersion, "2026.6.1", "many-plugin blocked target version");
+  assertEqual(blocked.minimumOpenClawVersion, "2026.6.2", "many-plugin blocked minimum version");
+  assertEqual(blocked.doctorStatus, null, "many-plugin unsupported release skips doctor");
+  assertEqual(blocked.registryStatus, null, "many-plugin unsupported release skips registry refresh");
+  assertEqual(blocked.listStatus, null, "many-plugin unsupported release skips plugin list");
 }
 
 async function matrixWorkerRejectionCheck() {
@@ -24784,6 +24826,7 @@ function commandResultInterpretationCheck() {
     assertEqual(interpreted.interpretation.structured, true, "structured helper result detected");
     assertEqual(interpreted.interpretation.failureDomain, "kova-harness", "failure domain preserved");
     assertEqual(commandFailureRecordStatus(interpreted), "BLOCKED", "structured record status honored");
+    assertEqual(classifyCommandFailure(interpreted), "BLOCKED", "runner honors structured lifecycle status");
     const summary = buildReportSummary({
       schemaVersion: "kova.report.v1",
       mode: "execution",

--- a/states/many-bundled-plugins.json
+++ b/states/many-bundled-plugins.json
@@ -1,7 +1,7 @@
 {
   "id": "many-bundled-plugins",
   "title": "Many Installed Plugins",
-  "objective": "A pressure state for plugin and provider metadata paths. It migrates many synthetic install records into canonical SQLite state and verifies they are visible before OpenClaw startup and metadata measurements run.",
+  "objective": "A pressure state for plugin and provider metadata paths on OpenClaw 2026.6.1 or newer. It migrates many synthetic install records into canonical SQLite state and verifies they are visible before OpenClaw startup and metadata measurements run.",
   "tags": [
     "plugins",
     "providers",
@@ -11,7 +11,7 @@
     {
       "id": "prepare-many-plugin-pressure",
       "title": "Prepare Many Plugin Records",
-      "intent": "Create synthetic plugin packages, migrate their records into canonical state, and verify the measured runtime sees every plugin.",
+      "intent": "Confirm the target supports the shipped registry migration commands, create synthetic plugin packages, migrate their records into canonical state, and verify the measured runtime sees every plugin.",
       "afterPhases": [
         "env-create",
         "provision",
@@ -21,12 +21,12 @@
         "clone"
       ],
       "commands": [
-        "ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
-        "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80"
+        "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1 --version-only && ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
+        "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1"
       ],
       "evidence": [
         "80 synthetic install records migrated into canonical SQLite state",
-        "80 synthetic plugins visible through the refreshed registry and plugin list"
+        "OpenClaw 2026.6.1 or newer exposes 80 synthetic plugins through the refreshed registry and plugin list"
       ],
       "collectionIntent": "service-only"
     }
@@ -40,7 +40,7 @@
   "ownerArea": "plugins",
   "setupEvidence": [
     "80 synthetic install records migrated into canonical SQLite state",
-    "80 synthetic plugins visible through the refreshed registry and plugin list"
+    "OpenClaw 2026.6.1 or newer exposes 80 synthetic plugins through the refreshed registry and plugin list"
   ],
   "cleanupGuarantees": [
     "disposable env cleanup removes state fixture files"

--- a/states/many-bundled-plugins.json
+++ b/states/many-bundled-plugins.json
@@ -21,7 +21,8 @@
         "clone"
       ],
       "commands": [
-        "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1 --version-only && ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
+        "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1 --version-only",
+        "ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
         "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1"
       ],
       "evidence": [

--- a/states/many-bundled-plugins.json
+++ b/states/many-bundled-plugins.json
@@ -1,7 +1,7 @@
 {
   "id": "many-bundled-plugins",
-  "title": "Many Installed Plugins Enabled",
-  "objective": "A pressure state for plugin and provider metadata paths. It creates a canonical plugin install index with many synthetic entries so OpenClaw startup and metadata paths run under heavier registry pressure.",
+  "title": "Many Installed Plugins",
+  "objective": "A pressure state for plugin and provider metadata paths. It migrates many synthetic install records into canonical SQLite state and verifies they are visible before OpenClaw startup and metadata measurements run.",
   "tags": [
     "plugins",
     "providers",
@@ -9,22 +9,24 @@
   ],
   "setup": [
     {
-      "id": "write-many-plugin-index",
-      "title": "Write Many Plugin Index Entries",
-      "intent": "Create a large plugin install index in common OpenClaw plugin index locations.",
+      "id": "prepare-many-plugin-pressure",
+      "title": "Prepare Many Plugin Records",
+      "intent": "Create synthetic plugin packages, migrate their records into canonical state, and verify the measured runtime sees every plugin.",
       "afterPhases": [
+        "env-create",
         "provision",
-        "cold-start",
         "baseline",
         "gateway",
         "start",
         "clone"
       ],
       "commands": [
-        "ocm env exec {env} -- node -e 'const fs=require(\"fs\"), path=require(\"path\"); const home=process.env.OPENCLAW_HOME; const ids=Array.from({length:80},(_,i)=>`kova-plugin-${i}`); const installRecords={}; for (const id of ids) { const pluginDir=path.join(home,\"fixture-plugins\",id); fs.mkdirSync(pluginDir,{recursive:true}); fs.writeFileSync(path.join(pluginDir,\"package.json\"),JSON.stringify({name:`@kova/${id}`,version:\"0.0.0\",type:\"module\",openclaw:{extensions:[\"./index.js\"]}},null,2)); fs.writeFileSync(path.join(pluginDir,\"openclaw.plugin.json\"),JSON.stringify({id,configSchema:{type:\"object\",additionalProperties:false,properties:{}}},null,2)); fs.writeFileSync(path.join(pluginDir,\"index.js\"),`export default { id: ${JSON.stringify(id)}, register() {} };\\n`); installRecords[id]={source:\"path\",sourcePath:pluginDir,installPath:pluginDir,version:\"0.0.0\"}; } for (const rel of [\"plugins\",\".openclaw/plugins\"]) { const dir=path.join(home,rel); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,\"installs.json\"), JSON.stringify({installRecords}, null, 2)); }'"
+        "ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
+        "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80"
       ],
       "evidence": [
-        "canonical large plugin install index written"
+        "80 synthetic install records migrated into canonical SQLite state",
+        "80 synthetic plugins visible through the refreshed registry and plugin list"
       ],
       "collectionIntent": "service-only"
     }
@@ -37,7 +39,8 @@
   "riskArea": "plugin-metadata-scan",
   "ownerArea": "plugins",
   "setupEvidence": [
-    "canonical large plugin install index written"
+    "80 synthetic install records migrated into canonical SQLite state",
+    "80 synthetic plugins visible through the refreshed registry and plugin list"
   ],
   "cleanupGuarantees": [
     "disposable env cleanup removes state fixture files"

--- a/support/assert-many-plugin-pressure-state.mjs
+++ b/support/assert-many-plugin-pressure-state.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+const options = parseArgs(process.argv.slice(2));
+const expectedIds = Array.from(
+  { length: options.expectedCount },
+  (_, index) => `kova-plugin-${index}`
+);
+
+const doctor = await runProcess("ocm", [
+  `@${options.env}`,
+  "--",
+  "doctor",
+  "--fix",
+  "--non-interactive"
+]);
+const registry = doctor.status === 0
+  ? await runProcess("ocm", [
+      `@${options.env}`,
+      "--",
+      "plugins",
+      "registry",
+      "--refresh",
+      "--json"
+    ])
+  : skippedResult();
+const list = registry.status === 0
+  ? await runProcess("ocm", [`@${options.env}`, "--", "plugins", "list", "--json"])
+  : skippedResult();
+
+const registryPayload = parseJsonPayload(registry.stdout);
+const listPayload = parseJsonPayload(list.stdout);
+const installRecordIds = Object.keys(registryPayload?.registry?.installRecords ?? {});
+const registryPluginIds = (registryPayload?.registry?.plugins ?? [])
+  .map((plugin) => plugin?.pluginId)
+  .filter(Boolean);
+const listedPluginIds = (listPayload?.plugins ?? []).map((plugin) => plugin?.id).filter(Boolean);
+const missingInstallRecords = missingIds(expectedIds, installRecordIds);
+const missingRegistryPlugins = missingIds(expectedIds, registryPluginIds);
+const missingListedPlugins = missingIds(expectedIds, listedPluginIds);
+const ok =
+  doctor.status === 0 &&
+  registry.status === 0 &&
+  list.status === 0 &&
+  missingInstallRecords.length === 0 &&
+  missingRegistryPlugins.length === 0 &&
+  missingListedPlugins.length === 0;
+
+console.log(
+  JSON.stringify(
+    {
+      schemaVersion: "kova.manyPluginPressure.assertion.v1",
+      env: options.env,
+      expectedCount: options.expectedCount,
+      doctorStatus: doctor.status,
+      registryStatus: registry.status,
+      listStatus: list.status,
+      canonicalInstallRecordCount: countExpected(expectedIds, installRecordIds),
+      registryPluginCount: countExpected(expectedIds, registryPluginIds),
+      listedPluginCount: countExpected(expectedIds, listedPluginIds),
+      missingInstallRecords,
+      missingRegistryPlugins,
+      missingListedPlugins,
+      errors: ok
+        ? []
+        : [
+            failureSummary("doctor", doctor),
+            failureSummary("registry refresh", registry),
+            failureSummary("plugin list", list)
+          ].filter(Boolean)
+    },
+    null,
+    2
+  )
+);
+
+process.exit(ok ? 0 : 1);
+
+function parseArgs(args) {
+  const options = {
+    env: null,
+    expectedCount: 80
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--env") {
+      options.env = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--expected-count") {
+      options.expectedCount = Number.parseInt(args[index + 1], 10);
+      index += 1;
+      continue;
+    }
+    throw new Error(`unexpected argument: ${arg}`);
+  }
+  if (!/^kova-[a-z0-9][a-z0-9-]*$/i.test(String(options.env ?? ""))) {
+    throw new Error(`--env must be a disposable Kova env, got ${JSON.stringify(options.env)}`);
+  }
+  if (
+    !Number.isInteger(options.expectedCount) ||
+    options.expectedCount <= 0 ||
+    options.expectedCount > 500
+  ) {
+    throw new Error("--expected-count must be an integer between 1 and 500");
+  }
+  return options;
+}
+
+function runProcess(command, args) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => resolve({ status: 127, stdout, stderr: error.message }));
+    child.on("close", (status) => resolve({ status: status ?? 1, stdout, stderr }));
+  });
+}
+
+function skippedResult() {
+  return { status: 1, stdout: "", stderr: "skipped because a prerequisite command failed" };
+}
+
+function parseJsonPayload(output) {
+  const text = String(output ?? "").trim();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start < 0 || end <= start) {
+      return null;
+    }
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return null;
+    }
+  }
+}
+
+function missingIds(expected, actual) {
+  const actualIds = new Set(actual);
+  return expected.filter((id) => !actualIds.has(id));
+}
+
+function countExpected(expected, actual) {
+  const actualIds = new Set(actual);
+  return expected.filter((id) => actualIds.has(id)).length;
+}
+
+function failureSummary(label, result) {
+  if (result.status === 0) {
+    return null;
+  }
+  const detail = firstNonEmptyLine(`${result.stderr}\n${result.stdout}`);
+  return `${label} exited ${result.status}${detail ? `: ${detail}` : ""}`;
+}
+
+function firstNonEmptyLine(value) {
+  return String(value ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean) ?? "";
+}

--- a/support/assert-many-plugin-pressure-state.mjs
+++ b/support/assert-many-plugin-pressure-state.mjs
@@ -1,11 +1,92 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 
+const DEFAULT_MINIMUM_OPENCLAW_VERSION = "2026.6.1";
 const options = parseArgs(process.argv.slice(2));
 const expectedIds = Array.from(
   { length: options.expectedCount },
   (_, index) => `kova-plugin-${index}`
 );
+
+const version = await runProcess("ocm", [`@${options.env}`, "--", "--version"]);
+const openclawVersion = parseOpenClawVersion(`${version.stdout}\n${version.stderr}`);
+
+if (version.status !== 0) {
+  finish({
+    ok: false,
+    failureDomain: "openclaw",
+    recordStatus: "FAIL",
+    error: failureSummary("OpenClaw version", version),
+    versionStatus: version.status,
+    openclawVersion,
+    minimumOpenClawVersion: options.minimumOpenClawVersion,
+    doctorStatus: null,
+    registryStatus: null,
+    listStatus: null
+  });
+}
+
+if (!openclawVersion) {
+  finish({
+    ok: false,
+    failureDomain: "kova-harness",
+    recordStatus: "BLOCKED",
+    error: "could not determine the target OpenClaw version",
+    versionStatus: version.status,
+    openclawVersion: null,
+    minimumOpenClawVersion: options.minimumOpenClawVersion,
+    doctorStatus: null,
+    registryStatus: null,
+    listStatus: null
+  });
+}
+
+if (compareCalendarVersions(openclawVersion, options.minimumOpenClawVersion) < 0) {
+  finish({
+    ok: false,
+    failureDomain: "kova-harness",
+    recordStatus: "BLOCKED",
+    error: `many-bundled-plugins requires OpenClaw >= ${options.minimumOpenClawVersion}; target reports ${openclawVersion}`,
+    versionStatus: version.status,
+    openclawVersion,
+    minimumOpenClawVersion: options.minimumOpenClawVersion,
+    doctorStatus: null,
+    registryStatus: null,
+    listStatus: null
+  });
+}
+
+if (options.versionOnly) {
+  console.log(
+    JSON.stringify(
+      {
+        schemaVersion: "kova.manyPluginPressure.assertion.v1",
+        ok: true,
+        failureDomain: null,
+        recordStatus: null,
+        error: null,
+        env: options.env,
+        expectedCount: options.expectedCount,
+        versionStatus: version.status,
+        openclawVersion,
+        minimumOpenClawVersion: options.minimumOpenClawVersion,
+        doctorStatus: null,
+        registryStatus: null,
+        listStatus: null,
+        canonicalInstallRecordCount: 0,
+        registryPluginCount: 0,
+        listedPluginCount: 0,
+        missingInstallRecords: [],
+        missingRegistryPlugins: [],
+        missingListedPlugins: [],
+        errors: []
+      },
+      null,
+      2
+    )
+  );
+  process.exit(0);
+}
 
 const doctor = await runProcess("ocm", [
   `@${options.env}`,
@@ -45,13 +126,27 @@ const ok =
   missingInstallRecords.length === 0 &&
   missingRegistryPlugins.length === 0 &&
   missingListedPlugins.length === 0;
+const errors = ok
+  ? []
+  : [
+      failureSummary("doctor", doctor),
+      failureSummary("registry refresh", registry),
+      failureSummary("plugin list", list)
+    ].filter(Boolean);
 
 console.log(
   JSON.stringify(
     {
       schemaVersion: "kova.manyPluginPressure.assertion.v1",
+      ok,
+      failureDomain: ok ? null : "openclaw",
+      recordStatus: ok ? null : "FAIL",
+      error: errors[0] ?? null,
       env: options.env,
       expectedCount: options.expectedCount,
+      versionStatus: version.status,
+      openclawVersion,
+      minimumOpenClawVersion: options.minimumOpenClawVersion,
       doctorStatus: doctor.status,
       registryStatus: registry.status,
       listStatus: list.status,
@@ -61,13 +156,7 @@ console.log(
       missingInstallRecords,
       missingRegistryPlugins,
       missingListedPlugins,
-      errors: ok
-        ? []
-        : [
-            failureSummary("doctor", doctor),
-            failureSummary("registry refresh", registry),
-            failureSummary("plugin list", list)
-          ].filter(Boolean)
+      errors
     },
     null,
     2
@@ -79,7 +168,9 @@ process.exit(ok ? 0 : 1);
 function parseArgs(args) {
   const options = {
     env: null,
-    expectedCount: 80
+    expectedCount: 80,
+    minimumOpenClawVersion: DEFAULT_MINIMUM_OPENCLAW_VERSION,
+    versionOnly: false
   };
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -91,6 +182,15 @@ function parseArgs(args) {
     if (arg === "--expected-count") {
       options.expectedCount = Number.parseInt(args[index + 1], 10);
       index += 1;
+      continue;
+    }
+    if (arg === "--minimum-openclaw-version") {
+      options.minimumOpenClawVersion = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--version-only") {
+      options.versionOnly = true;
       continue;
     }
     throw new Error(`unexpected argument: ${arg}`);
@@ -105,7 +205,33 @@ function parseArgs(args) {
   ) {
     throw new Error("--expected-count must be an integer between 1 and 500");
   }
+  if (!parseCalendarVersion(options.minimumOpenClawVersion)) {
+    throw new Error("--minimum-openclaw-version must use YYYY.M.D");
+  }
   return options;
+}
+
+function finish(result) {
+  console.log(
+    JSON.stringify(
+      {
+        schemaVersion: "kova.manyPluginPressure.assertion.v1",
+        env: options.env,
+        expectedCount: options.expectedCount,
+        canonicalInstallRecordCount: 0,
+        registryPluginCount: 0,
+        listedPluginCount: 0,
+        missingInstallRecords: [],
+        missingRegistryPlugins: [],
+        missingListedPlugins: [],
+        errors: result.error ? [result.error] : [],
+        ...result
+      },
+      null,
+      2
+    )
+  );
+  process.exit(1);
 }
 
 function runProcess(command, args) {
@@ -160,6 +286,30 @@ function missingIds(expected, actual) {
 function countExpected(expected, actual) {
   const actualIds = new Set(actual);
   return expected.filter((id) => actualIds.has(id)).length;
+}
+
+function parseOpenClawVersion(value) {
+  const match = String(value ?? "").match(/\b(\d{4}\.\d{1,2}\.\d{1,2})(?:[-+][0-9A-Za-z.-]+)?\b/);
+  return match?.[1] ?? null;
+}
+
+function parseCalendarVersion(value) {
+  const match = String(value ?? "").match(/^(\d{4})\.(\d{1,2})\.(\d{1,2})$/);
+  return match ? match.slice(1).map((part) => Number.parseInt(part, 10)) : null;
+}
+
+function compareCalendarVersions(left, right) {
+  const leftParts = parseCalendarVersion(left);
+  const rightParts = parseCalendarVersion(right);
+  if (!leftParts || !rightParts) {
+    throw new Error(`cannot compare OpenClaw versions ${JSON.stringify(left)} and ${JSON.stringify(right)}`);
+  }
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] - rightParts[index];
+    }
+  }
+  return 0;
 }
 
 function failureSummary(label, result) {

--- a/support/prepare-many-plugin-pressure-state.mjs
+++ b/support/prepare-many-plugin-pressure-state.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const expectedCount = parseExpectedCount(process.argv.slice(2));
+const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
+
+if (!stateDir) {
+  console.error("OPENCLAW_STATE_DIR is required");
+  process.exit(2);
+}
+
+const pluginRoot = join(stateDir, "fixture-plugins");
+const legacyIndexPath = join(stateDir, "plugins", "installs.json");
+const installRecords = {};
+
+rmSync(pluginRoot, { recursive: true, force: true });
+mkdirSync(pluginRoot, { recursive: true });
+
+for (let index = 0; index < expectedCount; index += 1) {
+  const id = `kova-plugin-${index}`;
+  const pluginDir = join(pluginRoot, id);
+  mkdirSync(pluginDir, { recursive: true });
+  writeFileSync(
+    join(pluginDir, "package.json"),
+    JSON.stringify(
+      {
+        name: `@kova/${id}`,
+        version: "0.0.0",
+        type: "module",
+        openclaw: { extensions: ["./index.js"] }
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(
+    join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id,
+        configSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {}
+        }
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(
+    join(pluginDir, "index.js"),
+    `export default { id: ${JSON.stringify(id)}, register() {} };\n`
+  );
+  installRecords[id] = {
+    source: "path",
+    sourcePath: pluginDir,
+    installPath: pluginDir,
+    version: "0.0.0"
+  };
+}
+
+mkdirSync(join(stateDir, "plugins"), { recursive: true });
+writeFileSync(legacyIndexPath, JSON.stringify({ installRecords }, null, 2));
+
+console.log(
+  JSON.stringify(
+    {
+      schemaVersion: "kova.manyPluginPressure.prepare.v1",
+      expectedCount,
+      legacyIndexPath,
+      pluginRoot
+    },
+    null,
+    2
+  )
+);
+
+function parseExpectedCount(args) {
+  let count = 80;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--expected-count") {
+      count = Number.parseInt(args[index + 1], 10);
+      index += 1;
+      continue;
+    }
+    throw new Error(`unexpected argument: ${arg}`);
+  }
+  if (!Number.isInteger(count) || count <= 0 || count > 500) {
+    throw new Error("--expected-count must be an integer between 1 and 500");
+  }
+  return count;
+}

--- a/tests/snapshots/matrix-plan-json.snap
+++ b/tests/snapshots/matrix-plan-json.snap
@@ -612,7 +612,7 @@
       "state": {
         "id": "many-bundled-plugins",
         "title": "Many Installed Plugins",
-        "objective": "A pressure state for plugin and provider metadata paths. It migrates many synthetic install records into canonical SQLite state and verifies they are visible before OpenClaw startup and metadata measurements run.",
+        "objective": "A pressure state for plugin and provider metadata paths on OpenClaw 2026.6.1 or newer. It migrates many synthetic install records into canonical SQLite state and verifies they are visible before OpenClaw startup and metadata measurements run.",
         "tags": [
           "plugins",
           "providers",

--- a/tests/snapshots/matrix-plan-json.snap
+++ b/tests/snapshots/matrix-plan-json.snap
@@ -611,8 +611,8 @@
       },
       "state": {
         "id": "many-bundled-plugins",
-        "title": "Many Installed Plugins Enabled",
-        "objective": "A pressure state for plugin and provider metadata paths. It creates a canonical plugin install index with many synthetic entries so OpenClaw startup and metadata paths run under heavier registry pressure.",
+        "title": "Many Installed Plugins",
+        "objective": "A pressure state for plugin and provider metadata paths. It migrates many synthetic install records into canonical SQLite state and verifies they are visible before OpenClaw startup and metadata measurements run.",
         "tags": [
           "plugins",
           "providers",

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -16261,7 +16261,7 @@
     {
       "id": "many-bundled-plugins",
       "title": "Many Installed Plugins",
-      "objective": "A pressure state for plugin and provider metadata paths. It migrates many synthetic install records into canonical SQLite state and verifies they are visible before OpenClaw startup and metadata measurements run.",
+      "objective": "A pressure state for plugin and provider metadata paths on OpenClaw 2026.6.1 or newer. It migrates many synthetic install records into canonical SQLite state and verifies they are visible before OpenClaw startup and metadata measurements run.",
       "tags": [
         "plugins",
         "providers",
@@ -16271,7 +16271,7 @@
         {
           "id": "prepare-many-plugin-pressure",
           "title": "Prepare Many Plugin Records",
-          "intent": "Create synthetic plugin packages, migrate their records into canonical state, and verify the measured runtime sees every plugin.",
+          "intent": "Confirm the target supports the shipped registry migration commands, create synthetic plugin packages, migrate their records into canonical state, and verify the measured runtime sees every plugin.",
           "afterPhases": [
             "env-create",
             "provision",
@@ -16281,12 +16281,12 @@
             "clone"
           ],
           "commands": [
-            "ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
-            "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80"
+            "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1 --version-only && ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
+            "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1"
           ],
           "evidence": [
             "80 synthetic install records migrated into canonical SQLite state",
-            "80 synthetic plugins visible through the refreshed registry and plugin list"
+            "OpenClaw 2026.6.1 or newer exposes 80 synthetic plugins through the refreshed registry and plugin list"
           ],
           "collectionIntent": "service-only"
         }
@@ -16300,7 +16300,7 @@
       "ownerArea": "plugins",
       "setupEvidence": [
         "80 synthetic install records migrated into canonical SQLite state",
-        "80 synthetic plugins visible through the refreshed registry and plugin list"
+        "OpenClaw 2026.6.1 or newer exposes 80 synthetic plugins through the refreshed registry and plugin list"
       ],
       "cleanupGuarantees": [
         "disposable env cleanup removes state fixture files"

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -16260,8 +16260,8 @@
     },
     {
       "id": "many-bundled-plugins",
-      "title": "Many Installed Plugins Enabled",
-      "objective": "A pressure state for plugin and provider metadata paths. It creates a canonical plugin install index with many synthetic entries so OpenClaw startup and metadata paths run under heavier registry pressure.",
+      "title": "Many Installed Plugins",
+      "objective": "A pressure state for plugin and provider metadata paths. It migrates many synthetic install records into canonical SQLite state and verifies they are visible before OpenClaw startup and metadata measurements run.",
       "tags": [
         "plugins",
         "providers",
@@ -16269,22 +16269,24 @@
       ],
       "setup": [
         {
-          "id": "write-many-plugin-index",
-          "title": "Write Many Plugin Index Entries",
-          "intent": "Create a large plugin install index in common OpenClaw plugin index locations.",
+          "id": "prepare-many-plugin-pressure",
+          "title": "Prepare Many Plugin Records",
+          "intent": "Create synthetic plugin packages, migrate their records into canonical state, and verify the measured runtime sees every plugin.",
           "afterPhases": [
+            "env-create",
             "provision",
-            "cold-start",
             "baseline",
             "gateway",
             "start",
             "clone"
           ],
           "commands": [
-            "ocm env exec {env} -- node -e 'const fs=require(\"fs\"), path=require(\"path\"); const home=process.env.OPENCLAW_HOME; const ids=Array.from({length:80},(_,i)=>`kova-plugin-${i}`); const installRecords={}; for (const id of ids) { const pluginDir=path.join(home,\"fixture-plugins\",id); fs.mkdirSync(pluginDir,{recursive:true}); fs.writeFileSync(path.join(pluginDir,\"package.json\"),JSON.stringify({name:`@kova/${id}`,version:\"0.0.0\",type:\"module\",openclaw:{extensions:[\"./index.js\"]}},null,2)); fs.writeFileSync(path.join(pluginDir,\"openclaw.plugin.json\"),JSON.stringify({id,configSchema:{type:\"object\",additionalProperties:false,properties:{}}},null,2)); fs.writeFileSync(path.join(pluginDir,\"index.js\"),`export default { id: ${JSON.stringify(id)}, register() {} };\\n`); installRecords[id]={source:\"path\",sourcePath:pluginDir,installPath:pluginDir,version:\"0.0.0\"}; } for (const rel of [\"plugins\",\".openclaw/plugins\"]) { const dir=path.join(home,rel); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,\"installs.json\"), JSON.stringify({installRecords}, null, 2)); }'"
+            "ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
+            "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80"
           ],
           "evidence": [
-            "canonical large plugin install index written"
+            "80 synthetic install records migrated into canonical SQLite state",
+            "80 synthetic plugins visible through the refreshed registry and plugin list"
           ],
           "collectionIntent": "service-only"
         }
@@ -16297,7 +16299,8 @@
       "riskArea": "plugin-metadata-scan",
       "ownerArea": "plugins",
       "setupEvidence": [
-        "canonical large plugin install index written"
+        "80 synthetic install records migrated into canonical SQLite state",
+        "80 synthetic plugins visible through the refreshed registry and plugin list"
       ],
       "cleanupGuarantees": [
         "disposable env cleanup removes state fixture files"

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -16281,7 +16281,8 @@
             "clone"
           ],
           "commands": [
-            "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1 --version-only && ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
+            "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1 --version-only",
+            "ocm env exec {env} -- node {kovaRoot}/support/prepare-many-plugin-pressure-state.mjs --expected-count 80",
             "node {kovaRoot}/support/assert-many-plugin-pressure-state.mjs --env {env} --expected-count 80 --minimum-openclaw-version 2026.6.1"
           ],
           "evidence": [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Kova's many-plugin pressure state wrote retired JSON state after cold startup, so performance runs could claim plugin pressure without loading the 80 synthetic plugins into OpenClaw's canonical state.

## Why This Change Was Made

The fixture now prepares valid synthetic plugin packages inside the disposable OCM environment, migrates their install records through `openclaw doctor --fix`, refreshes the registry, and fails setup unless all 80 plugins are visible in canonical install records, the registry, and the public plugin list.

This fixture targets OpenClaw `>=2026.6.1`, the first release with the canonical SQLite plugin state required by this scenario. The target-version preflight runs before the fixture preparer, so unsupported targets return a structured `BLOCKED` result without mutating the environment.

The destructive preparer is not an approved direct Node scenario entry point; its only scenario route is nested inside `ocm env exec kova-*`. The version preflight, preparer, and final assertion are separate lifecycle commands so each materialized command passes Kova's top-level safety parser.

## User Impact

Kova gateway-performance runs using `many-bundled-plugins` now measure real cold-start plugin pressure. A broken or incomplete fixture fails before measurements instead of producing misleading green evidence. Older unsupported targets are blocked before fixture mutation rather than failing partway through setup.

## Evidence

- Exact head: `28c2d2331041f4a2e98e182e78994ba3f8d3be62`
- `npm run check`: 275/275 passed
- `npm run test:snapshots`: 21/21 passed
- `npm run check:web-payload`: passed
- `npm run test:release-contracts`: passed
- `git diff --check`: passed
- Exact-commit autoreview: clean; no P0 findings
- TruffleHog: clean
- Release-owned `CHANGELOG.md` entry removed; user-visible context remains in this PR body
- Lifecycle command safety:
  - the preflight, preparer, and final assertion are three independent commands; no compound `&&` command remains
  - lifecycle execution now stops after the first nonzero command result, so a blocked or failed preflight cannot run the mutating preparer
  - regression proof plans two commands, observes only the failing preflight, preserves status 2, and confirms the preparer marker was never created
  - selfcheck materializes the real lifecycle commands and passes each through `assertSafeScenarioCommand`
  - fresh disposable OpenClaw `2026.6.1` run completed all three commands and reported 80 canonical install records, 80 registry plugins, and 80 listed plugins
- Preflight containment:
  - direct preparer invocation is rejected by scenario safety
  - `ocm env exec kova-* -- node ...prepare-many-plugin-pressure-state.mjs` remains approved
  - OpenClaw `2026.4.25` returns structured `BLOCKED` before the fixture directory or install index is created
- Supported release proof:
  - OpenClaw `2026.6.1` completes fixture preparation and reports 80 canonical install records, 80 registry plugins, and 80 listed plugins
- Exact OpenClaw candidate runs `kova-260804-024746-058402` and `kova-260804-025454-d3e8ab`: 80 canonical install records, 80 registry plugins, 80 listed plugins
- Exact OpenClaw main runs `kova-260804-025349-9f7754` and `kova-260804-025546-f78834`: 80 canonical install records, 80 registry plugins, 80 listed plugins
