### PR TITLE
fix: time out wedged ocm --version during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Kova are documented in this file.
 
 ## [0.1.4] - Unreleased
 
+### Fixed
+
+- Bound setup's OCM version probe to 30 seconds, forcibly stop unresponsive probes, and report timeouts as failed prerequisites. Thanks @SebTardif. (#107)
+
 ### Internal
 
 - Refresh compatible CLI and website dependencies, including Zod 4.5.4 and Astro 7.3.1, and update the pinned OCM CI runtime, pnpm hydration toolchain, and release action.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -62,6 +62,9 @@ runtime rather than an OpenClaw development command.
 
 ## Execution controls
 
+Setup bounds its OCM version probe to 30 seconds. A timed-out probe fails the
+required prerequisite check, reports the timeout, and makes setup exit nonzero.
+
 `run` and `matrix run` are dry-run unless `--execute` is present. Matrix runs
 also accept `--parallel`, `--repeat`, `--include`, `--exclude`, and `--gate`.
 Kova defaults to deterministic mock auth; use `--auth live` only after

--- a/src/commands.mjs
+++ b/src/commands.mjs
@@ -5,6 +5,7 @@ import { startResourceSampler } from "./collectors/resources.mjs";
 import { repoRoot } from "./paths.mjs";
 
 const defaultCommandTimeoutMs = 120000;
+const defaultCheckCommandTimeoutMs = 30000;
 const commandEnvStorage = new AsyncLocalStorage();
 const timeoutTerminationGraceMs = 3000;
 const shutdownTerminationGraceMs = 1000;
@@ -29,15 +30,21 @@ export function runWithCommandEnv(env, callback) {
   );
 }
 
