### PR TITLE
chore: refresh compatible dependencies and CI tooling

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "11.24.0"
+  PNPM_VERSION: "11.25.0"
 
 jobs:
   hydrate:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -80,7 +80,7 @@ jobs:
             printf 'prerelease=false\n' >> "$GITHUB_OUTPUT"
           fi
       - name: Publish release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ steps.release.outputs.tag }}
           prerelease: ${{ steps.release.outputs.prerelease }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Kova are documented in this file.
 
 ## [0.1.4] - Unreleased
 
+### Internal
+
+- Refresh compatible CLI and website dependencies, including Zod 4.5.4 and Astro 7.3.1, and update the pinned OCM CI runtime, pnpm hydration toolchain, and release action.
+
 ## [0.1.3] - 2026-08-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "tar-stream": "3.2.1",
         "unicode-case-folding": "1.1.1",
         "wrap-ansi": "^10.0.0",
-        "zod": "^4.4.3"
+        "zod": "^4.5.4"
       },
       "bin": {
         "kova": "bin/kova.mjs"
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "tar-stream": "3.2.1",
     "unicode-case-folding": "1.1.1",
     "wrap-ansi": "^10.0.0",
-    "zod": "^4.4.3"
+    "zod": "^4.5.4"
   }
 }

--- a/scripts/install-ocm-ci.sh
+++ b/scripts/install-ocm-ci.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="v0.2.33"
+version="v0.2.38"
 case "$(uname -s):$(uname -m)" in
   Linux:x86_64)
     asset="ocm-x86_64-unknown-linux-gnu.tar.gz"
-    expected_sha256="06b0e46791e750eb044e4a898b6643ad5e7b20224fe0c64f160e35a42f08d00a"
+    expected_sha256="436f1bee1759b39b36a3011bfca273135acde89ac2763052ae14b2e0137ed117"
     ;;
   Darwin:arm64)
     asset="ocm-aarch64-apple-darwin.tar.gz"
-    expected_sha256="f7444dc4265a76ddb2563743bfd4ff2fb1dfa95a5850004f3ed7092ce487c275"
+    expected_sha256="354f932b80a2d04afd9315b67fd1ad48e52b4e9466db05c01d1db4c56c794bdb"
     ;;
   *)
     echo "unsupported OCM CI platform: $(uname -s) $(uname -m)" >&2

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",
-        "astro": "^7.2.9"
+        "astro": "^7.3.1"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
-        "@types/node": "^26.4.0",
+        "@types/node": "^26.4.1",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "npm:@typescript/typescript6@^6.0.2"
       }
@@ -233,9 +233,9 @@
       }
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
-      "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.11.0.tgz",
+      "integrity": "sha512-3rzxJ+xbo0+8YyqOzLziIN32wmsHdCjEVz2sGOpRxJ+Ben/KiLph4ItxBy1abEL+E8fkRzqjg0rfXmaHJGw9JA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.4",
@@ -291,12 +291,12 @@
       }
     },
     "node_modules/@astrojs/markdown-satteri": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.8.tgz",
