### PR TITLE
fix(reports): capture identity at successful runtime binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Bind exact npm target identity to successful OCM start/upgrade receipts before rollback or cleanup, and omit identity claims when provisioning fails. Thanks @pdurlej.
 - Restrict command-output assertions to literal marker matching and pin CI's token to read-only repository access.
 - Route version bumps through pull requests, gate signed tags on exact-main CI, avoid repeating the full suite during tag builds, and skip ClawSweeper token creation for ordinary comments.
 - Keep agent CLI, agent runtime, and mock-provider resource roles disjoint so RSS gates report the owning process once.

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -79,6 +79,43 @@ kova.report.v1
 whether Kova removed the generated temporary OCM runtime after execution, or why
 it retained that runtime.
 
+`targetIdentity` is optional exact-candidate evidence for `npm:<semver>` targets:
+
+```json
+{
+  "schemaVersion": "kova.target.identity.v1",
+  "requestedSelector": "npm:2026.7.1-2",
+  "resolvedVersion": "2026.7.1-2",
+  "npmIntegrity": "sha512-<canonical base64 encoding of 64 digest bytes>",
+  "gitSha": null,
+  "buildDigest": null
+}
+```
+
+Kova captures this identity immediately after a successful target `ocm start`
+or `ocm upgrade`, using the runtime name in that operation's JSON receipt and
+`ocm runtime show <bound-name> --json`. The installed runtime must report the
+requested version and a canonical SHA-512 npm integrity. Global inventory,
+selector matches, and post-cleanup version probes never establish identity.
+The captured value survives later scenario failures, rollback, and cleanup.
+
+Dry runs, moving selectors, failed provisioning, missing metadata, and invalid
+digests omit `targetIdentity`; the requested `target` remains diagnostic only.
+Command results retain the captured identity (or `null` for an unattested target
+binding attempt), and scenario records emit it only when their target binding
+attempts agree. A report emits one identity only when every executed record has
+the same identity; skipped records do not contribute. Mixed or missing bindings
+omit the report-level field while preserving each record's evidence.
+
+Run and matrix JSON receipts and bundle `manifest.json` copy the report's
+optional identity verbatim. An identity proves which npm candidate was bound,
+not that the scenario passed or that OpenClaw reached readiness.
+
+With OCM installed, `node tests/report-identity-ocm.mjs artifacts/identity-proof`
+reproduces the failed-provisioning fixture and a successful binding through both
+run and matrix receipts. It uses an isolated OCM store, a loopback registry, and
+a tiny fixture package; this is report-path proof, not OpenClaw readiness proof.
+
 Report bundles include `artifact-index.json` at the archive root. The index
 lists every file staged into the bundle with its original relative `path`,
 portable `archivePath`, byte size, and SHA-256 digest. Kova maps names that

