### PR TITLE
improve(harness): cover mock provider aliases

### DIFF
--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -25188,17 +25188,57 @@ async function mockAuthOpenClawConfigCheck(tmp) {
   const portFile = join(tmp, "mock-auth-port");
   await writeFile(portFile, "12345\n", "utf8");
   const contracts = [
-    { id: "canonical", home: join(tmp, "mock-auth-config-canonical") },
-    { id: "legacy-list", home: join(tmp, "mock-auth-config-legacy") }
+    {
+      id: "canonical",
+      configContract: "canonical",
+      home: join(tmp, "mock-auth-config-canonical"),
+      providerId: "openai"
+    },
+    {
+      id: "legacy-list",
+      configContract: "legacy-list",
+      home: join(tmp, "mock-auth-config-legacy"),
+      providerId: "openai"
+    },
+    {
+      id: "canonical-provider-alias",
+      configContract: "canonical",
+      home: join(tmp, "mock-auth-config-provider-alias"),
+      providerId: "x-ai"
+    }
   ];
   const commands = [];
   let durationMs = 0;
   try {
     for (const contract of contracts) {
+      if (contract.providerId === "x-ai") {
+        const stateDir = join(contract.home, ".openclaw");
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(
+          join(stateDir, "openclaw.json"),
+          `${JSON.stringify({
+            models: {
+              providers: {
+                openai: {
+                  request: {
+                    openaiOnly: true
+                  }
+                },
+                "x-ai": {
+                  request: {
+                    aliasOnly: true
+                  }
+                }
+              }
+            }
+          }, null, 2)}\n`,
+          "utf8"
+        );
+      }
       const command = [
-        `KOVA_OPENCLAW_CONFIG_CONTRACT=${contract.id}`,
+        `KOVA_OPENCLAW_CONFIG_CONTRACT=${contract.configContract}`,
         `OPENCLAW_HOME=${quoteShell(contract.home)}`,
-        `node support/configure-openclaw-mock-auth.mjs --port-file ${quoteShell(portFile)} --skip-health-check --gateway-http-endpoint chatCompletions`
+        `node support/configure-openclaw-mock-auth.mjs --port-file ${quoteShell(portFile)} --provider-id ${contract.providerId} --skip-health-check --gateway-http-endpoint chatCompletions`
       ].join(" ");
       commands.push(command);
       const result = await runCommand(command, { timeoutMs: 30000, maxOutputChars: 1000000 });
@@ -25209,19 +25249,28 @@ async function mockAuthOpenClawConfigCheck(tmp) {
       const config = JSON.parse(
         await readFile(join(contract.home, ".openclaw", "openclaw.json"), "utf8")
       );
-      assertEqual(config.models?.providers?.openai?.baseUrl, "http://127.0.0.1:12345/v1", "mock provider base URL");
-      assertEqual(config.agents?.defaults?.model?.primary, "openai/gpt-5.5", "mock default model");
+      const provider = config.models?.providers?.[contract.providerId];
+      assertEqual(provider?.baseUrl, "http://127.0.0.1:12345/v1", `${contract.id} mock provider base URL`);
+      assertEqual(
+        config.agents?.defaults?.model?.primary,
+        `${contract.providerId}/gpt-5.5`,
+        `${contract.id} mock default model`
+      );
       assertEqual(config.gateway?.auth?.mode, "token", "mock gateway token mode");
       assertEqual(config.gateway?.auth?.token, "kova-mock-gateway-token", "mock gateway auth token");
       assertEqual(config.gateway?.remote?.token, "kova-mock-gateway-token", "mock gateway remote token");
       assertEqual(config.gateway?.http?.endpoints?.chatCompletions?.enabled, true, "mock gateway chat completions endpoint enabled");
+      if (contract.providerId === "x-ai") {
+        assertEqual(provider?.request?.aliasOnly, true, "provider alias request settings");
+        assertEqual(provider?.request?.openaiOnly, undefined, "provider alias excludes OpenAI request settings");
+      }
       if (contract.id === "legacy-list") {
         assertEqual(Array.isArray(config.agents?.list), true, "legacy mock config agent list");
         assertEqual(config.agents?.entries, undefined, "legacy mock config omits agent entries");
         assertEqual(
           config.agents?.defaults?.imageGenerationModel?.primary,
-          "openai/gpt-image-1",
-          "legacy mock image model"
+          `${contract.providerId}/gpt-image-1`,
+          `${contract.id} mock image model`
         );
         assertEqual(config.agents?.defaults?.mediaModels, undefined, "legacy mock config omits media models");
       } else {
@@ -25229,8 +25278,13 @@ async function mockAuthOpenClawConfigCheck(tmp) {
         assertEqual(config.agents?.list, undefined, "canonical mock config omits agent list");
         assertEqual(
           config.agents?.defaults?.mediaModels?.image?.primary,
-          "openai/gpt-image-1",
-          "canonical mock image model"
+          `${contract.providerId}/gpt-image-1`,
+          `${contract.id} mock image model`
+        );
+        assertEqual(
+          config.agents?.defaults?.mediaModels?.video?.primary,
+          `${contract.providerId}/sora-2`,
+          `${contract.id} mock video model`
         );
         assertEqual(
           config.agents?.defaults?.imageGenerationModel,

--- a/states/mock-openai-provider-alias.json
+++ b/states/mock-openai-provider-alias.json
@@ -1,0 +1,56 @@
+{
+  "id": "mock-openai-provider-alias",
+  "title": "Mock OpenAI Provider Alias",
+  "objective": "A local OpenAI-compatible provider configured through the x-ai provider alias so OpenClaw exercises manifest-owned provider policy resolution without external model dependencies.",
+  "tags": [
+    "agent",
+    "models",
+    "providers",
+    "mock",
+    "latency",
+    "alias"
+  ],
+  "setup": [
+    {
+      "id": "configure-provider-alias",
+      "title": "Configure Provider Alias",
+      "intent": "Rewrite the mock provider config to use x-ai after Kova creates the disposable OpenClaw environment.",
+      "afterPhase": "provision",
+      "commands": [
+        "ocm env exec {env} -- node {kovaRoot}/support/configure-openclaw-mock-auth.mjs --port-file {artifactDir}/mock-openai/port --provider-id x-ai"
+      ],
+      "evidence": [
+        "OpenClaw config points x-ai at the mock provider",
+        "default agent model is x-ai/gpt-5.5"
+      ],
+      "collectionIntent": "service-only"
+    }
+  ],
+  "auth": {
+    "mode": "mock",
+    "reason": "Use the run-level mock provider auth contract before rewriting the provider key to x-ai."
+  },
+  "traits": [
+    "mock-provider",
+    "provider-pressure",
+    "agent-state",
+    "performance-pressure"
+  ],
+  "riskArea": "agent-provider-policy-latency",
+  "ownerArea": "agent-runtime",
+  "setupEvidence": [
+    "mock provider port",
+    "mock provider request log",
+    "mock provider health",
+    "OpenClaw config points x-ai to the mock provider",
+    "default agent model is x-ai/gpt-5.5"
+  ],
+  "cleanupGuarantees": [
+    "run-level mock provider cleanup stops fixture process",
+    "disposable env cleanup removes alias provider config"
+  ],
+  "source": {
+    "kind": "provider-compatible-mock-server",
+    "command": "mock-ai-provider serve --providers openai"
+  }
+}

--- a/support/configure-openclaw-mock-auth.mjs
+++ b/support/configure-openclaw-mock-auth.mjs
@@ -7,6 +7,7 @@ if (!options.portFile) {
   throw new Error("--port-file is required");
 }
 const configContract = resolveConfigContract(process.env.KOVA_OPENCLAW_CONFIG_CONTRACT);
+const providerId = resolveProviderId(options.providerId);
 
 const port = fs.readFileSync(options.portFile, "utf8").trim();
 if (!/^\d+$/.test(port)) {
@@ -36,9 +37,9 @@ try {
   config = {};
 }
 
-const modelRef = "openai/gpt-5.5";
-const imageModelRef = "openai/gpt-image-1";
-const videoModelRef = "openai/sora-2";
+const modelRef = `${providerId}/gpt-5.5`;
+const imageModelRef = `${providerId}/gpt-image-1`;
+const videoModelRef = `${providerId}/sora-2`;
 const gatewayToken = "kova-mock-gateway-token";
 const existingAgents = asObject(config.agents);
 const existingAgentEntries = asObject(config.agents?.entries);
@@ -68,8 +69,8 @@ config.models = {
   mode: "merge",
   providers: {
     ...(config.models?.providers || {}),
-    openai: {
-      ...(config.models?.providers?.openai || {}),
+    [providerId]: {
+      ...(config.models?.providers?.[providerId] || {}),
       baseUrl: `http://127.0.0.1:${port}/v1`,
       apiKey: {
         source: "env",
@@ -78,7 +79,7 @@ config.models = {
       },
       api: "openai-responses",
       request: {
-        ...(config.models?.providers?.openai?.request || {}),
+        ...(config.models?.providers?.[providerId]?.request || {}),
         allowPrivateNetwork: true
       },
       models: [
@@ -280,6 +281,7 @@ function parseArgs(args) {
   }
   return {
     portFile: parsed.portfile,
+    providerId: parsed.providerid,
     skipHealthCheck: parsed.skiphealthcheck === true,
     gatewayHttpEndpoints: parsed.gatewayHttpEndpoints
   };
@@ -297,6 +299,14 @@ function resolveConfigContract(value) {
     );
   }
   return contract;
+}
+
+function resolveProviderId(value) {
+  const providerId = value?.trim() || "openai";
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(providerId)) {
+    throw new Error(`invalid --provider-id: ${JSON.stringify(value)}`);
+  }
+  return providerId;
 }
 
 function requiredEnv(name) {

--- a/surfaces/agent-cli-local-turn.json
+++ b/surfaces/agent-cli-local-turn.json
@@ -56,7 +56,8 @@
       "id": "baseline",
       "states": [
         "agent-auth-missing",
-        "mock-openai-provider"
+        "mock-openai-provider",
+        "mock-openai-provider-alias"
       ],
       "targetKinds": [
         "npm",

--- a/tests/snapshots/matrix-plan-json.snap
+++ b/tests/snapshots/matrix-plan-json.snap
@@ -281,7 +281,8 @@
         "reason": null,
         "requiredStates": [
           "agent-auth-missing",
-          "mock-openai-provider"
+          "mock-openai-provider",
+          "mock-openai-provider-alias"
         ],
         "requiredStateTraits": [],
         "requiredTargetKinds": [

--- a/tests/snapshots/plan-default.snap
+++ b/tests/snapshots/plan-default.snap
@@ -3,7 +3,7 @@
 ╚══════════════════════════════════════════════════════════════════════════════╝
    61 scenarios · 41 surfaces                <os> <os-release> · <arch> · <node>
 
-  Scenarios 61   ·   States 43   ·   Profiles 12   ·   Surfaces 41
+  Scenarios 61   ·   States 44   ·   Profiles 12   ·   Surfaces 41
 
 ─── surfaces by owner ──────────────────────────────────────────────────────────
   ◆ OpenClaw  2 surfaces · 2 scenarios

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -138,7 +138,8 @@
           "id": "baseline",
           "states": [
             "agent-auth-missing",
-            "mock-openai-provider"
+            "mock-openai-provider",
+            "mock-openai-provider-alias"
           ],
           "targetKinds": [
             "npm",
@@ -16377,6 +16378,62 @@
       "cleanupGuarantees": [
         "disposable env cleanup removes state fixture files"
       ]
+    },
+    {
+      "id": "mock-openai-provider-alias",
+      "title": "Mock OpenAI Provider Alias",
+      "objective": "A local OpenAI-compatible provider configured through the x-ai provider alias so OpenClaw exercises manifest-owned provider policy resolution without external model dependencies.",
+      "tags": [
+        "agent",
+        "models",
+        "providers",
+        "mock",
+        "latency",
+        "alias"
+      ],
+      "setup": [
+        {
+          "id": "configure-provider-alias",
+          "title": "Configure Provider Alias",
+          "intent": "Rewrite the mock provider config to use x-ai after Kova creates the disposable OpenClaw environment.",
+          "afterPhase": "provision",
+          "commands": [
+            "ocm env exec {env} -- node {kovaRoot}/support/configure-openclaw-mock-auth.mjs --port-file {artifactDir}/mock-openai/port --provider-id x-ai"
+          ],
+          "evidence": [
+            "OpenClaw config points x-ai at the mock provider",
+            "default agent model is x-ai/gpt-5.5"
+          ],
+          "collectionIntent": "service-only"
+        }
+      ],
+      "auth": {
+        "mode": "mock",
+        "reason": "Use the run-level mock provider auth contract before rewriting the provider key to x-ai."
+      },
+      "traits": [
+        "mock-provider",
+        "provider-pressure",
+        "agent-state",
+        "performance-pressure"
+      ],
+      "riskArea": "agent-provider-policy-latency",
+      "ownerArea": "agent-runtime",
+      "setupEvidence": [
+        "mock provider port",
+        "mock provider request log",
+        "mock provider health",
+        "OpenClaw config points x-ai to the mock provider",
+        "default agent model is x-ai/gpt-5.5"
+      ],
+      "cleanupGuarantees": [
+        "run-level mock provider cleanup stops fixture process",
+        "disposable env cleanup removes alias provider config"
+      ],
+      "source": {
+        "kind": "provider-compatible-mock-server",
+        "command": "mock-ai-provider serve --providers openai"
+      }
     },
     {
       "id": "mock-openai-provider",


### PR DESCRIPTION
## What Problem This Solves

Kova could only provision its local OpenAI-compatible mock under the canonical `openai` provider key. That left provider-alias policy paths such as `x-ai` without a reusable, dependency-free runtime fixture.

## Why This Change Was Made

Add a validated `--provider-id` option to the existing mock-auth configurator and a dedicated `mock-openai-provider-alias` state for `agent-cli-local-turn`. The configurator preserves request settings from the selected provider, updates primary and media model references consistently, and defaults to the existing `openai` behavior.

The alias state is registered only for the surface it currently proves; it is not added to standard profiles.

## User Impact

Kova operators can reproduce and measure manifest-owned provider alias behavior against a local mock provider without external credentials or network model calls.

## Evidence

- `node bin/kova.mjs self-check --json`: all checks passed, including canonical, legacy-list, and `x-ai` mock-auth config contracts.
- `node tests/render-snapshots.mjs`: 21/21 snapshots passed after regeneration.
- Dry-run planning accepted `agent-cold-warm-message` with `mock-openai-provider-alias`.
- Real disposable exact-head run `kova-260804-181313-e7313c`: 1/1 PASS.
- Cleanup verified: no remaining OCM environments, services, or mock-provider processes.
- `node --check` passed for the modified scripts.
- `git diff --check` passed.
- Autoreview: clean, confidence 0.98.

AI-assisted implementation and review; the maintainer verified the final diff and runtime evidence.