-      "integrity": "sha512-n8ItpFTCmlDsVR5+rwDmehSf+jFCYLWmZiisZNGuF7xILqYhsVeBfcha4qgS2Seq3fAc9Tm58ZVrvqFQ6RQgRQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.4.0.tgz",
+      "integrity": "sha512-wykOOW9KsUVcZweOpY/CeXpdKcCKZy6fQbdcteWFuI75+sQCiqxYM7VKsGa5b+aGl3cYQscFY37rsbbyal5MRw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/internal-helpers": "0.11.0",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "satteri": "^0.10.3"
@@ -2336,9 +2336,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
-      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2974,14 +2974,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.9.tgz",
-      "integrity": "sha512-o5nZFo/bieF6rp4x9sQSLhI7GO7Bahpld38Y4LvX27nFoxNiuttjI+Hea81w5ksORLHgdPUlQpU9obPz5QRa8g==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.3.1.tgz",
+      "integrity": "sha512-A/bJYHtc6n0UAdROY9W948fW6lX0pnUA+JWKW+IGCXRyDIGN2MsXC0OlS8onZGJjr+sv8htemwOc9W5PBRXCkw==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.4.0",
-        "@astrojs/internal-helpers": "0.10.4",
-        "@astrojs/markdown-satteri": "0.3.8",
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/markdown-satteri": "0.4.0",
         "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -3031,7 +3031,7 @@
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
-        "zod": "^4.3.6"
+        "zod": "^4.5.4"
       },
       "bin": {
         "astro": "bin/astro.mjs"
@@ -3049,7 +3049,7 @@
         "sharp": "^0.35.4"
       },
       "peerDependencies": {
-        "@astrojs/markdown-remark": "7.2.4"
+        "@astrojs/markdown-remark": "^7.3.0"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-remark": {
@@ -3565,9 +3565,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.3.tgz",
-      "integrity": "sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "dev": true,
       "funding": [
         {
@@ -5817,9 +5817,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web/package.json
+++ b/web/package.json
@@ -12,16 +12,16 @@
   },
   "dependencies": {
     "@resvg/resvg-js": "^2.6.2",
-    "astro": "^7.2.9"
+    "astro": "^7.3.1"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
-    "@types/node": "^26.4.0",
+    "@types/node": "^26.4.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2"
   },
   "overrides": {
-    "fast-uri": "4.1.3",
+    "fast-uri": "4.1.4",
     "sharp": "0.35.4",
     "svgo": "4.1.0"
   }


### PR DESCRIPTION
## What Problem This Solves

Kova's CLI, website, and CI tooling were behind compatible upstream maintenance releases. Refresh these dependencies so validation and packaged installations use the current fixes.

## Why This Change Was Made

Update Zod to 4.5.4, Astro to 7.3.1, Node type definitions to 26.4.1, and the fast-uri override to 4.1.4, keeping both npm lockfiles aligned. Refresh the checksum-verified OCM CI runtime to 0.2.38, pnpm hydration tooling to 11.25.0, and the pinned release action to 3.0.3. The npm package manager, Node support floor, and release behavior stay unchanged.

## User Impact

No intentional behavior or interface changes. The CLI and report website receive upstream maintenance fixes; the existing Unreleased changelog records the refresh.

## Evidence

- Full CLI check suite and packaged install smoke under Node 24.
- Website type-check, all six tests, production build (18 pages), and HTTP smoke through the production preview server.
- Both OCM archives independently downloaded and verified against the published SHA256 digests.
- Full candidate review, including both semantic lockfiles: no actionable P0–P2 findings.
- Initial dependency audits reported zero vulnerabilities. Follow-up audit requests hit npm advisory endpoint timeouts; both installed workspaces report no outdated direct dependencies.

### Observed results for `38c4eccb7b5edf2da0e17ce2261e2c32bd8fb3c7`

The completed [exact-head CI run](https://github.com/openclaw/Kova/actions/runs/33858896243) provides the executed command logs, including checksum-enforced OCM installation, the full check suite, and installed archive smoke tests on [Linux](https://github.com/openclaw/Kova/actions/runs/33858896243/job/100978501689) and [macOS](https://github.com/openclaw/Kova/actions/runs/33858896243/job/100978501814). Both jobs passed. [CodeQL analysis](https://github.com/openclaw/Kova/actions/runs/33858892751) also passed.

| Executed validation | Observed result |
| --- | --- |
| Node 24.20.0: `npm run check:full` | Passed; self-check, 21 snapshot cases, web payload validation, and release contract checks |
| Installed archive outside source checkout: `kova version --json`, `setup --ci --json`, `matrix plan --profile smoke --target runtime:stable --json`, `self-check --json` | All exited 0; version 0.1.3; setup `ok: true`; self-check `ok: true`, 280 checks, all PASS |
| Website: `npm run check` | 34 files; 0 errors, 0 warnings, 1 existing deprecation hint |
| Website: `npm test` | 6 passed, 0 failed, 0 skipped |
| Website: `npm run build` | Completed; 18 pages built |
| Production `astro preview` on loopback HTTP | `/` and `/scenarios/plugin-lifecycle/` returned HTTP 200 with expected rendered Kova content; server stopped after checks |
| `pnpm --version` using the pinned package | 11.25.0 |

Both OCM release archives were independently downloaded and hashed before the pin update. The resulting SHA256 values matched the published release metadata and the installer pins:

- Linux x86_64: `436f1bee1759b39b36a3011bfca273135acde89ac2763052ae14b2e0137ed117`
- macOS arm64: `354f932b80a2d04afd9315b67fd1ad48e52b4e9466db05c01d1db4c56c794bdb`

The live CI jobs above subsequently exercised these exact installer pins on both platforms. The hydration pnpm binary was verified locally; the release action was statically checked against its upstream tag. No release or deployment workflow was manually executed.
