### PR TITLE
fix(security): restrict command assertions and CI access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (${{ matrix.os }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Restrict command-output assertions to literal marker matching and pin CI's token to read-only repository access.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.
 - Emit canonical OpenClaw plugin install records from plugin-index state fixtures so migration and metadata scenarios reach the intended runtime paths.

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "scripts": {
     "kova": "node bin/kova.mjs",
     "plan": "node bin/kova.mjs plan",
-    "check": "npm run test:selfcheck-isolation && node bin/kova.mjs self-check",
+    "check": "npm run test:assert-command-output && npm run test:selfcheck-isolation && node bin/kova.mjs self-check",
     "check:full": "npm run check && npm run test:snapshots && npm run check:web-payload && npm run test:release-contracts",
     "check:web-payload": "node scripts/check-web-payload.mjs",
+    "test:assert-command-output": "node tests/assert-command-output.mjs",
     "test:selfcheck-isolation": "node tests/selfcheck-isolation.mjs",
     "test:snapshots": "node tests/render-snapshots.mjs",
     "test:release-contracts": "scripts/check-release-contracts.sh",

--- a/scenarios/plugin-legacy-unsafe-memory.json
+++ b/scenarios/plugin-legacy-unsafe-memory.json
@@ -46,7 +46,7 @@
       "commands": [
         "ocm service restart {env}",
         "ocm service status {env} --json",
-        "node {kovaRoot}/support/assert-command-output.mjs --pattern KOVA_LEGACY_UNSAFE_MEMORY_PLUGIN_REJECTED --retries 12 --delay-ms 750 -- ocm logs {env} --tail 500 --raw"
+        "node {kovaRoot}/support/assert-command-output.mjs --contains KOVA_LEGACY_UNSAFE_MEMORY_PLUGIN_REJECTED --retries 12 --delay-ms 750 -- ocm logs {env} --tail 500 --raw"
       ],
       "evidence": [
         "restart status after unsafe-memory rejection",

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -10437,7 +10437,7 @@ function safetyGuardCheck() {
       "node support/run-openclaw-release-age-upgrade.mjs --env=Violet --age day --json",
       "node support/run-doctor-repair.mjs --env kova-safe-test --env Violet",
       "node support/expect-command-fails.mjs -- ocm env destroy Violet --yes",
-      "node support/assert-command-output.mjs --pattern done -- ocm logs Violet --tail 20 --raw",
+      "node support/assert-command-output.mjs --contains done -- ocm logs Violet --tail 20 --raw",
       "ocm env des\\\ntroy Violet --yes",
       "ocm --json env destroy Violet --yes",
       "ocm e?? d?????? Violet --yes",

--- a/support/assert-command-output.mjs
+++ b/support/assert-command-output.mjs
@@ -6,20 +6,21 @@ const options = parseArgs(separator >= 0 ? process.argv.slice(2, separator) : pr
 const command = separator >= 0 ? process.argv.slice(separator + 1) : [];
 
 if (command.length === 0) {
-  console.error("usage: assert-command-output.mjs --pattern <regex> [--expect-status <code>] [--retries <n>] [--delay-ms <n>] -- <command> [args...]");
+  console.error("usage: assert-command-output.mjs --contains <text> [--expect-status <code>] [--retries <n>] [--delay-ms <n>] -- <command> [args...]");
   process.exit(2);
 }
 
-const pattern = new RegExp(options.pattern, options.flags);
 let result;
 let combined = "";
-let match = null;
+let matchedLine = null;
 
 for (let attempt = 1; attempt <= options.retries; attempt += 1) {
   result = await runProcess(command[0], command.slice(1));
   combined = `${result.stdout}\n${result.stderr}`;
-  match = result.status === options.expectStatus ? combined.match(pattern) : null;
-  if (match) {
+  matchedLine = result.status === options.expectStatus
+    ? lineContaining(combined, options.expectedText)
+    : null;
+  if (matchedLine !== null) {
     break;
   }
   if (attempt < options.retries) {
@@ -27,45 +28,43 @@ for (let attempt = 1; attempt <= options.retries; attempt += 1) {
   }
 }
 
-if (!match) {
+if (matchedLine === null) {
   process.stdout.write(result?.stdout ?? "");
   process.stderr.write(result?.stderr ?? "");
   if (result?.status !== options.expectStatus) {
     console.error(`expected command status ${options.expectStatus}, got ${result?.status ?? "unknown"}`);
   } else {
-    console.error(`expected command output to match /${options.pattern}/${options.flags}`);
+    console.error(`expected command output to contain ${JSON.stringify(options.expectedText)}`);
   }
   process.exit(1);
 }
 
 console.log(JSON.stringify({
-  schemaVersion: "kova.commandOutputAssertion.v1",
+  schemaVersion: "kova.commandOutputAssertion.v2",
   command: command.join(" "),
   status: result.status,
-  pattern: options.pattern,
+  expectedText: options.expectedText,
   attempts: options.retries,
   matched: true,
-  matchedLine: lineContaining(combined, match[0])
+  matchedLine
 }, null, 2));
 
 function parseArgs(args) {
   const options = {
-    pattern: null,
-    flags: "i",
+    expectedText: null,
     expectStatus: 0,
     retries: 1,
     delayMs: 500
   };
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (arg === "--pattern" || arg === "--flags" || arg === "--expect-status" || arg === "--retries" || arg === "--delay-ms") {
+    if (arg === "--contains" || arg === "--expect-status" || arg === "--retries" || arg === "--delay-ms") {
       const value = args[index + 1];
       if (!value) {
         throw new Error(`${arg} requires a value`);
       }
       index += 1;
-      if (arg === "--pattern") options.pattern = value;
-      if (arg === "--flags") options.flags = value;
+      if (arg === "--contains") options.expectedText = value;
       if (arg === "--expect-status") options.expectStatus = Number.parseInt(value, 10);
       if (arg === "--retries") options.retries = Number.parseInt(value, 10);
       if (arg === "--delay-ms") options.delayMs = Number.parseInt(value, 10);
@@ -73,7 +72,7 @@ function parseArgs(args) {
     }
     throw new Error(`unexpected argument: ${arg}`);
   }
-  if (!options.pattern) throw new Error("--pattern is required");
+  if (!options.expectedText) throw new Error("--contains is required");
   if (!Number.isInteger(options.expectStatus)) throw new Error("--expect-status must be an integer");
   if (!Number.isInteger(options.retries) || options.retries <= 0) throw new Error("--retries must be a positive integer");
   if (!Number.isInteger(options.delayMs) || options.delayMs < 0) throw new Error("--delay-ms must be a non-negative integer");
@@ -95,8 +94,11 @@ function runProcess(command, args) {
   });
 }
 
-function lineContaining(value, match) {
-  return String(value ?? "").split(/\r?\n/).find((line) => line.includes(match)) ?? match;
+function lineContaining(value, expectedText) {
+  const expected = expectedText.toLowerCase();
+  return String(value ?? "").split(/\r?\n/).find((line) => {
+    return line.toLowerCase().includes(expected);
+  }) ?? null;
 }
 
 function sleep(ms) {

--- a/tests/assert-command-output.mjs
+++ b/tests/assert-command-output.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const helper = join(repoRoot, "support", "assert-command-output.mjs");
+
+const literal = runHelper([
+  "--contains",
+  "READY+NOW",
+  "--",
+  process.execPath,
+  "-e",
+  "console.log('ready+now')"
+]);
+assert.equal(literal.status, 0, literal.stderr);
+assert.deepEqual(JSON.parse(literal.stdout), {
+  schemaVersion: "kova.commandOutputAssertion.v2",
+  command: `${process.execPath} -e console.log('ready+now')`,
+  status: 0,
+  expectedText: "READY+NOW",
+  attempts: 1,
+  matched: true,
+  matchedLine: "ready+now"
+});
+
+const noRegexEvaluation = runHelper([
+  "--contains",
+  "ready+now",
+  "--",
+  process.execPath,
+  "-e",
+  "console.log('readynow')"
+]);
+assert.equal(noRegexEvaluation.status, 1);
+assert.match(noRegexEvaluation.stderr, /expected command output to contain "ready\+now"/);
+
+console.log("assert-command-output tests passed");
+
+function runHelper(args) {
+  return spawnSync(process.execPath, [helper, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+}

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -13125,7 +13125,7 @@
           "commands": [
             "ocm service restart {env}",
             "ocm service status {env} --json",
-            "node {kovaRoot}/support/assert-command-output.mjs --pattern KOVA_LEGACY_UNSAFE_MEMORY_PLUGIN_REJECTED --retries 12 --delay-ms 750 -- ocm logs {env} --tail 500 --raw"
+            "node {kovaRoot}/support/assert-command-output.mjs --contains KOVA_LEGACY_UNSAFE_MEMORY_PLUGIN_REJECTED --retries 12 --delay-ms 750 -- ocm logs {env} --tail 500 --raw"
           ],
           "evidence": [
             "restart status after unsafe-memory rejection",


### PR DESCRIPTION
## What Problem This Solves

Fixes the two fresh CodeQL alerts reported by default setup on `main`:

- High: regular expression injection in `support/assert-command-output.mjs`
- Medium: unrestricted default `GITHUB_TOKEN` permissions in CI

Source run: https://github.com/openclaw/Kova/actions/runs/32454479401

## Why This Change Was Made

The command-output helper only has one product caller, and that caller waits for a literal diagnostic marker. The helper now exposes that actual contract through case-insensitive literal containment instead of compiling command-line input as a regular expression. The scenario, safety fixture, result schema, and regression coverage move together.

CI now declares the least privilege it needs at workflow scope: `contents: read`.

## User Impact

Command-output assertions cannot interpret operator-supplied text as executable regular expressions, including costly expressions. Kova's CI token remains read-only even if repository defaults change.

## Evidence

- `node tests/assert-command-output.mjs`
- `npm run test:snapshots` (21 passed)
- `npm run check:web-payload`
- `npm run test:release-contracts`
- `npm run pack:release`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- Exact-head CI: https://github.com/openclaw/Kova/actions/runs/32455532317 (macOS and Linux passed)
- Exact-head CodeQL: https://github.com/openclaw/Kova/actions/runs/32455529383 (Actions and JavaScript analyses each reported `results_count: 0`)

The broad local self-check completed 271/277 checks. Its six failures were environment/baseline surfaces unrelated to this patch: three require the unavailable local `ocm` binary, while the remaining MCP, cleanup, and diagnostic timing checks are covered by clean hosted CI.

AI-assisted: yes.
