### PR TITLE
chore(release): bump version to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shakkernerd/kova",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shakkernerd/kova",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "cli-truncate": "^6.1.1",
         "json5": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shakkernerd/kova",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "OpenClaw runtime validation lab",
   "type": "module",


### PR DESCRIPTION
## What Problem This Solves

Prepare Kova v0.1.2 through the required version-only release PR. The release notes are already on main in #99, with the report identity-binding fix (#98, thanks @pdurlej) as the headline and the dependency refresh (#97) second.

## Why This Change Was Made

Change only package.json and the two root version entries in package-lock.json. After squash merge, the exact main commit must pass CI before scripts/release.sh can create the repository-authorized signed tag. Release Build and Release Publish own archive publication.

## User Impact

No additional runtime changes in this PR. This labels the fixes and dependency updates already on main as 0.1.2.

## Evidence

- Codex autoreview: clean at the default P0 scope.
- AWS Crabbox cbx_e30e0a8f90a6, run run_0ccf92b607f9: 280/280 source self-checks, 21/21 snapshots, web-payload validation, assertion/isolation checks, and release contracts passed.
- Release archive built and installed outside the source checkout; installed CLI reports 0.1.2 and passes 280/280 self-checks.
- Installed CLI plus OCM 0.2.33 passes all four report-identity regression cases: failed run/matrix provisioning emits no identity, and successful bindings preserve the exact digest across receipt, report, and bundle after cleanup. The OpenClaw package/registry are fixtures; these cases prove provenance, not service readiness.
- Corrected candidate source hashes match the version metadata in this PR plus prerequisite #101, which fixes the unsupported runtime-identity RPC option discovered by the live proof.
- Corrected installed-CLI fresh-install against published OpenClaw 2026.7.1-2: PASS with trusted gateway PID/port and Node v24.18.1. Uses the supported KOVA_OPENCLAW_CONFIG_CONTRACT=legacy-list fixture contract for that older runtime and mock auth; no live provider credential.
- All temporary test envs/runtimes were removed and AWS lease cbx_e30e0a8f90a6 was released.
- Prerequisite #101 is merged after macOS/Linux CI and CodeQL passed. Publication remains pending repository signing authorization; no tag or release has been created.