--- a/src/commands/matrix-run.mjs
+++ b/src/commands/matrix-run.mjs
@@ -162,6 +162,7 @@ export async function runMatrixRun(flags) {
       generatedAt: new Date().toISOString(),
       mode: report.mode,
       runId,
+      ...(report.targetIdentity ? { targetIdentity: report.targetIdentity } : {}),
       profile: profileSummary(profile),
       reportPath: outputPaths.markdown,
       jsonPath: outputPaths.json,

--- a/src/commands/run.mjs
+++ b/src/commands/run.mjs
@@ -134,6 +134,7 @@ export async function runScenarioCommand(flags) {
       generatedAt: new Date().toISOString(),
       mode,
       runId,
+      ...(report.targetIdentity ? { targetIdentity: report.targetIdentity } : {}),
       reportPath: outputPaths.markdown,
       jsonPath: outputPaths.json,
       summaryPath: outputPaths.summary,

--- a/src/reporting/artifacts.mjs
+++ b/src/reporting/artifacts.mjs
@@ -124,6 +124,7 @@ export async function bundleReport(reportPath, options = {}) {
         runId,
         mode: report.mode ?? null,
         target: report.target ?? null,
+        ...(report.targetIdentity ? { targetIdentity: report.targetIdentity } : {}),
         profile: report.profile ?? null,
         platform: report.platform ?? null,
         source: {

--- a/src/run/command-executor.mjs
+++ b/src/run/command-executor.mjs
@@ -18,6 +18,7 @@ import { commandReceivesNodeProfiler } from "../performance/instrumentation.mjs"
 import { resolveOwnedMockProviderPid } from "../process-safety.mjs";
 import { assertSafeScenarioCommand } from "../safety.mjs";
 import { safeSegment } from "./phase-commands.mjs";
+import { captureTargetIdentity } from "../target-identity.mjs";
 
 export async function runScenarioCommand(command, context, envName, artifactDir, phase, commandIndex, authPolicy = null) {
   return runCommandWithContext(command, context, envName, artifactDir, phase, commandIndex, authPolicy, true);
@@ -75,6 +76,11 @@ async function runCommandWithContext(command, context, envName, artifactDir, pha
       trackedRolePids,
       artifactPath: join(collectorArtifactDirs(artifactDir).resourceSamples, `${safeSegment(phaseId)}-${commandIndex + 1}.jsonl`)
     }
+  });
+  await captureTargetIdentity(result, context.targetPlan, envName, {
+    timeoutMs: context.timeoutMs,
+    env: context.commandEnv,
+    redactValues: authPolicy?.redactionValues ?? context.auth?.redactionValues ?? []
   });
   normalizeOptionalCommandResult(result);
   tagCommandResult(result, phase);

--- a/src/run/report-finalization.mjs
+++ b/src/run/report-finalization.mjs
@@ -8,6 +8,7 @@ import {
 } from "../performance/baselines.mjs";
 import { platformInfo } from "../platform.mjs";
 import { summarizeRecords } from "../reporting/report.mjs";
+import { reportTargetIdentity } from "../target-identity.mjs";
 
 const REPORT_SCHEMA_VERSION = "kova.report.v1";
 
@@ -28,6 +29,7 @@ export function buildRunReport({
   gate = null,
   platform = platformInfo()
 }) {
+  const targetIdentity = reportTargetIdentity(records);
   return {
     schemaVersion: REPORT_SCHEMA_VERSION,
     generatedAt: new Date().toISOString(),
@@ -36,6 +38,7 @@ export function buildRunReport({
     mode,
     ...(profile ? { profile } : {}),
     target,
+    ...(targetIdentity ? { targetIdentity } : {}),
     from,
     controls,
     auth,

--- a/src/runner.mjs
+++ b/src/runner.mjs
@@ -32,6 +32,7 @@ import { artifactsDir } from "./paths.mjs";
 import { plannedNetworkFrontage } from "./network-frontage.mjs";
 import { assertKovaEnvName } from "./safety.mjs";
 import { join } from "node:path";
+import { recordTargetIdentity } from "./target-identity.mjs";
 export { createRunId } from "./run/run-id.mjs";
 
 export function buildDryRunRecord(scenario, context) {
@@ -201,6 +202,8 @@ export async function executeScenario(scenario, context) {
       }
     }
   } finally {
+    const targetIdentity = recordTargetIdentity(record);
+    if (targetIdentity) record.targetIdentity = targetIdentity;
     await teardownScenario(record, scenario, context, envName, artifactDir, authPolicy);
   }
 

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -87,6 +87,7 @@ import { validateRegistryReferences } from "./registries/validate.mjs";
 import { isMissingOcmResource } from "./ocm/missing-resource.mjs";
 import { assertSafeScenarioCommand, assertSingleTopLevelShellCommand } from "./safety.mjs";
 import { resolveTarget } from "./targets.mjs";
+import { checkTargetIdentityBinding, checkTargetIdentityOutputs } from "./selfcheck/target-identity.mjs";
 import {
   commandResultFailureReason,
   commandResultFailed,
@@ -291,6 +292,8 @@ async function runScopedSelfCheck(flags, scope, workspace) {
   checks.push(await syntaxCheck());
   checks.push(await webPayloadContractCheck(tmp));
   checks.push(commandResultContractCheck());
+  checks.push(await inlineCheck("target-identity-binding", checkTargetIdentityBinding));
+  checks.push(await inlineCheck("target-identity-outputs", () => checkTargetIdentityOutputs(tmp)));
     checks.push(await jsonCommandCheck("version-json", "node bin/kova.mjs version --json", (data) => {
       assertEqual(data.schemaVersion, "kova.version.v1", "version schema");
       assertString(data.version, "version");

--- a/src/selfcheck/target-identity.mjs
+++ b/src/selfcheck/target-identity.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { quoteShell, runCommand } from "../commands.mjs";
+import { resolveTarget } from "../targets.mjs";
+import { captureTargetIdentity, recordTargetIdentity, reportTargetIdentity } from "../target-identity.mjs";
+
+const version = "2026.7.1-2";
+const plan = resolveTarget(`npm:${version}`, "target");
+const digest = `sha512-${Buffer.alloc(64, 0x5a).toString("base64")}`;
+const otherDigest = `sha512-${Buffer.alloc(64, 0x6b).toString("base64")}`;
+const envName = "kova-identity-check";
+const metadata = { name: "bound", sourceKind: "installed", releaseVersion: version, sourceIntegrity: digest };
+const success = (payload, extra = {}) => ({ status: 0, stdout: JSON.stringify(payload), ...extra });
+const start = () => success({ envName, defaultRuntime: "bound" }, {
+  command: `ocm start '${envName}' --version '${version}' --json`
+});
+const upgrade = () => success({ envName, bindingKind: "runtime", bindingName: "bound", outcome: "switched", runtimeReleaseVersion: version }, {
+  command: `ocm upgrade '${envName}' --version '${version}' --json`
+});
+
+export async function checkTargetIdentityBinding() {
+  const calls = [];
+  const execute = async (command) => {
+    calls.push(command);
+    assert.equal(command, "ocm runtime show 'bound' --json");
+    return success(metadata);
+  };
+  const bound = start();
+  await captureTargetIdentity(bound, plan, envName, { execute });
+  assert.equal(bound.targetIdentity.npmIntegrity, digest);
+  const upgraded = upgrade();
+  await captureTargetIdentity(upgraded, plan, envName, { execute });
+  assert.deepEqual(upgraded.targetIdentity, bound.targetIdentity);
+
+  for (const result of [
+    { ...start(), status: 1 }, { ...start(), timedOut: true },
+    { ...start(), signal: "SIGTERM" }, { ...start(), outputBudget: { truncated: true } },
+    { ...start(), stdout: "not json" },
+    { ...start(), stdout: JSON.stringify({ envName: "unrelated", defaultRuntime: "bound" }) },
+    { ...upgrade(), stdout: JSON.stringify({ envName, bindingKind: "runtime", bindingName: "bound", outcome: "rolled-back", runtimeReleaseVersion: version }) }
+  ]) {
+    await captureTargetIdentity(result, plan, envName, { execute });
+    assert.equal(result.targetIdentity, null);
+  }
+  assert.equal(calls.length, 2, "failed provisioning never looks up runtime identity");
+  for (const result of [
+    success({ ...metadata, name: "unrelated" }), success({ ...metadata, releaseVersion: "1.2.3" }),
+    success({ ...metadata, sourceKind: "registered" }), success({ ...metadata, sourceIntegrity: otherDigest.slice(0, -4) }),
+    success({ ...metadata, sourceIntegrity: `${digest.slice(0, -2)}A=` }),
+    success(metadata, { status: 1 }), success(metadata, { outputBudget: { truncated: true } }),
+    { status: 0, stdout: "not json" }
+  ]) {
+    const receipt = start();
+    await captureTargetIdentity(receipt, plan, envName, { execute: async () => result });
+    assert.equal(receipt.targetIdentity, null);
+  }
+  const source = { ...start(), command: `ocm start '${envName}' --channel stable --json` };
+  await captureTargetIdentity(source, plan, envName, { execute });
+  assert.equal(Object.hasOwn(source, "targetIdentity"), false);
+  const moving = start();
+  await captureTargetIdentity(moving, resolveTarget("release:stable", "target"), envName, { execute });
+  assert.equal(Object.hasOwn(moving, "targetIdentity"), false);
+
+  const identity = recordTargetIdentity({ phases: [{ results: [source, bound] }, { results: [{ command: "rollback" }] }] });
+  assert.deepEqual(identity, bound.targetIdentity, "rollback does not replace captured candidate");
+  assert.equal(recordTargetIdentity({ phases: [{ results: [bound, { targetIdentity: null }] }] }), null);
+  const records = [{ status: "PASS", targetIdentity: identity }, { status: "SKIPPED" }];
+  assert.deepEqual(reportTargetIdentity(records), identity);
+  assert.equal(reportTargetIdentity([...records, { status: "BLOCKED" }]), null);
+  assert.equal(reportTargetIdentity([...records, { status: "PASS", targetIdentity: { ...identity, npmIntegrity: otherDigest } }]), null);
+  assert.equal(reportTargetIdentity([{ status: "DRY-RUN" }]), null);
+}
+
+export async function checkTargetIdentityOutputs(parent) {
+  const root = join(parent, "identity-outputs");
+  const bin = join(root, "bin");
+  const eventsPath = join(root, "events.jsonl");
+  await mkdir(bin, { recursive: true });
+  await writeFile(join(bin, "ocm"), `#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+const args = process.argv.slice(2);
+appendFileSync(process.env.IDENTITY_EVENTS, JSON.stringify(args) + '\\n');
+if (args[0] === 'start') {
+  if (process.env.IDENTITY_FAIL === '1') process.exit(1);
+  console.log(JSON.stringify({envName: args[1], defaultRuntime: 'bound'}));
+} else if (args[0] === 'runtime' && args[1] === 'show') {
+  console.log(JSON.stringify(${JSON.stringify(metadata)}));
+} else if (args[0] === 'runtime' && args[1] === 'list') {
+  console.log(JSON.stringify([${JSON.stringify({ ...metadata, name: 'unrelated', sourceIntegrity: otherDigest })}]));
+} else if (args[0] === 'env' && args[1] === 'destroy') {
+  console.log('{}');
+} else process.exit(1);
+`, { mode: 0o755 });
+  const env = { PATH: `${bin}:${process.env.PATH}`, KOVA_HOME: join(root, "home"), IDENTITY_EVENTS: eventsPath };
+  for (const matrix of [false, true]) {
+    for (const mode of ["failed", "bound", "dry"]) {
+      await writeFile(eventsPath, "");
+      const args = matrix ? "matrix run --profile smoke --include scenario:fresh-install" : "run --scenario fresh-install";
+      const result = await runCommand(`node bin/kova.mjs ${args} --target npm:${version} --auth skip --timeout-ms 2000 --health-samples 1 --report-dir ${quoteShell(root)} ${mode === "dry" ? "" : "--execute"} --json`, {
+        env: { ...env, IDENTITY_FAIL: mode === "failed" ? "1" : "0" }, timeoutMs: 60000, maxOutputChars: 1000000
+      });
+      assert.equal(result.status, 0, result.stderr);
+      const receipt = JSON.parse(result.stdout);
+      const report = JSON.parse(await readFile(receipt.jsonPath, "utf8"));
+      const bundleResult = matrix ? null : await runCommand(`node bin/kova.mjs report bundle ${quoteShell(receipt.jsonPath)} --json`, { env, timeoutMs: 30000 });
+      if (bundleResult) assert.equal(bundleResult.status, 0, bundleResult.stderr);
+      const bundlePath = receipt.bundlePath ?? JSON.parse(bundleResult.stdout).outputPath;
+      const archiveList = await runCommand(`tar -tzf ${quoteShell(bundlePath)}`);
+      assert.equal(archiveList.status, 0, archiveList.stderr);
+      const manifestPath = archiveList.stdout.split("\n").find((name) => name.endsWith("/manifest.json"));
+      assert.ok(manifestPath);
+      const manifestResult = await runCommand(`tar -xOzf ${quoteShell(bundlePath)} ${quoteShell(manifestPath)}`);
+      assert.equal(manifestResult.status, 0, manifestResult.stderr);
+      const manifest = JSON.parse(manifestResult.stdout);
+      for (const output of [receipt, report, manifest, ...report.records]) {
+        if (mode === "bound") assert.equal(output.targetIdentity?.npmIntegrity, digest);
+        else assert.equal(Object.hasOwn(output, "targetIdentity"), false);
+      }
+      assert.deepEqual(receipt.targetIdentity, report.targetIdentity);
+      assert.deepEqual(manifest.targetIdentity, report.targetIdentity);
+      const events = (await readFile(eventsPath, "utf8")).trim().split("\n").filter(Boolean).map(JSON.parse);
+      assert.equal(events.some((args) => args[0] === "runtime" && args[1] === "list"), false);
+      const show = events.findIndex((args) => args[0] === "runtime" && args[1] === "show");
+      if (mode === "bound") {
+        assert.ok(show > 0);
+        assert.ok(show < events.findIndex((args) => args[0] === "env" && args[1] === "destroy"));
+        assert.notEqual(report.records[0].cleanup, "retained");
+      } else assert.equal(show, -1);
+    }
+  }
+}

--- a/src/target-identity.mjs
+++ b/src/target-identity.mjs
@@ -1,0 +1,84 @@
+import { Buffer } from "node:buffer";
+import { quoteShell, runCommand } from "./commands.mjs";
+
+const EXACT_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const SHA512_SRI = /^sha512-([A-Za-z0-9+/]{86}==)$/;
+
+function isCanonicalSha512Integrity(value) {
+  const match = typeof value === "string" ? SHA512_SRI.exec(value) : null;
+  if (!match) return false;
+  const decoded = Buffer.from(match[1], "base64");
+  return decoded.length === 64 && decoded.toString("base64") === match[1];
+}
+
+// Only the generated target operation can attest a binding. Source setup,
+// rollback, inventory, and later version probes cannot substitute for it.
+function targetBindingOperation(command, targetPlan, envName) {
+  if (targetPlan?.kind !== "npm" || !EXACT_VERSION.test(targetPlan.value)) return null;
+  const selector = `--version ${quoteShell(targetPlan.value)}`;
+  const start = `ocm start ${quoteShell(envName)} ${selector}`;
+  if (command === `${start} --json` || command === `${start} --no-service --json`) return "start";
+  if (command === `ocm upgrade ${quoteShell(envName)} ${selector} --json`) return "upgrade";
+  return null;
+}
+
+function successfulJson(result) {
+  if (result?.status !== 0 || result.timedOut || result.signal || result.outputBudget?.truncated) return null;
+  try {
+    const payload = JSON.parse(result.stdout);
+    return payload && typeof payload === "object" && !Array.isArray(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function captureTargetIdentity(result, targetPlan, envName, options = {}) {
+  const operation = targetBindingOperation(result.command, targetPlan, envName);
+  if (!operation) return;
+  result.targetIdentity = null;
+  const binding = successfulJson(result);
+  if (binding?.envName !== envName) return;
+  if (operation === "upgrade" && (
+    binding.bindingKind !== "runtime" ||
+    !["switched", "updated", "up-to-date"].includes(binding.outcome) ||
+    binding.rollback != null || binding.runtimeReleaseVersion !== targetPlan.value
+  )) return;
+  const runtimeName = operation === "start" ? binding.defaultRuntime : binding.bindingName;
+  if (typeof runtimeName !== "string" || !runtimeName || (operation === "start" && binding.defaultLauncher)) return;
+
+  // Resolve this receipt's named runtime before another command can roll it
+  // back or remove it. Never search global inventory by version or selector.
+  const execute = options.execute ?? runCommand;
+  const metadata = successfulJson(await execute(`ocm runtime show ${quoteShell(runtimeName)} --json`, {
+    timeoutMs: options.timeoutMs ?? 30000,
+    env: options.env,
+    redactValues: options.redactValues,
+    maxOutputChars: 1000000
+  }));
+  if (metadata?.name !== runtimeName || metadata.sourceKind !== "installed" ||
+      metadata.releaseVersion !== targetPlan.value || !isCanonicalSha512Integrity(metadata.sourceIntegrity)) return;
+  result.targetIdentity = {
+    schemaVersion: "kova.target.identity.v1",
+    requestedSelector: targetPlan.selector,
+    resolvedVersion: metadata.releaseVersion,
+    npmIntegrity: metadata.sourceIntegrity,
+    gitSha: null,
+    buildDigest: null
+  };
+}
+
+export function commonTargetIdentity(items) {
+  const identity = items[0]?.targetIdentity;
+  if (!identity || !items.every((item) => JSON.stringify(item.targetIdentity) === JSON.stringify(identity))) return null;
+  return identity;
+}
+
+export function recordTargetIdentity(record) {
+  const bindings = (record.phases ?? []).flatMap((phase) => phase.results ?? [])
+    .filter((result) => Object.hasOwn(result, "targetIdentity"));
+  return commonTargetIdentity(bindings);
+}
+
+export function reportTargetIdentity(records) {
+  return commonTargetIdentity(records.filter((record) => !["DRY-RUN", "SKIPPED"].includes(record.status)));
+}

--- a/tests/report-identity-ocm.mjs
+++ b/tests/report-identity-ocm.mjs
@@ -1,0 +1,128 @@
+// Real Kova + OCM report-path proof; the OpenClaw package and registry are fixtures.
+// Run: node tests/report-identity-ocm.mjs <output-directory>
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { spawn, execFileSync } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { gzipSync } from "node:zlib";
+import tar from "tar-stream";
+
+const output = resolve(process.argv[2] ?? "artifacts/report-identity-proof");
+await mkdir(output, { recursive: true });
+const root = await mkdtemp(join(output, "fixture-"));
+const version = "2026.7.1-2";
+const decoyDigest = `sha512-${Buffer.alloc(64, 0x42).toString("base64")}`;
+const archive = await packageFixture();
+const digest = `sha512-${createHash("sha512").update(archive).digest("base64")}`;
+let published = false;
+let origin;
+const server = createServer((req, res) => {
+  if (req.url === "/openclaw.tgz") return res.end(archive);
+  res.setHeader("content-type", "application/json");
+  res.end(JSON.stringify(published ? {
+    "dist-tags": { latest: version },
+    versions: { [version]: { version, dist: { tarball: `${origin}/openclaw.tgz`, integrity: digest } } },
+    time: { [version]: "2026-07-01T00:00:00Z" }
+  } : { "dist-tags": {}, versions: {} }));
+});
+await new Promise((done) => server.listen(0, "127.0.0.1", done));
+origin = `http://127.0.0.1:${server.address().port}`;
+const env = {
+  ...process.env,
+  OCM_HOME: join(root, "ocm"),
+  KOVA_HOME: join(root, "kova"),
+  OCM_INTERNAL_OPENCLAW_RELEASES_URL: `${origin}/openclaw`,
+  // This proof stops after binding; no actual service is launched.
+  OCM_INTERNAL_SERVICE_MANAGER: "unsupported",
+  npm_config_cache: join(root, "npm-cache")
+};
+const cases = [];
+try {
+  await mkdir(join(env.OCM_HOME, "runtimes"), { recursive: true });
+  await writeFile(join(env.OCM_HOME, "runtimes/unrelated-simulation-runtime.json"), JSON.stringify({
+    kind: "runtime", name: "unrelated-simulation-runtime", binaryPath: join(root, "nonexistent-runtime/openclaw.mjs"),
+    sourceKind: "installed", sourceIntegrity: decoyDigest, releaseVersion: version,
+    releaseSelectorKind: "version", releaseSelectorValue: version,
+    description: "synthetic fixture: never installed or executed",
+    createdAt: "2026-08-28T00:00:00Z", updatedAt: "2026-08-28T00:00:00Z"
+  }));
+  const inventory = JSON.parse(await run("ocm", ["runtime", "list", "--json"]));
+  assert.equal(inventory.length, 1);
+  assert.equal(inventory[0].sourceIntegrity, decoyDigest);
+  for (const matrix of [false, true]) await checkRun(matrix, false);
+  published = true;
+  for (const matrix of [false, true]) await checkRun(matrix, true);
+  const runtimes = JSON.parse(await run("ocm", ["runtime", "list", "--json"]));
+  assert.equal(runtimes.length, 2, "bound candidate and unrelated same-version runtime coexist");
+  for (const runtime of runtimes) await run("ocm", ["runtime", "remove", runtime.name, "--json"]);
+  assert.deepEqual(JSON.parse(await run("ocm", ["env", "list", "--json"])), []);
+  assert.deepEqual(JSON.parse(await run("ocm", ["runtime", "list", "--json"])), []);
+  const summary = { fixtureOnly: true, ocmVersion: (await run("ocm", ["--version"])).trim(), expectedBoundDigest: digest, decoyDigest, cases, cleanup: "env and runtime inventories empty" };
+  await writeFile(join(output, "summary.json"), JSON.stringify(summary, null, 2) + "\n");
+  console.log(JSON.stringify(summary, null, 2));
+} finally {
+  await new Promise((done) => server.close(done));
+  // Only this fixture owns these stores; retained reports and bundles live outside them.
+  await rm(root, { recursive: true, force: true });
+}
+
+async function checkRun(matrix, bound) {
+  const label = `${matrix ? "matrix" : "run"}-${bound ? "bound" : "failed"}`;
+  const scenario = bound ? "fresh-install" : "release-runtime-startup";
+  const command = matrix ? ["matrix", "run", "--profile", bound ? "smoke" : "release", "--include", `scenario:${scenario}`] : ["run", "--scenario", scenario];
+  const stdout = await run(process.execPath, ["bin/kova.mjs", ...command, "--target", `npm:${version}`, "--auth", "skip", "--execute", "--timeout-ms", "20000", "--report-dir", output, "--json"]);
+  const receipt = JSON.parse(stdout);
+  await writeFile(join(output, `${label}-receipt.json`), stdout);
+  const report = JSON.parse(await readFile(receipt.jsonPath, "utf8"));
+  const bundle = receipt.bundlePath ? { outputPath: receipt.bundlePath } : JSON.parse(await run(process.execPath, ["bin/kova.mjs", "report", "bundle", receipt.jsonPath, "--output-dir", output, "--json"]));
+  const names = execFileSync("tar", ["-tzf", bundle.outputPath], { encoding: "utf8" }).split("\n");
+  const manifestName = names.find((name) => name.endsWith("/manifest.json"));
+  assert.ok(manifestName);
+  const manifest = JSON.parse(execFileSync("tar", ["-xOzf", bundle.outputPath, manifestName], { encoding: "utf8" }));
+  assert.equal(report.records.length, 1);
+  const record = report.records[0];
+  const first = record.phases[0].results[0];
+  assert.equal(first.status, bound ? 0 : 1, first.stderr);
+  if (!bound) {
+    assert.equal(report.summary.statuses.BLOCKED, 1);
+    assert.match(first.stderr, /does not contain any published versions/);
+  }
+  for (const value of [receipt, report, manifest, record]) {
+    if (bound) assert.equal(value.targetIdentity?.npmIntegrity, digest);
+    else assert.equal(Object.hasOwn(value, "targetIdentity"), false);
+  }
+  assert.deepEqual(receipt.targetIdentity, report.targetIdentity);
+  assert.deepEqual(manifest.targetIdentity, report.targetIdentity);
+  assert.deepEqual(JSON.parse(await run("ocm", ["env", "list", "--json"])), []);
+  cases.push({ label, status: record.status, bindingStatus: first.status, identity: receipt.targetIdentity ?? null, cleanup: record.cleanup, reportPath: receipt.jsonPath, bundlePath: bundle.outputPath, firstCommandFailure: first.stderr.trim() });
+  console.log(`PASS ${label}: ${bound ? "exact bound digest survives cleanup" : "no identity claim"}`);
+}
+
+function run(program, args) {
+  return new Promise((done, reject) => {
+    const child = spawn(program, args, { env, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "", stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => code === 0 ? done(stdout) : reject(new Error(`${program} ${args.join(" ")}: ${stderr || stdout}`)));
+  });
+}
+
+async function packageFixture() {
+  const pack = tar.pack();
+  const chunks = [];
+  const complete = new Promise((done, reject) => {
+    pack.on("data", (chunk) => chunks.push(chunk));
+    pack.once("end", done);
+    pack.once("error", reject);
+  });
+  const script = `#!/usr/bin/env node\nconsole.log(${JSON.stringify(version)});\n`;
+  pack.entry({ name: "package/openclaw.mjs", mode: 0o755, mtime: new Date(0) }, script);
+  pack.entry({ name: "package/package.json", mode: 0o644, mtime: new Date(0) }, JSON.stringify({ name: "openclaw", version, bin: { openclaw: "openclaw.mjs" } }));
+  pack.finalize();
+  await complete;
+  return gzipSync(Buffer.concat(chunks));
+}


### PR DESCRIPTION
Fixes the report-identity defect tracked in #95.

#95 identified the need for exact npm candidate evidence, but its post-run global inventory lookup could attach an unrelated same-version runtime's SHA-512 even when provisioning failed. This repair starts from current main and preserves Piotr Durlej (@pdurlej) as co-author.

Kova now captures the runtime name from a successful target start/upgrade JSON receipt and immediately reads that bound runtime's verified metadata. It retains the validated digest before rollback or cleanup, then carries it through command results, scenario records, reports, run/matrix receipts, and bundle manifests. Failed provisioning, dry runs, invalid metadata, and conflicting or missing bindings cannot produce a report-wide identity claim. Moving selectors remain outside this exact-npm identity contract.

Validation covers failed provisioning with unrelated same-version inventory, exact bound SHA-512, malformed/truncated metadata, upgrades, rollback preservation, cleanup ordering, and mixed matrix/repeat identities. The real Kova CLI regressions check both run and matrix receipts and their report/bundle output.

Validation ran on AWS Crabbox `cbx_4f7ea1a038ab` (`harbor-crab-5521`), Linux x86_64, Node 24.18.1, and checksum-verified OCM 0.2.33:

- `npm run check:full`: **280/280 self-checks**, all **21 snapshots**, web-payload contract, and release-contract checks passed in [the full-gate run](https://crabbox.openclaw.ai/portal/runs/run_246a0ef78bc8).
- `node tests/report-identity-ocm.mjs .proof-output/identity`: **four proof cases passed** in [the final fixture run](https://crabbox.openclaw.ai/portal/runs/run_05ee67f995df).
- Codex autoreview: no accepted/actionable findings at its default P0 threshold. The remote source SHA-256 manifest matches the local files being committed.

| Real Kova + OCM fixture | Binding result | Receipt / report / bundle |
|---|---|---|
| Run, empty registry + unrelated inventory | Provisioning fails; `BLOCKED` | No identity field |
| Matrix, same prior-review fixture | Provisioning fails; `BLOCKED` | No identity field |
| Run, fixture npm package + unrelated inventory | Target start succeeds | Exact package SHA-512 in all three |
| Matrix, fixture npm package + unrelated inventory | Target start succeeds | Exact package SHA-512 in all three |

The positive controls intentionally lack a service backend and retain the subsequent scenario `FAIL`; they prove binding provenance, not OpenClaw readiness or performance. The original empty-registry failure is reproduced verbatim. The first proof attempt had a fixture-only record-count assertion because the release profile expands fresh-install into two states; the positive matrix control now uses smoke, and the rerun passed. No product code changed after the full gates. Temporary OCM environments/runtimes were removed, and the AWS lease was stopped.

No merge or release is requested here. The orchestrator owns merging this repair, closing #95 as superseded with thanks, and the v0.1.2 release step.
