### PR TITLE
fix: local runtime builds stop failing at two minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Give local runtime packaging its own bounded setup budget instead of aborting it at the shorter scenario command timeout.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
-- Give local runtime packaging its own bounded setup budget instead of aborting it at the shorter scenario command timeout.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.

--- a/src/run/target-setup.mjs
+++ b/src/run/target-setup.mjs
@@ -4,6 +4,8 @@ import { collectorArtifactDirs } from "../collectors/artifacts.mjs";
 import { tagCommandResult } from "../measurement-contract.mjs";
 import { buildTargetSetupPhase } from "./phase-plan.mjs";
 
+const localBuildSetupTimeoutMs = 10 * 60_000;
+
 export async function executeTargetSetup(context, envName, artifactDir) {
   const phase = buildTargetSetupPhase(context, envName);
   if (!phase) {
@@ -51,7 +53,9 @@ export async function executeTargetSetup(context, envName, artifactDir) {
 async function runTargetSetup(phase, context, envName, artifactDir) {
   return [
     tagCommandResult(await runCommand(phase.commands[0], {
-      timeoutMs: context.timeoutMs,
+      // Packaging and dependency installation outlive scenario command budgets
+      // on ordinary hosts, but matrices still share this one bounded build.
+      timeoutMs: localBuildSetupTimeoutMs,
       env: {
         ...(context.commandEnv ?? {}),
         KOVA_ENV_NAME: envName,

--- a/tests/selfcheck-isolation.mjs
+++ b/tests/selfcheck-isolation.mjs
@@ -19,6 +19,7 @@ const root = await mkdtemp(join(tmpdir(), "kova-selfcheck-isolation-test-"));
 
 try {
   await verifyScopedShell(root);
+  await verifyTargetSetupBuildTimeoutBudget(root);
   await verifyConcurrentInvocationHomes(root);
 
   const scopes = [createSelfCheckScope(), createSelfCheckScope()];
@@ -73,6 +74,38 @@ exec /bin/sh "$@"
   assert.equal(result.status, 0);
   assert.equal(result.stdout, "scoped-shell");
   assert.equal((await readFile(shellLog, "utf8")).trim(), shellPath);
+}
+
+async function verifyTargetSetupBuildTimeoutBudget(parentDir) {
+  const shellPath = join(parentDir, "slow-build-shell");
+  await writeFile(shellPath, `#!/bin/sh
+sleep 0.05
+exit 0
+`, "utf8");
+  await chmod(shellPath, 0o755);
+
+  const results = await executeTargetSetup({
+    targetPlan: {
+      kind: "local-build",
+      runtimeName: "kova-local-build-timeout",
+      repoPath: "/tmp/openclaw"
+    },
+    timeoutMs: 10,
+    resourceSampling: false,
+    commandEnv: {
+      SHELL: shellPath
+    },
+    targetSetup: {
+      completed: false,
+      failed: false,
+      results: [],
+      inFlight: null
+    }
+  }, "kova-build-timeout", parentDir);
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].status, 0);
+  assert.equal(results[0].timedOut, false);
 }
 
 async function verifyConcurrentInvocationHomes(parentDir) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Kova local-build runs could fail during target setup after two minutes even while OpenClaw packaging was still making progress.

The observed run exited `124` after `120134ms` while `npm pack`, the OpenClaw prepack build, and `tsdown` extension compilation were active. Reproduced package builds completed in roughly 2m19s and 3m35s.

## Why This Change Was Made

Local runtime packaging now owns a bounded 10-minute setup deadline instead of inheriting the shorter per-scenario command timeout. The existing matrix single-flight behavior remains unchanged, so parallel scenarios still share one build.

No public flag, profile, or configuration surface is added.

## User Impact

Operators can run local-build scenarios on ordinary hosts without healthy package builds being terminated at the generic two-minute scenario deadline. A genuinely stuck build remains bounded.

## Evidence

- `node tests/selfcheck-isolation.mjs`
- `npm run check:full`
  - 274/274 self-checks
  - 21/21 snapshots
  - web payload contract passed
  - release contract checks passed
- Branch autoreview: clean, 0.98 confidence
- TruffleHog: clean
- Production delta: +5/-1 lines
