### PR TITLE
fix: timeout ps in readProcessCommand

### DIFF
--- a/src/process-safety.mjs
+++ b/src/process-safety.mjs
@@ -294,7 +294,8 @@ async function readProcessCommand(pid) {
   try {
     const result = await execFileAsync("ps", ["-ww", "-p", String(pid), "-o", "command="], {
       encoding: "utf8",
-      maxBuffer: 1024 * 1024
+      maxBuffer: 1024 * 1024,
+      timeout: 2000
     });
     const command = result.stdout.trim();
     return command || null;

--- a/tests/process-command-timeout.mjs
+++ b/tests/process-command-timeout.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mockProviderOwnerRecord, resolveOwnedMockProviderPid } from "../src/process-safety.mjs";
+
+const hangProbeMs = 8000;
+
+export async function runProcessCommandTimeoutChecks(parentDir) {
+  const binDir = join(parentDir, "bin");
+  await mkdir(binDir, { recursive: true });
+  await writeFile(join(binDir, "ps"), "#!/bin/sh\nexec sleep 60\n", "utf8");
+  await chmod(join(binDir, "ps"), 0o755);
+
+  const pidFile = join(parentDir, "pid");
+  await writeFile(pidFile, `${JSON.stringify(mockProviderOwnerRecord(process.pid, randomUUID()))}\n`, "utf8");
+
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${binDir}${delimiter}${previousPath}`;
+  try {
+    let settled = "pending";
+    let inspectError = null;
+    const inspect = resolveOwnedMockProviderPid({
+      pidFile,
+      supervisorPath: join(parentDir, "supervisor.mjs"),
+      scriptPath: join(parentDir, "script.json"),
+      requestLog: join(parentDir, "requests.jsonl"),
+      serverLog: join(parentDir, "server.log")
+    }).then(
+      (pid) => {
+        settled = "resolved";
+        return pid;
+      },
+      (error) => {
+        settled = "rejected";
+        inspectError = error;
+        throw error;
+      }
+    );
+
+    const outcome = await Promise.race([
+      inspect.then(() => "completed").catch(() => "completed"),
+      new Promise((resolveOutcome) => {
+        setTimeout(() => resolveOutcome("hung"), hangProbeMs);
+      })
+    ]);
+
+    assert.equal(outcome, "completed", "stuck ps must be timed out instead of hanging inspect");
+    assert.equal(settled, "rejected", "timed-out ps must fail inspect instead of returning a command");
+    assert.equal(
+      inspectError?.killed === true || inspectError?.code === "ETIMEDOUT" || inspectError?.code === "ETIME",
+      true,
+      "timed-out ps must surface a child timeout"
+    );
+  } finally {
+    process.env.PATH = previousPath;
+  }
+}
+
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  const root = await mkdtemp(join(tmpdir(), "kova-process-command-timeout-"));
+  try {
+    await runProcessCommandTimeoutChecks(root);
+    console.log("PASS process command timeout");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/tests/selfcheck-isolation.mjs
+++ b/tests/selfcheck-isolation.mjs
@@ -14,11 +14,15 @@ import { collectEnvMetrics } from "../src/metrics.mjs";
 import { runScenarioCommand } from "../src/run/command-executor.mjs";
 import { executeTargetSetup } from "../src/run/target-setup.mjs";
 import { resolveTarget } from "../src/targets.mjs";
+import { runProcessCommandTimeoutChecks } from "./process-command-timeout.mjs";
 import { runProxyLogStreamChecks } from "./proxy-log-stream.mjs";
 
 const root = await mkdtemp(join(tmpdir(), "kova-selfcheck-isolation-test-"));
 
 try {
+  const processCommandRoot = join(root, "process-command-timeout");
+  await mkdir(processCommandRoot);
+  await runProcessCommandTimeoutChecks(processCommandRoot);
   const proxyLogRoot = join(root, "proxy-log-stream");
   await mkdir(proxyLogRoot);
   await runProxyLogStreamChecks(proxyLogRoot);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `kova run` with mock auth can hang forever while resolving the mock-provider PID. Default process inspect runs `ps` with no timeout. If that `ps` sticks, `resolveOwnedMockProviderPid` never returns and the run never finishes.

## Why This Change Was Made

`readProcessCommand` now gives `execFile` a 2000ms timeout, matching the existing `ps` listing budget in `src/collectors/resources.mjs`. A stuck inspect fails closed instead of blocking the mock-auth path. This PR does not change PID identity checks from #45 and #48.

## User Impact

Operators running mock-auth scenarios get a failed inspect after two seconds instead of an unbounded hang. Healthy `ps` inspect is unchanged (milliseconds, then a normal command or `null`).

## Evidence

Before the patch, a PATH-shadowed `ps` that only runs `exec sleep 60` left inspect pending until an 8s hang probe fired:

```console
$ node tests/process-command-timeout.mjs
AssertionError [ERR_ASSERTION]: stuck ps must be timed out instead of hanging inspect
+ actual - expected
+ 'hung'
- 'completed'
EXIT:1
```

After the patch, the same hanging `ps` is killed at the 2000ms budget. Live `node` against the patched module:

```console
$ node /tmp/kova-f002-proof.mjs
elapsed_ms=2002
killed=true
code=null
signal=SIGTERM
message=Command failed: ps -ww -p 40568 -o command=
```

Healthy inspect of the current process with the real `ps` still returns quickly and does not claim mock-provider ownership:

```console
$ node --input-type=module -e '... resolveOwnedMockProviderPid(...)'
elapsed_ms=5
pid=null
```

## Real behavior proof

- **Behavior or issue addressed:** Default mock-provider PID inspect no longer blocks `kova run` when `ps` never exits.
- **Real environment tested:** macOS 15 (Darwin 25.6.0 arm64), Node v26.7.0, checkout `/tmp/oc-pr-Kova-F002` on `fix/f002-ps-timeout` at `579598c` plus this patch.
- **Exact steps or command run after this patch:**

  ```bash
  node /tmp/kova-f002-proof.mjs
  node --input-type=module -e 'resolveOwnedMockProviderPid against the current pid with the real ps'
  ```

- **Evidence after fix:** terminal output from the patched checkout:

  ```console
  $ node /tmp/kova-f002-proof.mjs
  elapsed_ms=2002
  killed=true
  code=null
  signal=SIGTERM
  message=Command failed: ps -ww -p 40568 -o command=
  ```

  ```console
  $ node --input-type=module -e 'healthy resolveOwnedMockProviderPid'
  elapsed_ms=5
  pid=null
  ```

- **Observed result after fix:** The hanging `ps` is SIGTERM'd at about 2000ms and inspect rejects. Real `ps` still completes in a few milliseconds and returns `null` for a non-supervisor process.
- **What was not tested:** A full `kova run` against a live OpenClaw gateway with OCM, and Windows process inspect.

## Summary

`readProcessCommand` is the default `inspectProcess` for `resolveOwnedMockProviderPid`, which `kova run` calls from `resolveTrackedRolePids` when auth is mock. The hang was introduced with provider cleanup in [#45](https://github.com/openclaw/Kova/pull/45) ([`c3e7859c`](https://github.com/openclaw/Kova/commit/c3e7859c)). [#48](https://github.com/openclaw/Kova/pull/48) tightened PID identity only. Sibling `ps` already uses a 2s timeout in [`src/collectors/resources.mjs`](https://github.com/openclaw/Kova/blob/main/src/collectors/resources.mjs). Node `execFile` documents `timeout` as sending `killSignal` (default SIGTERM) when the child exceeds the budget.
