### PR TITLE
fix(ci): restore Crabbox provisioning and refresh pnpm

### DIFF
--- a/.crabbox.yaml
+++ b/.crabbox.yaml
@@ -24,7 +24,7 @@ actions:
   ephemeral: true
 aws:
   region: eu-west-1
-  rootGB: 160
+  rootGB: 400
 sync:
   delete: true
   checksum: false

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -43,10 +43,6 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -57,6 +53,9 @@ jobs:
           set -euo pipefail
           git fetch --no-tags --depth=50 origin "+refs/heads/main:refs/remotes/origin/main"
           npm ci
+          npm install --global --prefix "$RUNNER_TEMP/kova-pnpm" "pnpm@$PNPM_VERSION"
+          export PATH="$RUNNER_TEMP/kova-pnpm/bin:$PATH"
+          echo "$RUNNER_TEMP/kova-pnpm/bin" >> "$GITHUB_PATH"
           node --version
           npm --version
           pnpm --version

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "11.25.0"
+  PNPM_VERSION: "12.3.4"
 
 jobs:
   hydrate:
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Kova are documented in this file.
 
 - Update Crabbox hydration to pnpm 12.3.4 and pnpm/action-setup 6.1.0.
 - Restore AWS validation provisioning by sizing the root volume for the current 400 GB base image.
+- Refresh the transitive bare-path and bare-url patch releases used by archive dependencies.
 - Refresh compatible CLI and website dependencies, including Zod 4.5.4 and Astro 7.3.1, and update the pinned OCM CI runtime, pnpm hydration toolchain, and release action.
 
 ## [0.1.3] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Kova are documented in this file.
 
 ### Internal
 
+- Update Crabbox hydration to pnpm 12.3.4 and pnpm/action-setup 6.1.0.
+- Restore AWS validation provisioning by sizing the root volume for the current 400 GB base image.
 - Refresh compatible CLI and website dependencies, including Zod 4.5.4 and Astro 7.3.1, and update the pinned OCM CI runtime, pnpm hydration toolchain, and release action.
 
 ## [0.1.3] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Kova are documented in this file.
 
 ### Internal
 
-- Update Crabbox hydration to pnpm 12.3.4 and pnpm/action-setup 6.1.0.
+- Update Crabbox hydration to pnpm 12.3.4 with a portable install step supported by local Actions hydration.
 - Restore AWS validation provisioning by sizing the root volume for the current 400 GB base image.
 - Refresh the transitive bare-path and bare-url patch releases used by archive dependencies.
 - Refresh compatible CLI and website dependencies, including Zod 4.5.4 and Astro 7.3.1, and update the pinned OCM CI runtime, pnpm hydration toolchain, and release action.

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/bare-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
-      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.2.tgz",
+      "integrity": "sha512-ZyKbsuuqK6Ag0K8pX6V5Txq6XeJRvY+wXucnFGRjiyVYP9YWDpIQugk/b+enRYrEYBJaqLzghRQpXPMR7341Nw==",
       "license": "Apache-2.0"
     },
     "node_modules/bare-stream": {
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
-      "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.4.tgz",
+      "integrity": "sha512-Gxa7UVWBr0/edU1b+TJhn/AZvMQUj9OGspvYsaTYQrAbZA4BOTZGL3LiZxvD+CeMlDH4juwD84+eTAp/bLYW5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"


### PR DESCRIPTION
AWS validation leases failed before Kova could run: this repository requested a 160 GB root volume, while the current base image requires at least 400 GB. Set the volume to the image minimum and refresh the hydration toolchain to pnpm 12.3.4. Install pnpm with npm into the runner's temporary directory after Node setup, replacing an action that Crabbox's local Actions hydration cannot execute. Workspace installation continues to use `npm ci`.

Also refresh compatible archive dependency patches: bare-path 3.1.1 → 3.1.2 and bare-url 2.5.2 → 2.5.4. Direct CLI and website dependencies, website overrides, OCM 0.2.38, and the other Actions pins are current. Keep ansi-styles within the ranges required by slice-ansi and wrap-ansi instead of forcing a transitive major override.

The portable install step successfully installed pnpm 12.3.4 in a disposable directory. The corrected AWS configuration created a live instance and reached SSH/source synchronization, resolving the original InvalidBlockDeviceMapping failure. Final full-suite, package-install, exact-head CI, and independent-review results are recorded in the proof comment.

Added Unreleased notes for provisioning, hydration tooling, and archive dependencies. No product API or CLI changes.
