### PR TITLE
fix: bound mock-provider process inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Kova are documented in this file.
 
 ## [0.1.3] - Unreleased
 
+### Fixed
+
+- Bound mock-provider process inspection to two seconds so a stuck `ps` cannot indefinitely block mock-auth runs or cleanup. Thanks @SebTardif. (#103)
+
 ## [0.1.2] - 2026-08-28
 
 ### Highlights

--- a/src/process-safety.mjs
+++ b/src/process-safety.mjs
@@ -294,7 +294,8 @@ async function readProcessCommand(pid) {
   try {
     const result = await execFileAsync("ps", ["-ww", "-p", String(pid), "-o", "command="], {
       encoding: "utf8",
-      maxBuffer: 1024 * 1024
+      maxBuffer: 1024 * 1024,
+      timeout: 2000
     });
     const command = result.stdout.trim();
     return command || null;

--- a/tests/process-command-timeout.mjs
+++ b/tests/process-command-timeout.mjs
@@ -19,6 +19,7 @@ export async function runProcessCommandTimeoutChecks(parentDir) {
 
   const previousPath = process.env.PATH;
   process.env.PATH = `${binDir}${delimiter}${previousPath}`;
+  let hangProbeTimer;
   try {
     let settled = "pending";
     let inspectError = null;
@@ -43,7 +44,7 @@ export async function runProcessCommandTimeoutChecks(parentDir) {
     const outcome = await Promise.race([
       inspect.then(() => "completed").catch(() => "completed"),
       new Promise((resolveOutcome) => {
-        setTimeout(() => resolveOutcome("hung"), hangProbeMs);
+        hangProbeTimer = setTimeout(() => resolveOutcome("hung"), hangProbeMs);
       })
     ]);
 
@@ -55,6 +56,7 @@ export async function runProcessCommandTimeoutChecks(parentDir) {
       "timed-out ps must surface a child timeout"
     );
   } finally {
+    clearTimeout(hangProbeTimer);
     process.env.PATH = previousPath;
   }
 }

--- a/tests/process-command-timeout.mjs
+++ b/tests/process-command-timeout.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mockProviderOwnerRecord, resolveOwnedMockProviderPid } from "../src/process-safety.mjs";
+
+const hangProbeMs = 8000;
+
+export async function runProcessCommandTimeoutChecks(parentDir) {
+  const binDir = join(parentDir, "bin");
+  await mkdir(binDir, { recursive: true });
+  await writeFile(join(binDir, "ps"), "#!/bin/sh\nexec sleep 60\n", "utf8");
+  await chmod(join(binDir, "ps"), 0o755);
+
+  const pidFile = join(parentDir, "pid");
+  await writeFile(pidFile, `${JSON.stringify(mockProviderOwnerRecord(process.pid, randomUUID()))}\n`, "utf8");
+
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${binDir}${delimiter}${previousPath}`;
+  try {
+    let settled = "pending";
+    let inspectError = null;
+    const inspect = resolveOwnedMockProviderPid({
+      pidFile,
+      supervisorPath: join(parentDir, "supervisor.mjs"),
+      scriptPath: join(parentDir, "script.json"),
+      requestLog: join(parentDir, "requests.jsonl"),
+      serverLog: join(parentDir, "server.log")
+    }).then(
+      (pid) => {
+        settled = "resolved";
+        return pid;
+      },
+      (error) => {
+        settled = "rejected";
+        inspectError = error;
+        throw error;
+      }
+    );
+
+    const outcome = await Promise.race([
+      inspect.then(() => "completed").catch(() => "completed"),
+      new Promise((resolveOutcome) => {
+        setTimeout(() => resolveOutcome("hung"), hangProbeMs);
+      })
+    ]);
+
+    assert.equal(outcome, "completed", "stuck ps must be timed out instead of hanging inspect");
+    assert.equal(settled, "rejected", "timed-out ps must fail inspect instead of returning a command");
+    assert.equal(
+      inspectError?.killed === true || inspectError?.code === "ETIMEDOUT" || inspectError?.code === "ETIME",
+      true,
+      "timed-out ps must surface a child timeout"
+    );
+  } finally {
+    process.env.PATH = previousPath;
+  }
+}
+
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  const root = await mkdtemp(join(tmpdir(), "kova-process-command-timeout-"));
+  try {
+    await runProcessCommandTimeoutChecks(root);
+    console.log("PASS process command timeout");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/tests/selfcheck-isolation.mjs
+++ b/tests/selfcheck-isolation.mjs
@@ -14,11 +14,15 @@ import { collectEnvMetrics } from "../src/metrics.mjs";
 import { runScenarioCommand } from "../src/run/command-executor.mjs";
 import { executeTargetSetup } from "../src/run/target-setup.mjs";
 import { resolveTarget } from "../src/targets.mjs";
+import { runProcessCommandTimeoutChecks } from "./process-command-timeout.mjs";
 import { runProxyLogStreamChecks } from "./proxy-log-stream.mjs";
 
 const root = await mkdtemp(join(tmpdir(), "kova-selfcheck-isolation-test-"));
 
 try {
+  const processCommandRoot = join(root, "process-command-timeout");
+  await mkdir(processCommandRoot);
+  await runProcessCommandTimeoutChecks(processCommandRoot);
   const proxyLogRoot = join(root, "proxy-log-stream");
   await mkdir(proxyLogRoot);
   await runProxyLogStreamChecks(proxyLogRoot);


### PR DESCRIPTION
A stuck `ps` can block mock-auth scenarios before their command timeout starts, because mock-provider PID resolution awaits an unbounded process inspection. Give that inspection the same two-second `execFile` timeout used by the resource collector, so failure propagates without changing process ownership checks.

This preserves @SebTardif's original commit from https://github.com/openclaw/Kova/pull/103 and clears the regression test's losing eight-second watchdog in `finally`. Without that cleanup, the test reports success after two seconds but keeps Node alive for eight. The changelog credits @SebTardif. This same-repository candidate supersedes #103 for landing; the fork branch remains unchanged.

## Verification

On macOS arm64 (Darwin 25.6.0), Node v24.20.0:

- Baseline `579598c`: a real subprocess probe with a PATH-shadowed `ps` executing `/bin/sleep 60` remained pending at 4004 ms; the probe killed its own process group afterward.
- `/usr/bin/time -p node tests/process-command-timeout.mjs`: original PR `PASS`, real 8.22 seconds; repaired test `PASS`, real 2.29 seconds.
- `npm run pack:release -- --output-dir /private/tmp/kova-103-package-20260830`, followed by `./install.sh --archive /private/tmp/kova-103-package-20260830/kova.tar.gz --prefix /private/tmp/kova-103-installed-20260830 --bin-dir /private/tmp/kova-103-installed-20260830/bin-links --skip-ocm`: built and installed successfully.
- From outside the checkout, the installed `kova version --json`, `kova setup --ci --json`, and `kova matrix plan --profile smoke --target runtime:stable --json` succeeded. Setup used OCM 0.2.33 verified against CI's pinned archive checksum.
- The installed package's real `resolveOwnedMockProviderPid` rejected the stuck child after 2005 ms with `killed=true`, `signal=SIGTERM`. A healthy real-`ps` inspection returned `pid=null` in 25 ms for an unrelated process.
- Codex autoreview: scoped-clean, no findings at the configured P0 threshold, reviewing the complete candidate against `579598c`.

The full check suite and packaged-install self-checks passed on both Linux and macOS for exact head `93c6ddef516e667e03b2337fed55f68f2c9bacdd`: https://github.com/openclaw/Kova/actions/runs/33362330179. CodeQL and both analysis jobs also passed.

Local aggregate runs did not establish a clean result: the first lacked OCM on PATH; subsequent checks encountered failures in unchanged credential-lock, diagnostic-timing, and process-resource tests. The host had 1,831 processes and a one-minute load average of 38.27, making contention a plausible contributor, not a proven diagnosis. The final OCM-enabled local run completed with 279/280 self-checks passing; only `credential-store-concurrent-writers` failed with a lock timeout. Focused timeout and self-check isolation tests passed. The landing recommendation relies on the independent installed-package fault injection and clean Linux/macOS CI, with these local limitations explicit.

No full OpenClaw gateway scenario or Windows run is claimed; the live fault injection exercises the changed process-inspection implementation in the installed release package.
