### PR TITLE
fix(frontage): handle proxy log stream errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
-- Keep the network-frontage proxy parent alive when the proxy log stream or stderr pipe cannot be written.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Keep the network-frontage proxy parent alive when the proxy log stream or stderr pipe cannot be written.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.

--- a/src/network-frontage.mjs
+++ b/src/network-frontage.mjs
@@ -292,7 +292,13 @@ export function attachProxyLogStream(log, stderr) {
   const onError = (error) => {
     console.error(`network frontage proxy log stream error: ${error?.message ?? error}`);
   };
-  log.on("error", onError);
+  log.on("error", (error) => {
+    onError(error);
+    if (stderr) {
+      stderr.unpipe(log);
+      stderr.resume();
+    }
+  });
   if (stderr) {
     stderr.on("error", onError);
     stderr.pipe(log);

--- a/src/network-frontage.mjs
+++ b/src/network-frontage.mjs
@@ -288,6 +288,17 @@ export function summarizeNetworkFrontage(records = [], controls = null) {
   };
 }
 
+export function attachProxyLogStream(log, stderr) {
+  const onError = (error) => {
+    console.error(`network frontage proxy log stream error: ${error?.message ?? error}`);
+  };
+  log.on("error", onError);
+  if (stderr) {
+    stderr.on("error", onError);
+    stderr.pipe(log);
+  }
+}
+
 function startProxy(allocation) {
   const childArgs = [
     join(repoRoot, "support", "network-frontage-proxy.mjs"),
@@ -300,7 +311,7 @@ function startProxy(allocation) {
   const child = spawn(process.execPath, childArgs, {
     stdio: ["ignore", "ignore", "pipe"]
   });
-  child.stderr.pipe(log);
+  attachProxyLogStream(log, child.stderr);
   const closed = new Promise((resolve) => child.once("close", (code, signal) => resolve({ code, signal })));
   child.once("close", () => log.end());
   return {

--- a/src/network-frontage.mjs
+++ b/src/network-frontage.mjs
@@ -305,7 +305,7 @@ export function attachProxyLogStream(log, stderr) {
   }
 }
 
-function startProxy(allocation) {
+export function startProxy(allocation) {
   const childArgs = [
     join(repoRoot, "support", "network-frontage-proxy.mjs"),
     "--listen-host", allocation.frontageHost,

--- a/src/network-frontage.mjs
+++ b/src/network-frontage.mjs
@@ -405,6 +405,7 @@ export function waitForProxyReady(child, timeoutMs) {
     const cleanup = () => {
       clearTimeout(timer);
       child.stderr.off("data", onData);
+      child.stderr.off("error", onStderrError);
       child.off("error", onError);
       child.off("close", onClose);
     };
@@ -421,6 +422,9 @@ export function waitForProxyReady(child, timeoutMs) {
       resolve(event);
     };
     const onError = (error) => {
+      rejectOnce(error);
+    };
+    const onStderrError = (error) => {
       rejectOnce(error);
     };
     const onClose = (code, signal) => {
@@ -453,6 +457,7 @@ export function waitForProxyReady(child, timeoutMs) {
     };
 
     child.stderr.on("data", onData);
+    child.stderr.once("error", onStderrError);
     child.once("error", onError);
     child.once("close", onClose);
   });

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -16664,6 +16664,11 @@ async function networkFrontagePartialStartupCleanupInvariantCheck() {
     const source = await readFile(selfCheckPath("src", "network-frontage.mjs"), "utf8");
     const pattern = /const proxy = startProxy\(allocation\);[\s\S]+context\.networkFrontageProxy = proxy;[\s\S]+await proxy\.ready;/;
     assertEqual(pattern.test(source), true, "network frontage proxy registered before readiness wait");
+    assertEqual(
+      /attachProxyLogStream\(log,\s*child\.stderr\)/.test(source),
+      true,
+      "proxy log and stderr stream errors are handled"
+    );
     const blocker = createServer((request, response) => {
       response.writeHead(200, { "content-type": "text/plain" });
       response.end("not-kova-frontage");

--- a/tests/proxy-log-stream.mjs
+++ b/tests/proxy-log-stream.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createWriteStream } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { PassThrough } from "node:stream";
@@ -79,6 +80,51 @@ export async function runProxyLogStreamChecks(parentDir) {
 
   const source = await readFile(new URL("../src/network-frontage.mjs", import.meta.url), "utf8");
   assert.match(source, /attachProxyLogStream\(log,\s*child\.stderr\)/, "startProxy attaches log stream error handlers");
+
+  const childLogPath = join(parentDir, "start-proxy.log");
+  await mkdir(childLogPath);
+  const listenPort = await freePort();
+  const targetPort = await freePort();
+  const proxy = frontage.startProxy({
+    frontageHost: "127.0.0.1",
+    frontagePort: listenPort,
+    gatewayHost: "127.0.0.1",
+    gatewayPort: targetPort,
+    proxyLogPath: childLogPath
+  });
+  const later = [];
+  proxy.child.stderr.on("data", (chunk) => {
+    later.push(chunk.toString("utf8"));
+  });
+  const ready = await proxy.ready;
+  assert.equal(ready.event, "listening");
+  assert.equal(typeof proxy.pid, "number");
+  try {
+    await fetch(`http://127.0.0.1:${listenPort}/health`, { signal: AbortSignal.timeout(500) });
+  } catch {
+    // target is intentionally down; proxy should emit target-error and keep running
+  }
+  proxy.child.kill("SIGTERM");
+  const closed = await proxy.closed;
+  assert.equal(closed.signal === "SIGTERM" || closed.code === 0, true, "real proxy child exits after SIGTERM");
+  assert.equal(later.some((line) => line.includes("target-error") || line.includes("shutdown")), true, "post-ready proxy stderr still drains");
+}
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+    server.once("error", reject);
+  });
 }
 
 function captureUncaughtException(start) {

--- a/tests/proxy-log-stream.mjs
+++ b/tests/proxy-log-stream.mjs
@@ -38,6 +38,21 @@ export async function runProxyLogStreamChecks(parentDir) {
     assert.equal(stderr.listenerCount("error") >= 1, true, "stderr error handler attached");
     assert.equal(uncaught.length, 0, "unwritable proxy log does not crash the parent");
     assert.equal(logged.some((line) => line.includes("network frontage proxy log stream error")), true, "log stream error is reported");
+    assert.equal(stderr.isPaused(), false, "stderr keeps flowing after log error");
+    assert.notEqual(stderr.readableFlowing, false, "stderr remains flowing after log error");
+    const postReadyChunk = Buffer.alloc(8 * 1024, 0x78);
+    for (let i = 0; i < 16; i += 1) {
+      stderr.write(postReadyChunk);
+    }
+    assert.equal(stderr.isPaused(), false, "post-ready stderr writes do not pause the source");
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("stderr did not finish after log error")), 200);
+      stderr.once("finish", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      stderr.end();
+    });
 
     const writableLogPath = join(parentDir, "writable-proxy.log");
     await writeFile(writableLogPath, "", "utf8");

--- a/tests/proxy-log-stream.mjs
+++ b/tests/proxy-log-stream.mjs
@@ -92,22 +92,64 @@ export async function runProxyLogStreamChecks(parentDir) {
     gatewayPort: targetPort,
     proxyLogPath: childLogPath
   });
-  const later = [];
-  proxy.child.stderr.on("data", (chunk) => {
-    later.push(chunk.toString("utf8"));
-  });
-  const ready = await proxy.ready;
-  assert.equal(ready.event, "listening");
-  assert.equal(typeof proxy.pid, "number");
   try {
-    await fetch(`http://127.0.0.1:${listenPort}/health`, { signal: AbortSignal.timeout(500) });
-  } catch {
-    // target is intentionally down; proxy should emit target-error and keep running
+    const ready = await proxy.ready;
+    assert.equal(ready.event, "listening");
+    assert.equal(typeof proxy.pid, "number");
+    assert.equal(proxy.child.stderr.readableFlowing, true, "failed log sink leaves proxy stderr flowing without a test consumer");
+    await requestMissingTarget(listenPort);
+    assert.equal(proxy.child.stderr.readableFlowing, true, "post-ready proxy diagnostics keep draining after the log failure");
+  } finally {
+    proxy.child.kill("SIGTERM");
   }
-  proxy.child.kill("SIGTERM");
   const closed = await proxy.closed;
   assert.equal(closed.signal === "SIGTERM" || closed.code === 0, true, "real proxy child exits after SIGTERM");
-  assert.equal(later.some((line) => line.includes("target-error") || line.includes("shutdown")), true, "post-ready proxy stderr still drains");
+
+  const healthyLogPath = join(parentDir, "healthy-start-proxy.log");
+  const healthyListenPort = await freePort();
+  const healthyTargetPort = await freePort();
+  const healthyProxy = frontage.startProxy({
+    frontageHost: "127.0.0.1",
+    frontagePort: healthyListenPort,
+    gatewayHost: "127.0.0.1",
+    gatewayPort: healthyTargetPort,
+    proxyLogPath: healthyLogPath
+  });
+  try {
+    const ready = await healthyProxy.ready;
+    assert.equal(ready.event, "listening");
+    await requestMissingTarget(healthyListenPort);
+  } finally {
+    healthyProxy.child.kill("SIGTERM");
+  }
+  const healthyClosed = await healthyProxy.closed;
+  assert.equal(healthyClosed.signal === "SIGTERM" || healthyClosed.code === 0, true, "healthy-log proxy exits after SIGTERM");
+  const healthyLog = await waitForLogEvents(healthyLogPath, ["listening", "target-error", "shutdown"]);
+  assert.match(healthyLog, /"event":"listening"/, "healthy proxy log records readiness");
+  assert.match(healthyLog, /"event":"target-error"/, "healthy proxy log remains open for later diagnostics");
+  assert.match(healthyLog, /"event":"shutdown"/, "healthy proxy log records shutdown");
+}
+
+async function requestMissingTarget(port) {
+  try {
+    await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(500) });
+  } catch {
+    // The target is intentionally down; the proxy should report the failure and keep running.
+  }
+}
+
+async function waitForLogEvents(path, events) {
+  const deadline = Date.now() + 2000;
+  for (;;) {
+    const content = await readFile(path, "utf8");
+    if (events.every((event) => content.includes(`"event":"${event}"`))) {
+      return content;
+    }
+    if (Date.now() >= deadline) {
+      assert.fail(`proxy log did not contain ${events.join(", ")} before timeout: ${content}`);
+    }
+    await waitMs(20);
+  }
 }
 
 function freePort() {

--- a/tests/proxy-log-stream.mjs
+++ b/tests/proxy-log-stream.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { createWriteStream } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { PassThrough } from "node:stream";
+import { fileURLToPath } from "node:url";
+import * as frontage from "../src/network-frontage.mjs";
+
+export async function runProxyLogStreamChecks(parentDir) {
+  const unwritableLogPath = join(parentDir, "proxy.log");
+  await mkdir(unwritableLogPath);
+
+  const uncaughtWithoutHandler = await captureUncaughtException(() => {
+    createWriteStream(unwritableLogPath, { flags: "a" });
+  });
+  assert.equal(uncaughtWithoutHandler?.code, "EISDIR");
+  assert.match(uncaughtWithoutHandler.message, /illegal operation on a directory/);
+
+  assert.equal(typeof frontage.attachProxyLogStream, "function", "attachProxyLogStream is exported");
+
+  const uncaught = [];
+  const onUncaught = (error) => {
+    uncaught.push(error);
+  };
+  process.on("uncaughtException", onUncaught);
+  const logged = [];
+  const originalError = console.error;
+  console.error = (...args) => {
+    logged.push(args.map(String).join(" "));
+  };
+  try {
+    const log = createWriteStream(unwritableLogPath, { flags: "a" });
+    const stderr = new PassThrough();
+    frontage.attachProxyLogStream(log, stderr);
+    await waitMs(80);
+    assert.equal(log.listenerCount("error") >= 1, true, "log error handler attached");
+    assert.equal(stderr.listenerCount("error") >= 1, true, "stderr error handler attached");
+    assert.equal(uncaught.length, 0, "unwritable proxy log does not crash the parent");
+    assert.equal(logged.some((line) => line.includes("network frontage proxy log stream error")), true, "log stream error is reported");
+
+    const writableLogPath = join(parentDir, "writable-proxy.log");
+    await writeFile(writableLogPath, "", "utf8");
+    const writableLog = createWriteStream(writableLogPath, { flags: "a" });
+    const brokenStderr = new PassThrough();
+    frontage.attachProxyLogStream(writableLog, brokenStderr);
+    brokenStderr.destroy(Object.assign(new Error("broken pipe"), { code: "EPIPE" }));
+    await waitMs(80);
+    assert.equal(uncaught.length, 0, "stderr pipe error does not crash the parent");
+    try {
+      log.destroy();
+    } catch {
+      // already failed open
+    }
+    try {
+      writableLog.destroy();
+    } catch {
+      // ignore
+    }
+  } finally {
+    console.error = originalError;
+    process.off("uncaughtException", onUncaught);
+  }
+
+  const source = await readFile(new URL("../src/network-frontage.mjs", import.meta.url), "utf8");
+  assert.match(source, /attachProxyLogStream\(log,\s*child\.stderr\)/, "startProxy attaches log stream error handlers");
+}
+
+function captureUncaughtException(start) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      process.off("uncaughtException", onUncaught);
+      reject(new Error("expected uncaughtException from unwritable write stream"));
+    }, 500);
+    const onUncaught = (error) => {
+      clearTimeout(timer);
+      process.off("uncaughtException", onUncaught);
+      resolve(error);
+    };
+    process.on("uncaughtException", onUncaught);
+    start();
+  });
+}
+
+function waitMs(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  const root = await mkdtemp(join(tmpdir(), "kova-proxy-log-stream-"));
+  try {
+    await runProxyLogStreamChecks(root);
+    console.log("PASS proxy log stream errors");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/tests/proxy-log-stream.mjs
+++ b/tests/proxy-log-stream.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { createWriteStream } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
@@ -63,6 +64,16 @@ export async function runProxyLogStreamChecks(parentDir) {
     brokenStderr.destroy(Object.assign(new Error("broken pipe"), { code: "EPIPE" }));
     await waitMs(80);
     assert.equal(uncaught.length, 0, "stderr pipe error does not crash the parent");
+
+    const readinessChild = new EventEmitter();
+    readinessChild.stderr = new PassThrough();
+    const readinessLog = new PassThrough();
+    frontage.attachProxyLogStream(readinessLog, readinessChild.stderr);
+    const readiness = frontage.waitForProxyReady(readinessChild, 500);
+    const readinessError = Object.assign(new Error("stderr read failed"), { code: "EIO" });
+    readinessChild.stderr.destroy(readinessError);
+    await assert.rejects(readiness, (error) => error === readinessError, "readiness preserves the original stderr error");
+    readinessLog.destroy();
     try {
       log.destroy();
     } catch {

--- a/tests/selfcheck-isolation.mjs
+++ b/tests/selfcheck-isolation.mjs
@@ -14,10 +14,14 @@ import { collectEnvMetrics } from "../src/metrics.mjs";
 import { runScenarioCommand } from "../src/run/command-executor.mjs";
 import { executeTargetSetup } from "../src/run/target-setup.mjs";
 import { resolveTarget } from "../src/targets.mjs";
+import { runProxyLogStreamChecks } from "./proxy-log-stream.mjs";
 
 const root = await mkdtemp(join(tmpdir(), "kova-selfcheck-isolation-test-"));
 
 try {
+  const proxyLogRoot = join(root, "proxy-log-stream");
+  await mkdir(proxyLogRoot);
+  await runProxyLogStreamChecks(proxyLogRoot);
   await verifyScopedShell(root);
   await verifyTargetSetupBuildTimeoutBudget(root);
   await verifyConcurrentInvocationHomes(root);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running Kova with `--network-frontage loopback` would lose the whole lab parent process when the frontage proxy log could not be written. That happens if the artifact disk is full, the log path is a directory, or the file is not writable. Node then emits an unhandled `error` on the `createWriteStream` used by `startProxy`, and the Kova runner exits instead of keeping the rest of the lab alive.

## Why This Change Was Made

`startProxy` now attaches error handlers on the proxy log WriteStream and on the child stderr pipe. After a log destination error, the helper unpipes that dest and `resume()`s stderr so later proxy diagnostics keep draining. The parent logs the failure and continues. The rest of frontage startup is unchanged.

The after-fix transcript below is from a live `startProxy()` call that spawned `support/network-frontage-proxy.mjs`. The log path was a directory. The child still reported `listening`, then `target-error` / `client-error` / `shutdown`, and the parent stayed up.

## User Impact

A full or unwritable proxy log no longer crashes the Kova process, and the proxy child is not left paused on a full stderr pipe. Operators still see a one-line diagnostic on stderr. Loopback frontage startup, ready-wait, and cleanup behave as before when the log path is writable.

## Evidence

Live `node` on macOS 15, Node v26.7.0, checkout `/tmp/oc-impl-kova-logstream` at this patch. The same unwritable path (a directory used as `proxyLogPath`) was opened with `createWriteStream(..., { flags: "a" })` before and after `attachProxyLogStream`.

Before the handler, Node raised `uncaughtException` with `EISDIR` and that is the crash path for the lab parent:

```console
$ node --input-type=module -e 'createWriteStream(dirAsProxyLog)'
NODE v26.7.0
--- WITHOUT handler ---
listeners(error)= 0
handled= []
uncaughtException= [
  {
    name: 'Error',
    code: 'EISDIR',
    message: "EISDIR: illegal operation on a directory, open '/var/folders/7_/3g02szlx2h3_4pdqp0knlw740000gn/T/kova-logstream-repro-dlNnfx/proxy.log'"
  }
]
```

After `attachProxyLogStream(log, stderr)` the same open is reported and swallowed. A later stderr pipe failure is also swallowed. The parent stays up:

```console
$ node --input-type=module ./src/network-frontage.mjs attach-demo
NODE v26.7.0
cwd /private/tmp/oc-impl-kova-logstream
--- AFTER attachProxyLogStream ---
network frontage proxy log stream error: EISDIR: illegal operation on a directory, open '/var/folders/7_/3g02szlx2h3_4pdqp0knlw740000gn/T/kova-logstream-after-WX7hnn/proxy.log'
listeners(log.error)= 1
listeners(stderr.error)= 1
uncaughtException= []
network frontage proxy log stream error: broken pipe
after stderr destroy uncaughtException= []
parent still running pid= 68812
```

Live `startProxy()` against the real frontage child, with the artifact log path set to a directory:

```console
$ node /tmp/proof-kova-startproxy.mjs
NODE v26.7.0
cwd /private/tmp/oc-impl-kova-logstream
calling startProxy with directory log path /var/folders/7_/3g02szlx2h3_4pdqp0knlw740000gn/T/kova-startproxy-proof-ymRMou/proxy.log
listen 127.0.0.1:50026 target 127.0.0.1:50027
network frontage proxy log stream error: EISDIR: illegal operation on a directory, open '/var/folders/7_/3g02szlx2h3_4pdqp0knlw740000gn/T/kova-startproxy-proof-ymRMou/proxy.log'
ready {
  event: 'listening',
  listenHost: '127.0.0.1',
  listenPort: 50026,
  targetHost: '127.0.0.1',
  targetPort: 50027,
  pid: 78264,
  at: '2026-08-15T21:35:06.436Z'
}
child pid 78264 parent pid 78263
fetch after dest error TypeError fetch failed
later stderr lines [
  '{"event":"listening","listenHost":"127.0.0.1","listenPort":50026,"targetHost":"127.0.0.1","targetPort":50027,"pid":78264,"at":"2026-08-15T21:35:06.436Z"}',
  '{"event":"target-error","message":"connect ECONNREFUSED 127.0.0.1:50027","at":"2026-08-15T21:35:06.447Z"}',
  '{"event":"client-error","message":"connect ECONNREFUSED 127.0.0.1:50027","at":"2026-08-15T21:35:06.447Z"}',
  '{"event":"shutdown","signal":"SIGTERM","at":"2026-08-15T21:35:06.448Z"}'
]
child closed { code: 0, signal: null }
uncaughtException []
parent still running pid 78263
```

## Real behavior proof

- **Behavior or issue addressed:** Unwritable network-frontage proxy logs emitted an unhandled WriteStream `error` from `startProxy` and could take down the Kova parent. After the dest error, Node also unpiped and paused child stderr, so later proxy events could fill the pipe and stall cleanup.
- **Real environment tested:** macOS 15.5, Node v26.7.0, Kova checkout `/tmp/oc-impl-kova-logstream` on branch `fix/proxy-log-stream-errors`. Live `node` called `startProxy()` and spawned `support/network-frontage-proxy.mjs`.
- **Exact steps or command run after this patch:** `node /tmp/proof-kova-startproxy.mjs`. That script calls `startProxy()` with a directory as `proxyLogPath`, waits for the child `listening` event, `fetch`es `/health` so the child emits `target-error`, then SIGTERM.
- **Evidence after fix:** terminal output from that live `startProxy()` run is in the Evidence section above. After EISDIR, the child still emits `listening`, then `target-error`, `client-error`, and `shutdown`. `uncaughtException` is `[]`. Parent pid 78263 stayed alive.
- **Observed result after fix:** The Kova parent does not die when the proxy log cannot be written. The real frontage child still becomes ready, later stderr events still drain, and SIGTERM cleanup finishes with `{ code: 0, signal: null }`.
- **What was not tested:** A live `kova run --network-frontage loopback` against a real full disk, and OCM-backed gateway bind/validation.

## Origin

Introduced in [`e1ad6b3f8894`](https://github.com/openclaw/Kova/commit/e1ad6b3f8894) via [#2](https://github.com/openclaw/Kova/pull/2) (2026-05-28). Present for 79 days.

