### PR TITLE
fix(perf): calibrate RSS by Node runtime major

### DIFF
--- a/scenarios/fresh-install.json
+++ b/scenarios/fresh-install.json
@@ -15,7 +15,11 @@
     "statusMs": 10000,
     "pluginsListMs": 10000,
     "modelsListMs": 20000,
-    "peakRssMb": 1050
+    "peakRssMb": {
+      "baselineByNodeMajor": { "22": 735, "24": 1070, "25": 1060 },
+      "maxRegressionPercent": 10,
+      "absoluteCeilingMb": 1200
+    }
   },
   "phases": [
     {

--- a/scenarios/gateway-performance.json
+++ b/scenarios/gateway-performance.json
@@ -13,7 +13,11 @@
   "thresholds": {
     "coldReadyMs": 30000,
     "warmReadyMs": 15000,
-    "peakRssMb": 1050,
+    "peakRssMb": {
+      "baselineByNodeMajor": { "22": 735, "24": 1070, "25": 1060 },
+      "maxRegressionPercent": 10,
+      "absoluteCeilingMb": 1200
+    },
     "eventLoopMaxMs": 500,
     "postReadyHealthP95Ms": 1000
   },

--- a/src/evaluation/thresholds.mjs
+++ b/src/evaluation/thresholds.mjs
@@ -1,17 +1,23 @@
-export function resolveThresholdPolicy({ profile = null, surface = null, scenario = null } = {}) {
+export function resolveThresholdPolicy({ profile = null, surface = null, scenario = null, nodeVersion = process.version } = {}) {
   const surfaceCalibration = profile?.calibration?.surfaces?.[surface?.id] ?? {};
   const configuredThresholds = mergeObjects(
     surface?.thresholds,
     surfaceCalibration.thresholds,
     scenario?.thresholds
   );
-  const { thresholds, derived } = applyDerivedThresholds(configuredThresholds);
-  const roleThresholds = mergeRoleThresholds(
+  const { thresholds: derivedThresholds, derived } = applyDerivedThresholds(configuredThresholds);
+  const configuredRoleThresholds = mergeRoleThresholds(
     profile?.calibration?.roles,
     surface?.roleThresholds,
     surfaceCalibration.roleThresholds,
     scenario?.thresholds?.roleThresholds
   );
+  const runtimeCalibration = [];
+  const thresholds = resolveRuntimeThresholds(derivedThresholds, nodeVersion, runtimeCalibration, "thresholds");
+  const roleThresholds = Object.fromEntries(Object.entries(configuredRoleThresholds).map(([role, values]) => [
+    role,
+    resolveRuntimeThresholds(values, nodeVersion, runtimeCalibration, `roleThresholds.${role}`)
+  ]));
 
   return {
     thresholds,
@@ -22,10 +28,41 @@ export function resolveThresholdPolicy({ profile = null, surface = null, scenari
       surfaceId: surface?.id ?? null,
       scenarioId: scenario?.id ?? null,
       sources: thresholdSources({ profile, surface, surfaceCalibration, scenario, derived }),
+      runtimeCalibration,
       thresholds,
       roleThresholds
     }
   };
+}
+
+function resolveRuntimeThresholds(thresholds, nodeVersion, report, prefix) {
+  return Object.fromEntries(Object.entries(thresholds ?? {}).map(([metric, value]) => {
+    if (metric !== "peakRssMb" || !isRuntimeRssThreshold(value)) {
+      return [metric, value];
+    }
+    const nodeMajor = /^v?(\d+)\./u.exec(String(nodeVersion))?.[1] ?? null;
+    const baselineMb = nodeMajor === null ? undefined : value.baselineByNodeMajor[nodeMajor];
+    const calibratedMb = typeof baselineMb === "number"
+      ? Math.floor(baselineMb * (1 + (value.maxRegressionPercent / 100)))
+      : value.absoluteCeilingMb;
+    const effectiveMb = Math.min(value.absoluteCeilingMb, calibratedMb);
+    report.push({
+      metric: `${prefix}.${metric}`,
+      nodeMajor,
+      baselineMb: baselineMb ?? null,
+      maxRegressionPercent: value.maxRegressionPercent,
+      absoluteCeilingMb: value.absoluteCeilingMb,
+      effectiveMb
+    });
+    return [metric, effectiveMb];
+  }));
+}
+
+function isRuntimeRssThreshold(value) {
+  return value && typeof value === "object" && !Array.isArray(value) &&
+    typeof value.absoluteCeilingMb === "number" &&
+    typeof value.maxRegressionPercent === "number" &&
+    value.baselineByNodeMajor && typeof value.baselineByNodeMajor === "object";
 }
 
 function thresholdSources({ profile, surface, surfaceCalibration, scenario, derived = [] }) {

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -104,7 +104,8 @@ export function evaluateRecord(record, scenario, options = {}) {
   const thresholdPolicy = resolveThresholdPolicy({
     profile: options.profile,
     surface: options.surface,
-    scenario
+    scenario,
+    nodeVersion: options.nodeVersion
   });
   const thresholds = thresholdPolicy.thresholds;
   const roleThresholds = thresholdPolicy.roleThresholds;

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -105,11 +105,27 @@ export function evaluateRecord(record, scenario, options = {}) {
     profile: options.profile,
     surface: options.surface,
     scenario,
-    nodeVersion: options.nodeVersion
+    nodeVersion: options.targetRuntime === undefined
+      ? options.nodeVersion
+      : options.targetRuntime?.nodeVersion ?? null
   });
   const thresholds = thresholdPolicy.thresholds;
   const roleThresholds = thresholdPolicy.roleThresholds;
   const violations = [];
+  const targetRuntimeIssue = targetRuntimeEvidenceIssue(
+    thresholdPolicy.report.runtimeCalibration,
+    options.targetRuntime
+  );
+  if (targetRuntimeIssue !== null) {
+    violations.push({
+      kind: "evidence",
+      metric: "targetRuntime.nodeVersion",
+      expected: "Gateway runtime identity with matching OCM service PID and port",
+      actual: targetRuntimeIssue,
+      failureDomain: "kova-harness",
+      message: `Gateway runtime identity was not trusted: ${targetRuntimeIssue}`
+    });
+  }
   const allResults = collectResults(record);
   const measurementScopeSummary = summarizeMeasurementScopes(record);
   const measuredResults = collectResults(record, { productOnly: true });
@@ -1263,6 +1279,43 @@ export function evaluateRecord(record, scenario, options = {}) {
   }
 
   return record;
+}
+
+function targetRuntimeEvidenceIssue(runtimeCalibration, targetRuntime) {
+  if ((runtimeCalibration ?? []).length === 0 || targetRuntime === undefined) {
+    return null;
+  }
+  if (
+    !targetRuntime ||
+    !["ok", "compatibility-fallback"].includes(targetRuntime.collectionStatus)
+  ) {
+    return targetRuntime?.collectionStatus ?? "missing";
+  }
+  if (
+    typeof targetRuntime.nodeVersion !== "string" ||
+    !/^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u.test(targetRuntime.nodeVersion)
+  ) {
+    return "invalid-node-version";
+  }
+  if (
+    !Number.isSafeInteger(targetRuntime.gatewayPid) ||
+    targetRuntime.gatewayPid <= 0 ||
+    !Number.isSafeInteger(targetRuntime.expectedGatewayPid) ||
+    targetRuntime.expectedGatewayPid <= 0 ||
+    !Number.isSafeInteger(targetRuntime.gatewayPort) ||
+    targetRuntime.gatewayPort <= 0 ||
+    !Number.isSafeInteger(targetRuntime.expectedGatewayPort) ||
+    targetRuntime.expectedGatewayPort <= 0
+  ) {
+    return "invalid-gateway-identity";
+  }
+  if (
+    targetRuntime.gatewayPid !== targetRuntime.expectedGatewayPid ||
+    targetRuntime.gatewayPort !== targetRuntime.expectedGatewayPort
+  ) {
+    return "identity-mismatch";
+  }
+  return null;
 }
 
 function buildInstrumentedPerformanceAssessment({

--- a/src/registries/surfaces.mjs
+++ b/src/registries/surfaces.mjs
@@ -128,6 +128,9 @@ function validateRoleThresholds(value, prefix, errors) {
       continue;
     }
     for (const key of ["peakRssMb", "peakProcessRssMb", "maxCpuPercent"]) {
+      if (key === "peakRssMb" && thresholds[key] && typeof thresholds[key] === "object") {
+        continue;
+      }
       if (thresholds[key] !== undefined && (!Number.isFinite(thresholds[key]) || thresholds[key] < 0)) {
         errors.push(`${prefix}.${role}.${key} must be a finite non-negative number when set`);
       }

--- a/src/registries/validate.mjs
+++ b/src/registries/validate.mjs
@@ -181,8 +181,30 @@ function validateThresholdMetrics(thresholds, metricIds, errors, prefix, process
     if (!metricIds.has(metric)) {
       errors.push(`${prefix} references unknown metric '${metric}'`);
     }
+    if (metric === "peakRssMb" && value && typeof value === "object" && !Array.isArray(value)) {
+      validateRuntimeRssThreshold(value, `${prefix}.${metric}`, errors);
+      continue;
+    }
     if (!Number.isFinite(value) || value < 0) {
       errors.push(`${prefix}.${metric} must be a finite non-negative number`);
+    }
+  }
+}
+
+function validateRuntimeRssThreshold(value, prefix, errors) {
+  for (const key of ["absoluteCeilingMb", "maxRegressionPercent"]) {
+    if (!Number.isFinite(value[key]) || value[key] < 0) {
+      errors.push(`${prefix}.${key} must be a finite non-negative number`);
+    }
+  }
+  const baselines = value.baselineByNodeMajor;
+  if (!baselines || typeof baselines !== "object" || Array.isArray(baselines) || Object.keys(baselines).length === 0) {
+    errors.push(`${prefix}.baselineByNodeMajor must be a non-empty object`);
+    return;
+  }
+  for (const [major, baseline] of Object.entries(baselines)) {
+    if (!/^\d+$/u.test(major) || !Number.isFinite(baseline) || baseline < 0) {
+      errors.push(`${prefix}.baselineByNodeMajor.${major} must be a finite non-negative number`);
     }
   }
 }

--- a/src/run/finalize-record.mjs
+++ b/src/run/finalize-record.mjs
@@ -6,19 +6,22 @@ import {
 } from "../evidence/record.mjs";
 import { compactEvaluatedTimelineEvidence, evaluateRecord } from "../evaluator.mjs";
 import { collectEnvMetrics, collectNodeProfileMetrics } from "../metrics.mjs";
+import { runCommand } from "../commands.mjs";
+import { ocmEnvExec } from "../ocm/commands.mjs";
 import { collectProviderEvidence } from "../collectors/provider.mjs";
 import { collectStateFixtureAccounting } from "../collectors/state-fixtures.mjs";
 import { metricOptions } from "./metric-options.mjs";
 
 export async function collectPreCleanupEvidence(record, scenario, context, envName, artifactDir, authPolicy) {
   record.finishedAt = new Date().toISOString();
+  record.targetRuntime = await collectTargetRuntime(envName, context.timeoutMs);
   record.finalMetrics = await collectEnvMetrics(envName, metricOptions(context, scenario, null, artifactDir, {
     kind: "final",
     redactValues: authPolicy.redactionValues
   }));
   record.stateFixtureAccounting = await collectStateFixtureAccounting(context.state, envName, artifactDir);
   record.providerEvidence = await collectProviderEvidence(artifactDir, { authPolicy });
-  evaluateRecord(record, scenario, evaluatorContext(context, scenario));
+  evaluateRecord(record, scenario, evaluatorContext(context, scenario, record));
 
   if (shouldCaptureFailureDiagnostics(record, context)) {
     record.failureDiagnostics = await collectEnvMetrics(envName, {
@@ -41,7 +44,7 @@ export async function attachPostCleanupEvidence(record, scenario, context, artif
     attachNodeProfileMeasurements(record);
   }
 
-  evaluateRecord(record, scenario, evaluatorContext(context, scenario));
+  evaluateRecord(record, scenario, evaluatorContext(context, scenario, record));
   attachEvidenceInvariants(record, scenario);
   attachCleanupEvidence(record);
   await attachEvidenceArtifactBudget(record, scenario);
@@ -82,10 +85,23 @@ function attachNodeProfileMeasurements(record) {
   record.measurements.nodeHeapTopFunctionUrl = topHeap?.url ?? record.measurements.nodeHeapTopFunctionUrl ?? null;
 }
 
-function evaluatorContext(context, scenario) {
+function evaluatorContext(context, scenario, record) {
   return {
     surface: context.surfacesById?.[scenario.surface] ?? null,
     targetPlan: context.targetPlan ?? null,
-    profile: context.profile ?? null
+    profile: context.profile ?? null,
+    nodeVersion: record.targetRuntime?.nodeVersion ?? null
+  };
+}
+
+async function collectTargetRuntime(envName, timeoutMs) {
+  const result = await runCommand(ocmEnvExec(envName, ["node", "--version"]), { timeoutMs });
+  const nodeVersion = result.status === 0 && /^v?\d+\.\d+\.\d+$/u.test(result.stdout.trim())
+    ? result.stdout.trim()
+    : null;
+  return {
+    schemaVersion: "kova.targetRuntime.v1",
+    nodeVersion,
+    collectionStatus: result.status
   };
 }

--- a/src/run/finalize-record.mjs
+++ b/src/run/finalize-record.mjs
@@ -7,18 +7,23 @@ import {
 import { compactEvaluatedTimelineEvidence, evaluateRecord } from "../evaluator.mjs";
 import { collectEnvMetrics, collectNodeProfileMetrics } from "../metrics.mjs";
 import { runCommand } from "../commands.mjs";
-import { ocmEnvExec } from "../ocm/commands.mjs";
+import { ocmAt } from "../ocm/commands.mjs";
 import { collectProviderEvidence } from "../collectors/provider.mjs";
 import { collectStateFixtureAccounting } from "../collectors/state-fixtures.mjs";
 import { metricOptions } from "./metric-options.mjs";
 
 export async function collectPreCleanupEvidence(record, scenario, context, envName, artifactDir, authPolicy) {
   record.finishedAt = new Date().toISOString();
-  record.targetRuntime = await collectTargetRuntime(envName, context.timeoutMs);
   record.finalMetrics = await collectEnvMetrics(envName, metricOptions(context, scenario, null, artifactDir, {
     kind: "final",
     redactValues: authPolicy.redactionValues
   }));
+  record.targetRuntime = await collectTargetRuntime(
+    envName,
+    record.finalMetrics?.service?.childPid ?? null,
+    record.finalMetrics?.service?.gatewayPort ?? null,
+    context.timeoutMs
+  );
   record.stateFixtureAccounting = await collectStateFixtureAccounting(context.state, envName, artifactDir);
   record.providerEvidence = await collectProviderEvidence(artifactDir, { authPolicy });
   evaluateRecord(record, scenario, evaluatorContext(context, scenario, record));
@@ -90,18 +95,117 @@ function evaluatorContext(context, scenario, record) {
     surface: context.surfacesById?.[scenario.surface] ?? null,
     targetPlan: context.targetPlan ?? null,
     profile: context.profile ?? null,
-    nodeVersion: record.targetRuntime?.nodeVersion ?? null
+    nodeVersion: record.targetRuntime?.nodeVersion ?? null,
+    targetRuntime: record.targetRuntime ?? null
   };
 }
 
-async function collectTargetRuntime(envName, timeoutMs) {
-  const result = await runCommand(ocmEnvExec(envName, ["node", "--version"]), { timeoutMs });
-  const nodeVersion = result.status === 0 && /^v?\d+\.\d+\.\d+$/u.test(result.stdout.trim())
-    ? result.stdout.trim()
-    : null;
-  return {
+export async function collectTargetRuntime(
+  envName,
+  expectedGatewayPid,
+  expectedGatewayPort,
+  timeoutMs,
+  execute = runCommand
+) {
+  const evidence = {
     schemaVersion: "kova.targetRuntime.v1",
-    nodeVersion,
-    collectionStatus: result.status
+    nodeVersion: null,
+    gatewayPid: null,
+    gatewayPort: null,
+    expectedGatewayPid: Number.isSafeInteger(expectedGatewayPid) && expectedGatewayPid > 0
+      ? expectedGatewayPid
+      : null,
+    expectedGatewayPort: Number.isSafeInteger(expectedGatewayPort) && expectedGatewayPort > 0
+      ? expectedGatewayPort
+      : null,
+    collectionStatus: "missing-service-identity",
+    commandStatus: null,
+    compatibilityCommandStatus: null
   };
+  if (evidence.expectedGatewayPid === null || evidence.expectedGatewayPort === null) {
+    return evidence;
+  }
+
+  const result = await execute(
+    ocmAt(envName, [
+      "gateway",
+      "call",
+      "system.info",
+      "--port",
+      String(evidence.expectedGatewayPort),
+      "--json"
+    ]),
+    { timeoutMs }
+  );
+  evidence.commandStatus = result.status;
+  if (result.status !== 0) {
+    if (isMissingSystemInfoMethod(result)) {
+      return collectLegacyTargetRuntime(evidence, envName, timeoutMs, execute);
+    }
+    evidence.collectionStatus = "command-failed";
+    return evidence;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(result.stdout);
+  } catch {
+    evidence.collectionStatus = "invalid-json";
+    return evidence;
+  }
+  const nodeVersion = typeof payload?.nodeVersion === "string" &&
+    isNodeVersion(payload.nodeVersion)
+    ? payload.nodeVersion
+    : null;
+  const gatewayPid = Number.isSafeInteger(payload?.pid) && payload.pid > 0
+    ? payload.pid
+    : null;
+  const gatewayPort = Number.isSafeInteger(payload?.port) && payload.port > 0
+    ? payload.port
+    : null;
+  evidence.gatewayPid = gatewayPid;
+  evidence.gatewayPort = gatewayPort;
+  if (nodeVersion === null || gatewayPid === null || gatewayPort === null) {
+    evidence.collectionStatus = "invalid-payload";
+    return evidence;
+  }
+  if (
+    gatewayPid !== evidence.expectedGatewayPid ||
+    gatewayPort !== evidence.expectedGatewayPort
+  ) {
+    evidence.collectionStatus = "identity-mismatch";
+    return evidence;
+  }
+
+  evidence.nodeVersion = nodeVersion;
+  evidence.collectionStatus = "ok";
+  return evidence;
+}
+
+async function collectLegacyTargetRuntime(evidence, envName, timeoutMs, execute) {
+  const result = await execute(ocmAt(envName, ["status"]), { timeoutMs });
+  evidence.compatibilityCommandStatus = result.status;
+  if (result.status !== 0) {
+    evidence.collectionStatus = "compatibility-command-failed";
+    return evidence;
+  }
+  const nodeVersion = /\bnode\s+(v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)/iu
+    .exec(result.stdout)?.[1] ?? null;
+  if (nodeVersion === null) {
+    evidence.collectionStatus = "compatibility-invalid-payload";
+    return evidence;
+  }
+  evidence.nodeVersion = nodeVersion;
+  evidence.gatewayPid = evidence.expectedGatewayPid;
+  evidence.gatewayPort = evidence.expectedGatewayPort;
+  evidence.collectionStatus = "compatibility-fallback";
+  return evidence;
+}
+
+function isMissingSystemInfoMethod(result) {
+  return /unknown method:\s*system\.info/iu.test(`${result.stdout ?? ""}\n${result.stderr ?? ""}`);
+}
+
+function isNodeVersion(value) {
+  return /^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u.test(value);
 }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -21083,8 +21083,11 @@ async function bundledPluginStartupSurfaceContractCheck() {
     const policy = resolveThresholdPolicy({
       profile: releaseProfile,
       surface,
-      scenario
+      scenario,
+      nodeVersion: "v24.19.0"
     });
+    const node22Policy = resolveThresholdPolicy({ profile: releaseProfile, surface, scenario, nodeVersion: "22.22.3" });
+    const uncalibratedPolicy = resolveThresholdPolicy({ profile: releaseProfile, surface, scenario, nodeVersion: "v26.0.0" });
 
     assertEqual(startPhase?.id, "gateway-start", "bundled plugin startup uses readiness phase contract");
     assertEqual(
@@ -21092,11 +21095,15 @@ async function bundledPluginStartupSurfaceContractCheck() {
       30000,
       "bundled plugin startup waits for gateway readiness"
     );
-    assertEqual(surface.roleThresholds?.gateway?.peakRssMb, 1000, "bundled plugin surface owns gateway RSS cap");
+    assertEqual(surface.roleThresholds?.gateway?.peakRssMb?.absoluteCeilingMb, 1200, "bundled plugin surface owns absolute gateway RSS ceiling");
     assertEqual(surface.roleThresholds?.gateway?.maxCpuPercent, 250, "bundled plugin surface owns gateway CPU cap");
     assertEqual(surface.roleThresholds?.["plugin-cli"]?.peakRssMb, 900, "bundled plugin surface owns plugin CLI RSS cap");
     assertEqual(surface.roleThresholds?.["plugin-cli"]?.maxCpuPercent, 250, "bundled plugin surface owns plugin CLI CPU cap");
-    assertEqual(policy.roleThresholds?.gateway?.peakRssMb, 1000, "bundled plugin resolved gateway RSS cap");
+    assertEqual(policy.roleThresholds?.gateway?.peakRssMb, 1193, "bundled plugin resolves Node 24 baseline with bounded regression allowance");
+    assertEqual(policy.report.runtimeCalibration?.[0]?.baselineMb, 1085, "bundled plugin reports selected Node 24 baseline");
+    assertEqual(node22Policy.roleThresholds?.gateway?.peakRssMb, 803, "bundled plugin selects the parsed Node 22 major baseline");
+    assertEqual(uncalibratedPolicy.roleThresholds?.gateway?.peakRssMb, 1200, "uncalibrated Node major remains bounded by the absolute ceiling");
+    assertEqual(uncalibratedPolicy.report.runtimeCalibration?.[0]?.baselineMb, null, "uncalibrated Node major reports missing baseline evidence");
     assertEqual(policy.roleThresholds?.gateway?.maxCpuPercent, 250, "bundled plugin resolved gateway CPU cap");
     assertEqual(policy.roleThresholds?.["plugin-cli"]?.peakRssMb, 900, "bundled plugin resolved plugin CLI RSS cap");
     assertEqual(policy.roleThresholds?.["plugin-cli"]?.maxCpuPercent, 250, "bundled plugin resolved plugin CLI CPU cap");
@@ -21305,22 +21312,22 @@ async function releaseResourceCalibrationCheck() {
         id: "fresh-install",
         scenario: freshScenario,
         surface: freshSurface,
-        primaryRssMb: 1050,
-        roles: { gateway: 1050, "status-cli": 900, "plugin-cli": 900 }
+        primaryRssMb: 1177,
+        roles: { gateway: 1177, "status-cli": 900, "plugin-cli": 900 }
       },
       {
         id: "gateway-performance",
         scenario: gatewayScenario,
         surface: gatewaySurface,
-        primaryRssMb: 1050,
-        roles: { gateway: 1050, "gateway-tree": 1200, "status-cli": 900, "plugin-cli": 950 }
+        primaryRssMb: 1177,
+        roles: { gateway: 1177, "gateway-tree": 1200, "status-cli": 900, "plugin-cli": 950 }
       },
       {
         id: "bundled-plugin-startup",
         scenario: null,
         surface: bundledPluginSurface,
         primaryRssMb: null,
-        roles: { gateway: 1000, "plugin-cli": 900 }
+        roles: { gateway: 1193, "plugin-cli": 900 }
       }
     ];
 
@@ -21328,11 +21335,12 @@ async function releaseResourceCalibrationCheck() {
       const policy = resolveThresholdPolicy({
         profile: releaseProfile,
         surface: contract.surface,
-        scenario: contract.scenario
+        scenario: contract.scenario,
+        nodeVersion: "v24.19.0"
       });
       if (contract.primaryRssMb !== null) {
-        assertEqual(contract.scenario?.thresholds?.peakRssMb, contract.primaryRssMb, `${contract.id} scenario primary RSS cap`);
-        assertEqual(contract.surface?.thresholds?.peakRssMb, contract.primaryRssMb, `${contract.id} surface primary RSS cap`);
+        assertEqual(policy.thresholds?.peakRssMb, contract.primaryRssMb, `${contract.id} resolved primary RSS cap`);
+        assertEqual(contract.surface?.thresholds?.peakRssMb?.absoluteCeilingMb, 1200, `${contract.id} absolute primary RSS ceiling`);
       }
       for (const [role, peakRssMb] of Object.entries(contract.roles)) {
         assertEqual(contract.surface?.processRoles?.includes(role), true, `${contract.id} declares ${role}`);
@@ -21959,6 +21967,34 @@ function thresholdPolicyCalibrationCheck() {
       true,
       "profile calibrated role violation"
     );
+    const runtimeMismatch = structuredClone(record);
+    runtimeMismatch.status = "PASS";
+    delete runtimeMismatch.violations;
+    const runtimeResources = runtimeMismatch.phases
+      .flatMap((phase) => phase.results)
+      .find((result) => result.resourceSamples)?.resourceSamples;
+    assertEqual(Boolean(runtimeResources), true, "runtime mismatch fixture has resource samples");
+    runtimeResources.peakTotalRssMb = 805;
+    runtimeResources.byRole.gateway.peakRssMb = 805;
+    runtimeResources.topRolesByRss[0].peakRssMb = 805;
+    evaluateRecord(runtimeMismatch, { id: "runtime-major-threshold", thresholds: {} }, {
+      nodeVersion: "v22.22.3",
+      surface: {
+        id: "runtime-major-threshold",
+        thresholds: {},
+        roleThresholds: {
+          gateway: {
+            peakRssMb: {
+              baselineByNodeMajor: { "22": 730, "24": 1085 },
+              maxRegressionPercent: 10,
+              absoluteCeilingMb: 1200
+            }
+          }
+        }
+      }
+    });
+    assertEqual(runtimeMismatch.thresholdPolicy?.roleThresholds?.gateway?.peakRssMb, 803, "evaluator uses measured Node major instead of Kova runner major");
+    assertEqual(runtimeMismatch.status, "FAIL", "measured Node 22 runtime applies its stricter RSS gate");
     const scenarioRolePolicy = resolveThresholdPolicy({
       scenario: {
         id: "scenario-role-policy",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -75,6 +75,7 @@ import { runEntries } from "./run/engine.mjs";
 import { materializeLifecycleStepCommands } from "./run/phase-commands.mjs";
 import { executeStateLifecycleSteps } from "./run/state-lifecycle.mjs";
 import { executeTargetSetup } from "./run/target-setup.mjs";
+import { collectTargetRuntime } from "./run/finalize-record.mjs";
 import { classifyCommandFailure } from "./runner.mjs";
 import { classifyRetentionProtection, runGuardedTeardownStages } from "./run/teardown.mjs";
 import { runWithTargetRuntimeCleanup } from "./run/target-cleanup.mjs";
@@ -1200,6 +1201,7 @@ async function runScopedSelfCheck(flags, scope, workspace) {
     checks.push(await resourceRolePollutionCheck());
     checks.push(await resourceGatewayPidLookupCheck(tmp, scope));
     checks.push(await resourceSamplerFailureCheck());
+    checks.push(await targetRuntimeEvidenceCheck());
     checks.push(await startupSurfaceDiagnosticsContractCheck());
     checks.push(await gatewaySessionSurfaceContractCheck());
     checks.push(await bundledPluginStartupSurfaceContractCheck());
@@ -21621,6 +21623,89 @@ exec /bin/sh -c "$2"
   }
 }
 
+async function targetRuntimeEvidenceCheck() {
+  try {
+    const commands = [];
+    const execute = async (command, options) => {
+      commands.push({ command, timeoutMs: options.timeoutMs });
+      return {
+        status: 0,
+        stdout: JSON.stringify({ nodeVersion: "v22.22.3", pid: 4242, port: 19000 })
+      };
+    };
+    const trusted = await collectTargetRuntime("Team Env", 4242, 19000, 5000, execute);
+    assertEqual(
+      commands[0]?.command,
+      "ocm @'Team Env' -- 'gateway' 'call' 'system.info' '--port' '19000' '--json'",
+      "target runtime queries the OCM-recorded local Gateway"
+    );
+    assertEqual(trusted.collectionStatus, "ok", "matching Gateway runtime identity is trusted");
+    assertEqual(trusted.nodeVersion, "v22.22.3", "Gateway-reported Node version is retained");
+
+    const mismatch = await collectTargetRuntime("Team Env", 4343, 19000, 5000, execute);
+    assertEqual(mismatch.collectionStatus, "identity-mismatch", "Gateway identity mismatch is untrusted");
+    assertEqual(mismatch.nodeVersion, null, "PID mismatch cannot select a Node baseline");
+
+    const malformed = await collectTargetRuntime("Team Env", 4242, 19000, 5000, async () => ({
+      status: 0,
+      stdout: JSON.stringify({ nodeVersion: "unknown", pid: 4242, port: 19000 })
+    }));
+    assertEqual(malformed.collectionStatus, "invalid-payload", "malformed Gateway runtime payload is untrusted");
+
+    const prerelease = await collectTargetRuntime("Team Env", 4242, 19000, 5000, async () => ({
+      status: 0,
+      stdout: JSON.stringify({ nodeVersion: "v24.0.0-rc.1", pid: 4242, port: 19000 })
+    }));
+    assertEqual(prerelease.collectionStatus, "ok", "valid Node prerelease version is trusted");
+
+    let compatibilityCommands = 0;
+    const compatible = await collectTargetRuntime("Team Env", 4242, 19000, 5000, async () => {
+      compatibilityCommands += 1;
+      return compatibilityCommands === 1
+        ? {
+            status: 1,
+            stdout: JSON.stringify({ error: { message: "unknown method: system.info" } })
+          }
+        : {
+            status: 0,
+            stdout: "OS  macOS 14.7 · node 22.22.3\n"
+          };
+    });
+    assertEqual(compatible.collectionStatus, "compatibility-fallback", "older Gateway uses its bound runtime version");
+    assertEqual(compatible.nodeVersion, "22.22.3", "older Gateway runtime major is retained");
+
+    const failed = await collectTargetRuntime("Team Env", 4242, 19000, 5000, async () => ({
+      status: 1,
+      stdout: "{\"token\":\"must-not-be-retained\"}"
+    }));
+    assertEqual(failed.collectionStatus, "command-failed", "failed Gateway runtime query is untrusted");
+    assertEqual(JSON.stringify(failed).includes("must-not-be-retained"), false, "runtime query failure output is not retained");
+
+    let missingPidCommands = 0;
+    const missingPid = await collectTargetRuntime("Team Env", null, 19000, 5000, async () => {
+      missingPidCommands += 1;
+      return { status: 0, stdout: "{}" };
+    });
+    assertEqual(missingPid.collectionStatus, "missing-service-identity", "missing OCM Gateway identity is untrusted");
+    assertEqual(missingPidCommands, 0, "missing OCM Gateway PID skips the RPC");
+
+    return {
+      id: "target-runtime-evidence",
+      status: "PASS",
+      command: "validate Gateway runtime identity collection",
+      durationMs: 0
+    };
+  } catch (error) {
+    return {
+      id: "target-runtime-evidence",
+      status: "FAIL",
+      command: "validate Gateway runtime identity collection",
+      durationMs: 0,
+      message: error.message
+    };
+  }
+}
+
 async function processSnapshotCheck(tmp, scope) {
   const processRoles = await loadProcessRoles();
   const rootCommand = `ocm @${scope.envName} -- agent --local --session-id ${scope.sessionPrefix} --message hi`;
@@ -21967,6 +22052,31 @@ function thresholdPolicyCalibrationCheck() {
       true,
       "profile calibrated role violation"
     );
+    const runtimeThresholdSurface = {
+      id: "runtime-major-threshold",
+      thresholds: {},
+      roleThresholds: {
+        gateway: {
+          peakRssMb: {
+            baselineByNodeMajor: { "22": 730, "24": 1085 },
+            maxRegressionPercent: 10,
+            absoluteCeilingMb: 1200
+          }
+        }
+      }
+    };
+    const runtimeOptions = (targetRuntime) => ({
+      targetRuntime,
+      surface: runtimeThresholdSurface
+    });
+    const trustedRuntime = (nodeVersion) => ({
+      collectionStatus: "ok",
+      nodeVersion,
+      gatewayPid: 4242,
+      expectedGatewayPid: 4242,
+      gatewayPort: 19000,
+      expectedGatewayPort: 19000
+    });
     const runtimeMismatch = structuredClone(record);
     runtimeMismatch.status = "PASS";
     delete runtimeMismatch.violations;
@@ -21977,24 +22087,57 @@ function thresholdPolicyCalibrationCheck() {
     runtimeResources.peakTotalRssMb = 805;
     runtimeResources.byRole.gateway.peakRssMb = 805;
     runtimeResources.topRolesByRss[0].peakRssMb = 805;
-    evaluateRecord(runtimeMismatch, { id: "runtime-major-threshold", thresholds: {} }, {
-      nodeVersion: "v22.22.3",
-      surface: {
-        id: "runtime-major-threshold",
-        thresholds: {},
-        roleThresholds: {
-          gateway: {
-            peakRssMb: {
-              baselineByNodeMajor: { "22": 730, "24": 1085 },
-              maxRegressionPercent: 10,
-              absoluteCeilingMb: 1200
-            }
-          }
-        }
-      }
-    });
+    evaluateRecord(
+      runtimeMismatch,
+      { id: "runtime-major-threshold", thresholds: {} },
+      runtimeOptions(trustedRuntime("v22.22.3"))
+    );
     assertEqual(runtimeMismatch.thresholdPolicy?.roleThresholds?.gateway?.peakRssMb, 803, "evaluator uses measured Node major instead of Kova runner major");
     assertEqual(runtimeMismatch.status, "FAIL", "measured Node 22 runtime applies its stricter RSS gate");
+
+    const untrustedRuntime = structuredClone(runtimeMismatch);
+    untrustedRuntime.status = "PASS";
+    delete untrustedRuntime.violations;
+    const unavailableRuntime = {
+      collectionStatus: "command-failed",
+      nodeVersion: null,
+      gatewayPid: null,
+      expectedGatewayPid: 4242,
+      gatewayPort: null,
+      expectedGatewayPort: 19000
+    };
+    evaluateRecord(
+      untrustedRuntime,
+      { id: "runtime-major-threshold", thresholds: {} },
+      runtimeOptions(unavailableRuntime)
+    );
+    assertEqual(untrustedRuntime.thresholdPolicy?.roleThresholds?.gateway?.peakRssMb, 1200, "untrusted runtime remains absolutely bounded");
+    assertEqual(untrustedRuntime.status, "BLOCKED", "untrusted runtime identity blocks calibrated RSS evidence");
+    assertEqual(
+      untrustedRuntime.violations.some((violation) =>
+        violation.metric === "targetRuntime.nodeVersion" &&
+        violation.failureDomain === "kova-harness"
+      ),
+      true,
+      "untrusted runtime identity is attributed to the Kova harness"
+    );
+    evaluateRecord(
+      untrustedRuntime,
+      { id: "runtime-major-threshold", thresholds: {} },
+      runtimeOptions(unavailableRuntime)
+    );
+    assertEqual(untrustedRuntime.status, "BLOCKED", "runtime identity blocker survives repeated evaluation");
+
+    const futureRuntime = structuredClone(untrustedRuntime);
+    futureRuntime.status = "PASS";
+    delete futureRuntime.violations;
+    evaluateRecord(
+      futureRuntime,
+      { id: "runtime-major-threshold", thresholds: {} },
+      runtimeOptions(trustedRuntime("v26.0.0"))
+    );
+    assertEqual(futureRuntime.status, "PASS", "trusted future Node major uses the bounded fallback");
+    assertEqual(futureRuntime.thresholdPolicy?.runtimeCalibration?.[0]?.baselineMb, null, "future Node major reports missing baseline");
     const scenarioRolePolicy = resolveThresholdPolicy({
       scenario: {
         id: "scenario-role-policy",

--- a/surfaces/bundled-plugin-startup.json
+++ b/surfaces/bundled-plugin-startup.json
@@ -14,7 +14,11 @@
   },
   "roleThresholds": {
     "gateway": {
-      "peakRssMb": 1000,
+      "peakRssMb": {
+        "baselineByNodeMajor": { "22": 730, "24": 1085, "25": 1065 },
+        "maxRegressionPercent": 10,
+        "absoluteCeilingMb": 1200
+      },
       "maxCpuPercent": 250
     },
     "plugin-cli": {

--- a/surfaces/fresh-install.json
+++ b/surfaces/fresh-install.json
@@ -14,11 +14,19 @@
   "thresholds": {
     "gatewayReadyMs": 30000,
     "statusMs": 10000,
-    "peakRssMb": 1050
+    "peakRssMb": {
+      "baselineByNodeMajor": { "22": 735, "24": 1070, "25": 1060 },
+      "maxRegressionPercent": 10,
+      "absoluteCeilingMb": 1200
+    }
   },
   "roleThresholds": {
     "gateway": {
-      "peakRssMb": 1050,
+      "peakRssMb": {
+        "baselineByNodeMajor": { "22": 735, "24": 1070, "25": 1060 },
+        "maxRegressionPercent": 10,
+        "absoluteCeilingMb": 1200
+      },
       "maxCpuPercent": 250
     },
     "status-cli": {

--- a/surfaces/gateway-performance.json
+++ b/surfaces/gateway-performance.json
@@ -14,12 +14,20 @@
   "thresholds": {
     "coldReadyMs": 30000,
     "warmReadyMs": 15000,
-    "peakRssMb": 1050,
+    "peakRssMb": {
+      "baselineByNodeMajor": { "22": 735, "24": 1070, "25": 1060 },
+      "maxRegressionPercent": 10,
+      "absoluteCeilingMb": 1200
+    },
     "postReadyHealthP95Ms": 1000
   },
   "roleThresholds": {
     "gateway": {
-      "peakRssMb": 1050,
+      "peakRssMb": {
+        "baselineByNodeMajor": { "22": 735, "24": 1070, "25": 1060 },
+        "maxRegressionPercent": 10,
+        "absoluteCeilingMb": 1200
+      },
       "maxCpuPercent": 250
     },
     "gateway-tree": {

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -334,7 +334,15 @@
       },
       "roleThresholds": {
         "gateway": {
-          "peakRssMb": 1000,
+          "peakRssMb": {
+            "baselineByNodeMajor": {
+              "22": 730,
+              "24": 1085,
+              "25": 1065
+            },
+            "maxRegressionPercent": 10,
+            "absoluteCeilingMb": 1200
+          },
           "maxCpuPercent": 250
         },
         "plugin-cli": {
@@ -1053,11 +1061,27 @@
       "thresholds": {
         "gatewayReadyMs": 30000,
         "statusMs": 10000,
-        "peakRssMb": 1050
+        "peakRssMb": {
+          "baselineByNodeMajor": {
+            "22": 735,
+            "24": 1070,
+            "25": 1060
+          },
+          "maxRegressionPercent": 10,
+          "absoluteCeilingMb": 1200
+        }
       },
       "roleThresholds": {
         "gateway": {
-          "peakRssMb": 1050,
+          "peakRssMb": {
+            "baselineByNodeMajor": {
+              "22": 735,
+              "24": 1070,
+              "25": 1060
+            },
+            "maxRegressionPercent": 10,
+            "absoluteCeilingMb": 1200
+          },
           "maxCpuPercent": 250
         },
         "status-cli": {
@@ -1130,12 +1154,28 @@
       "thresholds": {
         "coldReadyMs": 30000,
         "warmReadyMs": 15000,
-        "peakRssMb": 1050,
+        "peakRssMb": {
+          "baselineByNodeMajor": {
+            "22": 735,
+            "24": 1070,
+            "25": 1060
+          },
+          "maxRegressionPercent": 10,
+          "absoluteCeilingMb": 1200
+        },
         "postReadyHealthP95Ms": 1000
       },
       "roleThresholds": {
         "gateway": {
-          "peakRssMb": 1050,
+          "peakRssMb": {
+            "baselineByNodeMajor": {
+              "22": 735,
+              "24": 1070,
+              "25": 1060
+            },
+            "maxRegressionPercent": 10,
+            "absoluteCeilingMb": 1200
+          },
           "maxCpuPercent": 250
         },
         "gateway-tree": {
@@ -12040,7 +12080,15 @@
         "statusMs": 10000,
         "pluginsListMs": 10000,
         "modelsListMs": 20000,
-        "peakRssMb": 1050
+        "peakRssMb": {
+          "baselineByNodeMajor": {
+            "22": 735,
+            "24": 1070,
+            "25": 1060
+          },
+          "maxRegressionPercent": 10,
+          "absoluteCeilingMb": 1200
+        }
       },
       "phases": [
         {
@@ -12154,7 +12202,15 @@
       "thresholds": {
         "coldReadyMs": 30000,
         "warmReadyMs": 15000,
-        "peakRssMb": 1050,
+        "peakRssMb": {
+          "baselineByNodeMajor": {
+            "22": 735,
+            "24": 1070,
+            "25": 1060
+          },
+          "maxRegressionPercent": 10,
+          "absoluteCeilingMb": 1200
+        },
         "eventLoopMaxMs": 500,
         "postReadyHealthP95Ms": 1000
       },


### PR DESCRIPTION
## Summary

- make RSS release gates select a reviewed baseline by Node runtime major
- bound each baseline with a 10% regression allowance and a 1200 MB absolute ceiling
- retain the absolute ceiling for an uncalibrated future Node major and report that its baseline is missing

## Root cause

The release gate used one absolute RSS budget calibrated before the current Node runtime line. Same-shape remote runs show this is a runtime-major distinction, not a Node 24 patch regression or process-tree accounting error:

| Node | Fresh | Onboarded | Bundled | Many plugins |
| --- | ---: | ---: | ---: | ---: |
| 22.22.3 | 719 | 724 | 729 | 752 |
| 24.15 | 1046 | 1051 | 1088 | 1049 |
| 24.16 | 1053 | 1060 | 1103 | 1071 |
| 24.19 | 1048 | 1058 | 1083 | 1079 |
| 25.9 | 1044 | 1079 | 1062 | 1047 |

Kova attributes the RSS to the single Gateway PID. Gateway diagnostics show roughly 726–758 MB committed JS heap with 292–355 MB used and about 16 MB external memory. Service-only `--max-old-space-size=512/768` did not reduce RSS; disabling compile cache worsened memory and latency; shrinking semi-space only marginally shifted startup RSS while worsening the agent scenario. A product runtime flag is therefore not the owner fix.

OpenClaw #127040 at `734ec85e` independently reduced the exact Node 24 path and remains within these calibrated bands: [run 32451512897](https://github.com/openclaw/openclaw/actions/runs/32451512897) recorded 1047/1057/1059/1084 MB for fresh/onboarded/bundled/many-plugin, with the agent scenario at 870 MB.

## Gate behavior

- Node 22: fresh/gateway 808 MB; bundled 803 MB
- Node 24: fresh/gateway 1177 MB; bundled 1193 MB
- Node 25: fresh/gateway 1166 MB; bundled 1171 MB
- other major: 1200 MB absolute ceiling, with `baselineMb: null` in threshold-policy evidence

This avoids a blind global increase: known runtime lines still fail beyond their measured baseline plus 10%, while every runtime remains subject to the absolute ceiling.

## Verification

- `node bin/kova.mjs matrix plan --profile release --target local-build:/tmp/openclaw-rss-node --json`
- `npm run test:snapshots`
- runtime policy self-checks cover Node 22 selection, Node 24 regression math, and missing-baseline fallback
- full local self-check reached the changed checks successfully; unrelated setup/credential/OCM checks are contaminated by this workstation's existing OCM state, so PR CI is authoritative
