### PR TITLE
fix(runtime): stop blocking valid gateway identity evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Kova are documented in this file.
 
 ### Fixed
 
+- Avoid false blocked runtime-identity checks by using supported Gateway RPC options while still verifying the reported PID and port against OCM.
 - Keep profiled performance evidence diagnostic, exclude instrumented runs from normal baselines and release approval, and scope deep profiles to product commands. Thanks @vincentkoc. (#82, #89)
 - Allow local runtime packaging and dependency installation up to ten minutes instead of failing at the two-minute scenario timeout. Thanks @vincentkoc. (#88)
 - Recover local-agent startup attribution from timeline spans and isolate process-cold startup from warmup in agent cold/warm scenarios. Thanks @vincentkoc. (#86, #91)

--- a/src/run/finalize-record.mjs
+++ b/src/run/finalize-record.mjs
@@ -126,13 +126,12 @@ export async function collectTargetRuntime(
     return evidence;
   }
 
+  // OCM supplies the env's connection settings; gateway call has no --port option.
   const result = await execute(
     ocmAt(envName, [
       "gateway",
       "call",
       "system.info",
-      "--port",
-      String(evidence.expectedGatewayPort),
       "--json"
     ]),
     { timeoutMs }

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -21631,6 +21631,9 @@ async function targetRuntimeEvidenceCheck() {
     const commands = [];
     const execute = async (command, options) => {
       commands.push({ command, timeoutMs: options.timeoutMs });
+      if (command.includes("'--port'")) {
+        return { status: 1, stderr: 'OpenClaw does not recognize option "--port".' };
+      }
       return {
         status: 0,
         stdout: JSON.stringify({ nodeVersion: "v22.22.3", pid: 4242, port: 19000 })
@@ -21639,8 +21642,8 @@ async function targetRuntimeEvidenceCheck() {
     const trusted = await collectTargetRuntime("Team Env", 4242, 19000, 5000, execute);
     assertEqual(
       commands[0]?.command,
-      "ocm @'Team Env' -- 'gateway' 'call' 'system.info' '--port' '19000' '--json'",
-      "target runtime queries the OCM-recorded local Gateway"
+      "ocm @'Team Env' -- 'gateway' 'call' 'system.info' '--json'",
+      "target runtime uses supported RPC options in the selected OCM env"
     );
     assertEqual(trusted.collectionStatus, "ok", "matching Gateway runtime identity is trusted");
     assertEqual(trusted.nodeVersion, "v22.22.3", "Gateway-reported Node version is retained");
@@ -21648,6 +21651,10 @@ async function targetRuntimeEvidenceCheck() {
     const mismatch = await collectTargetRuntime("Team Env", 4343, 19000, 5000, execute);
     assertEqual(mismatch.collectionStatus, "identity-mismatch", "Gateway identity mismatch is untrusted");
     assertEqual(mismatch.nodeVersion, null, "PID mismatch cannot select a Node baseline");
+
+    const wrongPort = await collectTargetRuntime("Team Env", 4242, 19001, 5000, execute);
+    assertEqual(wrongPort.collectionStatus, "identity-mismatch", "Gateway port mismatch is untrusted");
+    assertEqual(wrongPort.nodeVersion, null, "port mismatch cannot select a Node baseline");
 
     const malformed = await collectTargetRuntime("Team Env", 4242, 19000, 5000, async () => ({
       status: 0,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a healthy OpenClaw gateway makes Kova report BLOCKED because the final runtime-identity RPC passes an unsupported CLI option. This was found while validating the installed 0.1.2 candidate before release.

## Why This Change Was Made

Remove --port from gateway call system.info. OCM already selects the environment and supplies OPENCLAW_GATEWAY_PORT. Keep the returned PID and port checks against OCM's service identity, so a different gateway still cannot select the Node-specific resource baseline.

The regression fixture now rejects the unsupported option, and the existing self-check additionally verifies that a port mismatch remains untrusted. The release note records the fix.

## User Impact

Healthy executed scenarios can retain trusted gateway runtime evidence instead of being blocked by CLI argument parsing. Failed RPCs and mismatched identities remain untrusted.

## Evidence

AWS Crabbox cbx_e30e0a8f90a6, using installed Kova and OCM 0.2.33 with published OpenClaw 2026.7.1-2:

- Before: gateway call system.info --port 18789 --json exits 1: OpenClaw does not recognize option "--port".
- The same RPC without --port succeeds and reports the expected gateway PID, port, and Node v24.18.1.
- Codex autoreview is clean at the default P0 scope; syntax checks and git diff --check pass.
- Corrected 0.1.2 candidate, AWS run run_0ccf92b607f9: 280/280 source and 280/280 installed self-checks; 21/21 snapshots; payload, assertion/isolation, and release-contract gates pass.
- The rebuilt and installed CLI passes fresh-install against published OpenClaw 2026.7.1-2 using the supported KOVA_OPENCLAW_CONFIG_CONTRACT=legacy-list fixture contract. All scenario commands pass, gateway identity matches OCM (PID and port), and the report is PASS.
- All four installed report-identity regression cases pass again. Test environments and runtimes were removed.

Related: #100. Keep this fix separate from the version-only release PR.
