### PR TITLE
fix(perf): calibrate status CLI CPU budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Calibrate status CLI CPU budgets for the aggregate parent and SQLite snapshot worker process tree.
 - Restrict command-output assertions to literal marker matching and pin CI's token to read-only repository access.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.

--- a/surfaces/cross-platform-smoke.json
+++ b/surfaces/cross-platform-smoke.json
@@ -19,7 +19,7 @@
     },
     "status-cli": {
       "peakRssMb": 500,
-      "maxCpuPercent": 200
+      "maxCpuPercent": 275
     }
   },
   "diagnostics": {

--- a/surfaces/fresh-install.json
+++ b/surfaces/fresh-install.json
@@ -31,7 +31,7 @@
     },
     "status-cli": {
       "peakRssMb": 900,
-      "maxCpuPercent": 200
+      "maxCpuPercent": 275
     },
     "plugin-cli": {
       "peakRssMb": 900,

--- a/surfaces/gateway-performance.json
+++ b/surfaces/gateway-performance.json
@@ -36,7 +36,7 @@
     },
     "status-cli": {
       "peakRssMb": 900,
-      "maxCpuPercent": 200
+      "maxCpuPercent": 275
     },
     "plugin-cli": {
       "peakRssMb": 950,

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -712,7 +712,7 @@
         },
         "status-cli": {
           "peakRssMb": 500,
-          "maxCpuPercent": 200
+          "maxCpuPercent": 275
         }
       },
       "diagnostics": {
@@ -1086,7 +1086,7 @@
         },
         "status-cli": {
           "peakRssMb": 900,
-          "maxCpuPercent": 200
+          "maxCpuPercent": 275
         },
         "plugin-cli": {
           "peakRssMb": 900,
@@ -1184,7 +1184,7 @@
         },
         "status-cli": {
           "peakRssMb": 900,
-          "maxCpuPercent": 200
+          "maxCpuPercent": 275
         },
         "plugin-cli": {
           "peakRssMb": 950,


### PR DESCRIPTION
## Summary

- raise the aggregate `status-cli` CPU cap from 200% to 275%
- apply the calibrated cap to fresh-install, gateway-performance, and cross-platform smoke
- refresh the plan snapshot and changelog

## Rationale

OpenClaw status now starts a short-lived SQLite snapshot worker. Kova attributes that worker and its parent CLI to the same `status-cli` role, so their simultaneous CPU usage is summed. Release evidence measured aggregate peaks between 219% and 253%. A 275% cap covers that process model while retaining a regression guard above the observed range.

## Testing

- `npm run test:snapshots`
- `npm run check:web-payload`
- `npm run test:release-contracts`
- verified all three plan surfaces resolve `status-cli.maxCpuPercent` to 275
- `npm run check:full` reaches 273/278 self-check passes; five unrelated local auth-config and live API-key execution checks fail because their expected OpenClaw config/timeline fixtures are absent