-export function checkCommand(command, args) {
+export function checkCommand(command, args, options = {}) {
+  const timeoutMs = normalizeCheckCommandTimeoutMs(options.timeoutMs);
   const result = spawnSync(command, args, {
     encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs
   });
 
   return {
     command: [command, ...args].join(" "),
     status: result.status,
+    signal: result.signal ?? null,
+    error: result.error,
+    timedOut: result.error?.code === "ETIMEDOUT",
+    timeoutMs,
     stdout: result.stdout ?? "",
     stderr: result.stderr ?? ""
   };
@@ -370,6 +377,14 @@ function normalizeTimeoutMs(value) {
   const timeoutMs = value === undefined ? defaultCommandTimeoutMs : Number(value);
   if (!Number.isInteger(timeoutMs) || timeoutMs < 1) {
     throw new Error(`runCommand timeoutMs must be a positive integer, got ${JSON.stringify(value)}`);
+  }
+  return timeoutMs;
+}
+
+function normalizeCheckCommandTimeoutMs(value) {
+  const timeoutMs = value === undefined ? defaultCheckCommandTimeoutMs : Number(value);
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1) {
+    throw new Error(`checkCommand timeoutMs must be a positive integer, got ${JSON.stringify(value)}`);
   }
   return timeoutMs;
 }

--- a/src/commands.mjs
+++ b/src/commands.mjs
@@ -35,7 +35,9 @@ export function checkCommand(command, args, options = {}) {
   const result = spawnSync(command, args, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: timeoutMs
+    timeout: timeoutMs,
+    // spawnSync keeps waiting if the child ignores the timeout signal.
+    killSignal: "SIGKILL"
   });
 
   return {

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -443,7 +443,7 @@ function commandAvailableCheck(command, args, options = {}) {
   return {
     id: `${command}-available`,
     required: options.required === true,
-    status: result.status === 0 ? "PASS" : "FAIL",
+    status: result.status === 0 && !result.error && !result.timedOut ? "PASS" : "FAIL",
     command: [command, ...args].join(" "),
     message: result.timedOut
       ? `timed out after ${result.timeoutMs}ms`

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -445,7 +445,9 @@ function commandAvailableCheck(command, args, options = {}) {
     required: options.required === true,
     status: result.status === 0 ? "PASS" : "FAIL",
     command: [command, ...args].join(" "),
-    message: result.status === 0 ? result.stdout.trim() : result.stderr.trim() || "not available"
+    message: result.timedOut
+      ? `timed out after ${result.timeoutMs}ms`
+      : result.status === 0 ? result.stdout.trim() : result.stderr.trim() || "not available"
   };
 }
 

--- a/tests/check-command-timeout.mjs
+++ b/tests/check-command-timeout.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { checkCommand } from "../src/commands.mjs";
+
+const hangProbeMs = 8000;
+const checkTimeoutMs = 1000;
+const commandsHref = pathToFileURL(fileURLToPath(new URL("../src/commands.mjs", import.meta.url))).href;
+
+export async function runCheckCommandTimeoutChecks(parentDir) {
+  const hangScript = join(parentDir, "hang.mjs");
+  await writeFile(hangScript, "setTimeout(() => {}, 120000);\n", "utf8");
+
+  const probeScript = join(parentDir, "probe.mjs");
+  await writeFile(
+    probeScript,
+    `import { checkCommand } from ${JSON.stringify(commandsHref)};
+const result = checkCommand(process.execPath, ${JSON.stringify([hangScript])}, { timeoutMs: ${checkTimeoutMs} });
+process.stdout.write(JSON.stringify({
+  status: result.status,
+  timedOut: result.timedOut === true,
+  errorCode: result.error?.code ?? result.signal ?? null
+}));
+`,
+    "utf8"
+  );
+
+  let hangProbeTimer;
+  const child = spawn(process.execPath, [probeScript], {
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const outcome = await Promise.race([
+    new Promise((resolveOutcome, rejectOutcome) => {
+      child.once("error", rejectOutcome);
+      child.once("close", (status) => {
+        resolveOutcome({ kind: "completed", status, stdout, stderr });
+      });
+    }),
+    new Promise((resolveOutcome) => {
+      hangProbeTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+        resolveOutcome({ kind: "hung" });
+      }, hangProbeMs);
+    })
+  ]);
+  clearTimeout(hangProbeTimer);
+
+  assert.equal(outcome.kind, "completed", "stuck ocm --version helper must be timed out instead of hanging checkCommand");
+  assert.equal(outcome.status, 0, `timeout probe must exit cleanly: ${outcome.stderr}`);
+  const result = JSON.parse(outcome.stdout);
+  assert.equal(result.timedOut, true, "timed-out helper must surface timedOut");
+  assert.notEqual(result.status, 0, "timed-out helper must not report success");
+  assert.equal(
+    result.errorCode === "ETIMEDOUT" || result.errorCode === "SIGTERM",
+    true,
+    "timed-out helper must surface a child timeout"
+  );
+
+  const healthy = checkCommand(process.execPath, ["--version"]);
+  assert.equal(healthy.status, 0, "node --version must still succeed");
+  assert.equal(healthy.timedOut, false, "fast --version must not report timedOut");
+  assert.match(healthy.stdout, /^v\d+/);
+}
+
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  const root = await mkdtemp(join(tmpdir(), "kova-check-command-timeout-"));
+  try {
+    await runCheckCommandTimeoutChecks(root);
+    console.log("PASS check command timeout");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/tests/check-command-timeout.mjs
+++ b/tests/check-command-timeout.mjs
@@ -1,77 +1,110 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { delimiter, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { checkCommand } from "../src/commands.mjs";
 
-const hangProbeMs = 8000;
-const checkTimeoutMs = 1000;
-const commandsHref = pathToFileURL(fileURLToPath(new URL("../src/commands.mjs", import.meta.url))).href;
+const commandsHref = new URL("../src/commands.mjs", import.meta.url).href;
+const cliHref = new URL("../bin/kova.mjs", import.meta.url).href;
 
 export async function runCheckCommandTimeoutChecks(parentDir) {
-  const hangScript = join(parentDir, "hang.mjs");
-  await writeFile(hangScript, "setTimeout(() => {}, 120000);\n", "utf8");
-
   const probeScript = join(parentDir, "probe.mjs");
-  await writeFile(
-    probeScript,
-    `import { checkCommand } from ${JSON.stringify(commandsHref)};
-const result = checkCommand(process.execPath, ${JSON.stringify([hangScript])}, { timeoutMs: ${checkTimeoutMs} });
-process.stdout.write(JSON.stringify({
-  status: result.status,
-  timedOut: result.timedOut === true,
-  errorCode: result.error?.code ?? result.signal ?? null
-}));
-`,
-    "utf8"
-  );
+  await writeFile(probeScript, `import { checkCommand } from ${JSON.stringify(commandsHref)};
+const results = [];
+for (const handler of [null, "process.exit(0)", ""]) {
+  const source = (handler === null ? "" : "process.on('SIGTERM', () => {" + handler + "});")
+    + "setInterval(() => {}, 1000);";
+  const result = checkCommand(process.execPath, ["-e", source], { timeoutMs: 1000 });
+  results.push({ status: result.status, timedOut: result.timedOut, errorCode: result.error?.code });
+}
+console.log(JSON.stringify(results));
+`, "utf8");
 
-  let hangProbeTimer;
-  const child = spawn(process.execPath, [probeScript], {
+  const probe = await runProbe([probeScript]);
+  assert.equal(probe.status, 0, probe.stderr);
+  const results = JSON.parse(probe.stdout);
+  assert.equal(results.length, 3);
+  for (const result of results) {
+    assert.equal(result.timedOut, true, "even SIGTERM handlers must not prevent the deadline");
+    assert.notEqual(result.status, 0, "timed-out helpers must not report success");
+    assert.equal(result.errorCode, "ETIMEDOUT");
+  }
+
+  const healthy = checkCommand(process.execPath, ["--version"]);
+  assert.equal(healthy.status, 0, "node --version must still succeed");
+  assert.equal(healthy.timedOut, false);
+  assert.equal(healthy.timeoutMs, 30000);
+  assert.match(healthy.stdout, /^v\d+/);
+  for (const timeoutMs of [0, -1, 1.5, NaN, Infinity]) {
+    assert.throws(() => checkCommand(process.execPath, ["--version"], { timeoutMs }), /positive integer/);
+  }
+
+  if (process.platform !== "win32") {
+    await checkSetupTimeoutVerdict(parentDir);
+  }
+}
+
+async function checkSetupTimeoutVerdict(parentDir) {
+  const binDir = join(parentDir, "bin");
+  await mkdir(binDir);
+  await writeFile(join(binDir, "ocm"), "#!/bin/sh\nprintf '[]\\n'\n", { mode: 0o755 });
+  const setupScript = join(parentDir, "setup-probe.mjs");
+  // A timeout error must win even if the OS reports a successful child exit.
+  await writeFile(setupScript, `import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
+const original = childProcess.spawnSync;
+childProcess.spawnSync = (command, args, options) => command === "ocm" && args[0] === "--version"
+  ? { status: 0, stdout: "ocm fixture", stderr: "", error: Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }) }
+  : original(command, args, options);
+syncBuiltinESMExports();
+await import(${JSON.stringify(cliHref)});
+`, "utf8");
+  const env = {
+    ...process.env,
+    KOVA_HOME: join(parentDir, "kova-home"),
+    PATH: `${binDir}${delimiter}${process.env.PATH}`,
+    SHELL: "/bin/sh"
+  };
+  const json = await runProbe([setupScript, "setup", "--ci", "--json"], env);
+  assert.equal(json.status, 1, "setup must exit nonzero on timeout despite status zero");
+  const report = JSON.parse(json.stdout);
+  assert.equal(report.ok, false);
+  const failed = report.checks.filter((check) => check.required && check.status !== "PASS");
+  assert.deepEqual(failed.map((check) => check.id), ["ocm-available"]);
+  assert.equal(failed[0].message, "timed out after 30000ms");
+  const plain = await runProbe([setupScript, "setup", "--ci", "--plain"], env);
+  assert.equal(plain.status, 1);
+  assert.match(plain.stdout, /FAIL ocm-available: timed out after 30000ms/);
+}
+
+async function runProbe(args, env = process.env) {
+  const child = spawn(process.execPath, args, {
+    env,
+    detached: process.platform !== "win32",
     stdio: ["ignore", "pipe", "pipe"]
   });
   let stdout = "";
   let stderr = "";
-  child.stdout.on("data", (chunk) => {
-    stdout += chunk;
-  });
-  child.stderr.on("data", (chunk) => {
-    stderr += chunk;
-  });
-
-  const outcome = await Promise.race([
-    new Promise((resolveOutcome, rejectOutcome) => {
-      child.once("error", rejectOutcome);
-      child.once("close", (status) => {
-        resolveOutcome({ kind: "completed", status, stdout, stderr });
-      });
-    }),
-    new Promise((resolveOutcome) => {
-      hangProbeTimer = setTimeout(() => {
-        child.kill("SIGKILL");
-        resolveOutcome({ kind: "hung" });
-      }, hangProbeMs);
-    })
-  ]);
-  clearTimeout(hangProbeTimer);
-
-  assert.equal(outcome.kind, "completed", "stuck ocm --version helper must be timed out instead of hanging checkCommand");
-  assert.equal(outcome.status, 0, `timeout probe must exit cleanly: ${outcome.stderr}`);
-  const result = JSON.parse(outcome.stdout);
-  assert.equal(result.timedOut, true, "timed-out helper must surface timedOut");
-  assert.notEqual(result.status, 0, "timed-out helper must not report success");
-  assert.equal(
-    result.errorCode === "ETIMEDOUT" || result.errorCode === "SIGTERM",
-    true,
-    "timed-out helper must surface a child timeout"
-  );
-
-  const healthy = checkCommand(process.execPath, ["--version"]);
-  assert.equal(healthy.status, 0, "node --version must still succeed");
-  assert.equal(healthy.timedOut, false, "fast --version must not report timedOut");
-  assert.match(healthy.stdout, /^v\d+/);
+  let expired = false;
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const timer = setTimeout(() => {
+    expired = true;
+    if (process.platform === "win32") child.kill("SIGKILL");
+    else process.kill(-child.pid, "SIGKILL");
+  }, 60000);
+  try {
+    const status = await new Promise((resolveStatus, reject) => {
+      child.once("error", reject);
+      child.once("close", resolveStatus);
+    });
+    assert.equal(expired, false, "probe must finish without the outer watchdog");
+    return { status, stdout, stderr };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
@@ -79,7 +112,7 @@ if (invokedDirectly) {
   const root = await mkdtemp(join(tmpdir(), "kova-check-command-timeout-"));
   try {
     await runCheckCommandTimeoutChecks(root);
-    console.log("PASS check command timeout");
+    console.log("PASS check command timeout and setup verdict");
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/tests/selfcheck-isolation.mjs
+++ b/tests/selfcheck-isolation.mjs
@@ -14,12 +14,16 @@ import { collectEnvMetrics } from "../src/metrics.mjs";
 import { runScenarioCommand } from "../src/run/command-executor.mjs";
 import { executeTargetSetup } from "../src/run/target-setup.mjs";
 import { resolveTarget } from "../src/targets.mjs";
+import { runCheckCommandTimeoutChecks } from "./check-command-timeout.mjs";
 import { runProcessCommandTimeoutChecks } from "./process-command-timeout.mjs";
 import { runProxyLogStreamChecks } from "./proxy-log-stream.mjs";
 
 const root = await mkdtemp(join(tmpdir(), "kova-selfcheck-isolation-test-"));
 
 try {
+  const checkCommandRoot = join(root, "check-command-timeout");
+  await mkdir(checkCommandRoot);
+  await runCheckCommandTimeoutChecks(checkCommandRoot);
   const processCommandRoot = join(root, "process-command-timeout");
   await mkdir(processCommandRoot);
   await runProcessCommandTimeoutChecks(processCommandRoot);


### PR DESCRIPTION
`kova setup` could wait indefinitely for `ocm --version`. Bound that read-only probe to 30 seconds, force termination when it does not exit, and treat timeout or spawn errors as failed prerequisites regardless of the reported child exit status. Setup now reports `timed out after 30000ms` and exits nonzero.

The original timeout used SIGTERM, which could still hang if ignored or produce a false PASS if the child handled the signal by exiting zero. The final change closes both cases, adds subprocess and setup-output regressions, and documents the deadline. Thanks @SebTardif for identifying and fixing the original unbounded probe.

Validation on macOS 26.6.2, Node 24.20.0:

- `npm run check:full` passed, including all 280 self-checks, snapshots, web payload checks, and release contracts.
- Built and installed the release archive outside the checkout. Its changed source files match the committed files byte for byte.
- Installed `kova setup --ci --json` with an OCM fixture that ignores SIGTERM returned in 31,826 ms: exit 1, `ok: false`, only `ocm-available` failed, with `timed out after 30000ms`.
- Installed setup against real OCM 0.2.38 passed in 5,567 ms. Installed `kova self-check` passed all 280 checks.
- Regression coverage includes a reported zero exit status plus ETIMEDOUT, setup JSON/plain output and exit status, signal handlers that exit zero or ignore termination, healthy probes, and invalid timeout values.
- Independent branch review through P2 passed. CI for head `b0b9ca436e96faa22e5d3ba17c056af463f66d1e`: https://github.com/openclaw/Kova/actions/runs/33984048442.

All setup proof used disposable Kova state and mock auth. Added the 0.1.4 Unreleased changelog entry with contributor credit.
