### PR TITLE
fix(performance): measure Linux CPU across process lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Kova are documented in this file.
 
 ## [0.1.5] - Unreleased
 
+### Fixed
+
+- Fix Linux CPU accounting so serial parent/child work is not reported as concurrent CPU, short commands retain final CPU evidence, and incomplete measurements cannot qualify a release.
+
 ## [0.1.4] - 2026-09-05
 
 **Highlights:** Setup now recovers from an unresponsive OCM version probe, and fresh validation machines provision and hydrate reliably.

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -1075,3 +1075,37 @@ Kova stages and preflights the complete artifact set before publication. It
 omits raw Node traces only when a bundle limit would otherwise be exceeded,
 never publishes an arbitrary subset of that class, and fails closed if the
 remaining mandatory artifacts still exceed a limit.
+
+### Linux CPU interval accounting
+
+`primary-role-product-scope-v4` keeps the existing resource thresholds and
+separates Linux interval CPU evidence from older lifetime-average samples.
+Linux resource samples bracket CPU-counter scans and use their common inner
+monotonic interval, retaining PID/start-time identities. Upper bounds conservatively
+include work in the scan margins; lower bounds subtract the maximum possible
+CPU in those margins. A range crossing a CPU threshold blocks qualification as
+inconclusive harness evidence instead of inventing a product failure. New children contribute their
+CPU since birth; reaped children contribute CPU not already observed in an
+earlier sample. Vanished process roles remain attached to their wait accounting,
+including a Gateway reaped by an external supervisor. Parent counters are read
+before child counters; a product process disappearing during that census
+discards the inconsistent scan before accounting. Collection attempts are
+recorded, and three unstable censuses produce a harness failure. Ambiguous reaped CPU is
+an upper bound for each affected role; it never raises the lower bound. Unsettled
+terminal wait accounting blocks qualification. CPU percentages may exceed 100% when product threads or
+processes execute concurrently. The collector does not sum `ps` lifetime CPU
+averages from processes of different ages.
+
+For sampled commands, a Kova wait owner remains alive until the final CPU sample.
+Its own CPU and RSS are harness work and excluded from product measurements;
+its child accounting retains sub-second commands and the last interval before
+exit. Product command stdout, stderr, exit status, signal, and timeout behavior
+remain unchanged. Resource artifacts identify the counter contract as
+`linux-process-interval-v1`. Incomplete counter/baseline evidence is a harness
+failure, never a zero-CPU result. A single-process final `ps` snapshot remains
+available as diagnostic data but does not override Linux interval CPU gates.
+
+Old reports cannot be reprocessed into interval evidence because they lack CPU
+time counters, process start identities, and terminal child accounting. Run
+fresh qualification after adopting this collector; do not reuse or recalibrate
+old zero-CPU short-command reports as an interval baseline.

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -1080,6 +1080,10 @@ remaining mandatory artifacts still exceed a limit.
 
 `primary-role-product-scope-v4` keeps the existing resource thresholds and
 separates Linux interval CPU evidence from older lifetime-average samples.
+Only product processes and the ancestor chains needed for their wait accounting
+participate in the Linux CPU census. Existing wait owners discovered with a new
+product process establish a baseline without importing historical host CPU.
+
 Linux resource samples bracket CPU-counter scans and use their common inner
 monotonic interval, retaining PID/start-time identities. Upper bounds conservatively
 include work in the scan margins; lower bounds subtract the maximum possible
@@ -1099,8 +1103,9 @@ averages from processes of different ages.
 For sampled commands, a Kova wait owner remains alive until the final CPU sample.
 Its own CPU and RSS are harness work and excluded from product measurements;
 its child accounting retains sub-second commands and the last interval before
-exit. Product command stdout, stderr, exit status, signal, and timeout behavior
-remain unchanged. Resource artifacts identify the counter contract as
+exit. The command environment is forwarded privately to its shell; Node preload and
+profiling options do not execute in the accounting helper. Product command
+stdout, stderr, exit status, signal, and timeout behavior remain unchanged. Resource artifacts identify the counter contract as
 `linux-process-interval-v1`. Incomplete counter/baseline evidence is a harness
 failure, never a zero-CPU result. A single-process final `ps` snapshot remains
 available as diagnostic data but does not override Linux interval CPU gates.

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -1103,7 +1103,8 @@ averages from processes of different ages.
 For sampled commands, a Kova wait owner remains alive until the final CPU sample.
 Its own CPU and RSS are harness work and excluded from product measurements;
 its child accounting retains sub-second commands and the last interval before
-exit. The command environment is forwarded privately to its shell; Node preload and
+exit. The watchdog remains active until inherited stdout/stderr writers drain
+and the captured process closes; direct shell exit does not release that ownership. The command environment is forwarded privately to its shell; Node preload and
 profiling options do not execute in the accounting helper. Product command
 stdout, stderr, exit status, signal, and timeout behavior remain unchanged. Resource artifacts identify the counter contract as
 `linux-process-interval-v1`. Incomplete counter/baseline evidence is a harness

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "kova": "node bin/kova.mjs",
     "plan": "node bin/kova.mjs plan",
-    "check": "npm run test:assert-command-output && npm run test:selfcheck-isolation && node bin/kova.mjs self-check",
+    "test:cpu-accounting": "node --test tests/linux-cpu-accounting.mjs tests/resource-command-accounting.mjs",
+    "check": "npm run test:cpu-accounting && npm run test:assert-command-output && npm run test:selfcheck-isolation && node bin/kova.mjs self-check",
     "check:full": "npm run check && npm run test:snapshots && npm run check:web-payload && npm run test:release-contracts",
     "check:web-payload": "node scripts/check-web-payload.mjs",
     "test:assert-command-output": "node tests/assert-command-output.mjs",

--- a/src/collectors/linux-cpu.mjs
+++ b/src/collectors/linux-cpu.mjs
@@ -1,0 +1,157 @@
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+let ticksPerSecond;
+function clockTicksPerSecond() {
+  if (ticksPerSecond === undefined) {
+    const result = spawnSync("getconf", ["CLK_TCK"], { encoding: "utf8", timeout: 2000 });
+    ticksPerSecond = result.status === 0 ? Number(result.stdout.trim()) : NaN;
+  }
+  if (!Number.isSafeInteger(ticksPerSecond) || ticksPerSecond <= 0) {
+    throw new Error("Linux CPU accounting requires CLK_TCK");
+  }
+  return ticksPerSecond;
+}
+
+export function readLinuxCpuCounters(pid) {
+  const text = readFileSync(`/proc/${pid}/stat`, "utf8");
+  // comm can contain spaces and parentheses; fields after its last ')' are fixed.
+  const fields = text.slice(text.lastIndexOf(")") + 2).trim().split(/\s+/);
+  const values = [fields[11], fields[12], fields[13], fields[14], fields[19]].map(Number);
+  if (values.some((value) => !Number.isSafeInteger(value) || value < 0)) {
+    throw new Error(`Invalid Linux CPU counters for process ${pid}`);
+  }
+  return { cpuTicks: values[0] + values[1], childCpuTicks: values[2] + values[3], startTicks: values[4], ppid: Number(fields[1]) };
+}
+
+export class LinuxCpuSnapshotChangedError extends Error {}
+
+export function readLinuxCpuSnapshot(processes, previouslyTrackedPids = new Set()) {
+  const byPid = new Map(processes.map((entry) => [entry.pid, entry]));
+  const visited = new Set();
+  const visiting = new Set();
+  const counters = [];
+  const visit = (entry) => {
+    if (visited.has(entry.pid)) return;
+    if (visiting.has(entry.pid)) throw new LinuxCpuSnapshotChangedError("Process ancestry changed during CPU collection");
+    visiting.add(entry.pid);
+    const parent = byPid.get(entry.ppid);
+    if (parent) visit(parent);
+    visiting.delete(entry.pid);
+    visited.add(entry.pid);
+    try {
+      const values = readLinuxCpuCounters(entry.pid);
+      if (values.ppid !== entry.ppid) throw new LinuxCpuSnapshotChangedError("Process parent changed during CPU collection");
+      counters.push({ ...entry, ...values });
+    } catch (error) {
+      if (error.code !== "ENOENT" && error.code !== "ESRCH") throw error;
+      // Parent counters precede every live child counter. A child disappearing
+      // after the process census invalidates this scan: its parent's earlier
+      // wait counter cannot establish that child's terminal CPU transfer.
+      if (entry.roles?.length || previouslyTrackedPids.has(entry.pid)) throw new LinuxCpuSnapshotChangedError("Product process exited during CPU collection");
+    }
+  };
+  for (const entry of processes) visit(entry);
+  return counters;
+}
+
+export function readLinuxCpuClock() {
+  const hz = clockTicksPerSecond();
+  const uptime = Number(readFileSync("/proc/uptime", "utf8").split(" ")[0]);
+  if (!Number.isFinite(uptime) || uptime < 0) throw new Error("Invalid Linux CPU clock");
+  return { hz, ticks: uptime * hz, monotonicMs: performance.now() };
+}
+
+const identity = (process) => `${process.pid}:${process.startTicks}`;
+
+export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
+  let previous = new Map();
+  let previousClock;
+  let reapDebt = new Map();
+  let missingWaitOwner = false;
+  return {
+    lastSuccessfulClock() {
+      return previousClock;
+    },
+    trackedProcessIds() {
+      return new Set([...previous.values()].filter((entry) => entry.roles?.length).map((entry) => entry.pid));
+    },
+    coverageComplete() {
+      return !missingWaitOwner && ![...reapDebt.values()].some((debt) => debt.ticks > 0 && debt.processes.some((entry) => entry.roles?.length));
+    },
+    sample(processes, clock) {
+      const nextDebt = new Map([...reapDebt].map(([key, debt]) => [key, { ...debt, processes: [...debt.processes] }]));
+      let nextMissingWaitOwner = missingWaitOwner;
+      processes = processes.map((entry) => {
+        const roles = [...new Set([...(previous.get(identity(entry))?.roles ?? []), ...(entry.roles ?? [])])];
+        return { ...entry, roles, role: roles.join(",") };
+      });
+      const current = new Map(processes.map((process) => [identity(process), process]));
+      const previousByPid = new Map([...previous.values()].map((process) => [process.pid, process]));
+      const intervalTicks = previousClock === undefined ? null :
+        (clock.monotonicMs - (previousClock.finishedMs ?? previousClock.monotonicMs)) * clock.hz / 1000;
+      if (intervalTicks !== null && (!(intervalTicks > 0) || clock.hz !== previousClock.hz)) {
+        throw new Error("Linux CPU sample clock did not advance");
+      }
+      // Once a child is reaped, Linux transfers its complete CPU lifetime to its
+      // wait owner. Subtract the part already observed, including nested waits.
+      for (const [key, process] of previous) {
+        if (current.has(key)) continue;
+        const heldDebt = nextDebt.get(key);
+        if (heldDebt?.ticks > 0 && heldDebt.processes.some((entry) => entry.roles?.length)) nextMissingWaitOwner = true;
+        let ancestor = previousByPid.get(process.ppid);
+        const seen = new Set([key]);
+        let foundWaitOwner = false;
+        while (ancestor && !seen.has(identity(ancestor))) {
+          const ancestorKey = identity(ancestor);
+          seen.add(ancestorKey);
+          if (current.has(ancestorKey)) {
+            const debt = nextDebt.get(ancestorKey) ?? { ticks: 0, processes: [] };
+            debt.ticks += process.cpuTicks + process.childCpuTicks;
+            debt.processes.push(process);
+            nextDebt.set(ancestorKey, debt);
+            foundWaitOwner = true;
+            break;
+          }
+          ancestor = previousByPid.get(ancestor.ppid);
+        }
+        if (!foundWaitOwner && process.roles?.length) nextMissingWaitOwner = true;
+      }
+      const measured = [];
+      for (const process of processes) {
+        const key = identity(process);
+        const before = previous.get(key);
+        let ownCpuPercent = null;
+        let reapedCpuPercent = null;
+        let reapedRoles = [];
+        let reapedProcesses = [];
+        if (intervalTicks !== null) {
+          if (!before && process.startTicks < Math.floor(previousClock.ticks) - 1) {
+            throw new Error(`Missing CPU baseline for process ${process.pid}`);
+          }
+          const ownTicks = process.cpuTicks - (before?.cpuTicks ?? 0);
+          const waitedTicks = process.childCpuTicks - (before?.childCpuTicks ?? 0);
+          if (ownTicks < 0 || waitedTicks < 0) throw new Error(`Regressed CPU counters for process ${process.pid}`);
+          const debt = nextDebt.get(key) ?? { ticks: 0, processes: [] };
+          const newlyReapedTicks = Math.max(0, waitedTicks - debt.ticks);
+          reapedRoles = [...new Set([...(process.roles ?? []), ...debt.processes.flatMap((entry) => entry.roles ?? [])])];
+          reapedProcesses = debt.processes.filter((entry) => entry.roles?.length).map(({ pid, startTicks, roles, command }) => ({ pid, startTicks, roles, command }));
+          if (debt.ticks > waitedTicks) nextDebt.set(key, { ...debt, ticks: debt.ticks - waitedTicks });
+          else nextDebt.delete(key);
+          // The accounting wrapper is harness work. Its waited-child counters
+          // still contain product work, including children missed by polling.
+          ownCpuPercent = (process.pid === accountingRootPid ? 0 : ownTicks) / intervalTicks * 100;
+          reapedCpuPercent = newlyReapedTicks / intervalTicks * 100;
+        }
+        measured.push({ ...process, ownCpuPercent, reapedCpuPercent, reapedRoles, reapedProcesses,
+          cpuPercent: ownCpuPercent === null ? null : ownCpuPercent + reapedCpuPercent });
+      }
+      for (const key of nextDebt.keys()) if (!current.has(key)) nextDebt.delete(key);
+      reapDebt = nextDebt;
+      missingWaitOwner = nextMissingWaitOwner;
+      previous = current;
+      previousClock = clock;
+      return measured;
+    }
+  };
+}

--- a/src/collectors/linux-cpu.mjs
+++ b/src/collectors/linux-cpu.mjs
@@ -51,7 +51,11 @@ export function readLinuxCpuSnapshot(processes, previouslyTrackedPids = new Set(
       if (entry.roles?.length || previouslyTrackedPids.has(entry.pid)) throw new LinuxCpuSnapshotChangedError("Product process exited during CPU collection");
     }
   };
-  for (const entry of processes) visit(entry);
+  // The census needs product processes and their wait-owner ancestry, not
+  // unrelated host workloads that happen to share an ancestor such as init.
+  for (const entry of processes) {
+    if (entry.roles?.length || previouslyTrackedPids.has(entry.pid)) visit(entry);
+  }
   return counters;
 }
 
@@ -74,7 +78,7 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
       return previousClock;
     },
     trackedProcessIds() {
-      return new Set([...previous.values()].filter((entry) => entry.roles?.length).map((entry) => entry.pid));
+      return new Set([...previous.values()].map((entry) => entry.pid));
     },
     coverageComplete() {
       return !missingWaitOwner && ![...reapDebt.values()].some((debt) => debt.ticks > 0 && debt.processes.some((entry) => entry.roles?.length));
@@ -126,11 +130,16 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
         let reapedRoles = [];
         let reapedProcesses = [];
         if (intervalTicks !== null) {
-          if (!before && process.startTicks < Math.floor(previousClock.ticks) - 1) {
+          const newlyObservedExistingOwner = !before && process.startTicks < Math.floor(previousClock.ticks) - 1;
+          if (newlyObservedExistingOwner && process.roles.length) {
             throw new Error(`Missing CPU baseline for process ${process.pid}`);
           }
-          const ownTicks = process.cpuTicks - (before?.cpuTicks ?? 0);
-          const waitedTicks = process.childCpuTicks - (before?.childCpuTicks ?? 0);
+          // A new product process can introduce an existing external wait owner.
+          // Its historical host work is not product CPU; establish its baseline
+          // before the child can be reaped in a later parent-first census.
+          const baseline = before ?? (newlyObservedExistingOwner ? process : null);
+          const ownTicks = process.cpuTicks - (baseline?.cpuTicks ?? 0);
+          const waitedTicks = process.childCpuTicks - (baseline?.childCpuTicks ?? 0);
           if (ownTicks < 0 || waitedTicks < 0) throw new Error(`Regressed CPU counters for process ${process.pid}`);
           const debt = nextDebt.get(key) ?? { ticks: 0, processes: [] };
           const newlyReapedTicks = Math.max(0, waitedTicks - debt.ticks);

--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -1,8 +1,10 @@
 import { spawnSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
+import { cpus } from "node:os";
 import { dirname } from "node:path";
 import { repoRoot } from "../paths.mjs";
 import { ocmServiceStatusJson } from "../ocm/commands.mjs";
+import { createLinuxCpuAccountant, LinuxCpuSnapshotChangedError, readLinuxCpuClock, readLinuxCpuSnapshot } from "./linux-cpu.mjs";
 
 export const RESOURCE_SAMPLES_SCHEMA = "kova.resourceSamples.v1";
 export const PROCESS_SNAPSHOT_SCHEMA = "kova.processSnapshot.v1";
@@ -21,6 +23,10 @@ export function startResourceSampler(rootPid, options = {}) {
       .filter(([role, pid]) => typeof role === "string" && role.length > 0 && Number.isSafeInteger(pid) && pid > 0)
   );
   const samples = [];
+  const cpuAccountant = process.platform === "linux" && !options.processLister
+    ? createLinuxCpuAccountant({ accountingRootPid: options.accountingRootPid }) : null;
+  const cpuCount = cpuAccountant ? cpus().length : 0;
+  let stopped;
   let gatewayPid = null;
   let nextGatewayLookupSample = 0;
 
@@ -29,24 +35,41 @@ export function startResourceSampler(rootPid, options = {}) {
   timer.unref?.();
 
   return {
-    async stop() {
-      clearInterval(timer);
-      sample();
-      const summary = summarizeResourceSamples(samples);
-      if (options.artifactPath) {
-        await mkdir(dirname(options.artifactPath), { recursive: true });
-        await writeFile(
-          options.artifactPath,
-          samples.map((item) => JSON.stringify(item)).join("\n") + (samples.length > 0 ? "\n" : ""),
-          "utf8"
-        );
-        summary.artifactPath = options.artifactPath;
-      }
-      return summary;
+    stop() {
+      stopped ??= finish();
+      return stopped;
     }
   };
 
-  function sample() {
+  async function finish() {
+    clearInterval(timer);
+    sample();
+    const summary = summarizeResourceSamples(samples);
+    if (cpuAccountant && !cpuAccountant.coverageComplete()) {
+      summary.cpuCoverageComplete = false;
+      summary.errors.push("Terminal product CPU wait accounting is incomplete");
+    }
+    if (options.artifactPath) {
+      await mkdir(dirname(options.artifactPath), { recursive: true });
+      await writeFile(
+        options.artifactPath,
+        samples.map((item) => JSON.stringify(item)).join("\n") + (samples.length > 0 ? "\n" : ""),
+        "utf8"
+      );
+      summary.artifactPath = options.artifactPath;
+    }
+    return summary;
+  }
+
+  function sample(attempt = 1) {
+    let cpuClock;
+    try {
+      cpuClock = cpuAccountant ? readLinuxCpuClock() : null;
+    } catch (error) {
+      samples.push({ timestamp: new Date().toISOString(), elapsedMs: Date.now() - startedAt,
+        rootPid, gatewayPid, collectionStatus: "error", collectionError: error.message, processes: [] });
+      return;
+    }
     const processResult = (options.processLister ?? listProcesses)(options.redactValues ?? []);
     if (!processResult.ok) {
       samples.push({
@@ -105,14 +128,41 @@ export function startResourceSampler(rootPid, options = {}) {
       if (roles.size === 1 && roles.has("gateway-tree")) {
         roles.add("uncategorized");
       }
-      if (roles.size === 0 || seen.has(process.pid)) {
+      if (seen.has(process.pid)) {
         continue;
       }
       seen.add(process.pid);
       const sortedRoles = [...roles].sort();
-      tracked.push({ ...process, roles: sortedRoles, role: sortedRoles.join(",") });
+      tracked.push({ ...process,
+        ...(process.pid === options.accountingRootPid ? { rssKb: 0, rssMb: 0, command: "[Kova command CPU accounting]" } : {}),
+        roles: sortedRoles, role: sortedRoles.join(",") });
     }
 
+    let measured = tracked;
+    let cpuUncertaintyPercent = null;
+    if (cpuAccountant) {
+      try {
+        const counters = readLinuxCpuSnapshot(tracked, cpuAccountant.trackedProcessIds());
+        cpuClock.finishedMs = performance.now();
+        const previousEnd = cpuAccountant.lastSuccessfulClock()?.finishedMs;
+        const previousStart = cpuAccountant.lastSuccessfulClock()?.monotonicMs;
+        const innerMs = previousEnd === undefined ? null : cpuClock.monotonicMs - previousEnd;
+        const scanMs = cpuClock.finishedMs - cpuClock.monotonicMs + (previousEnd === undefined ? 0 : previousEnd - previousStart);
+        cpuUncertaintyPercent = innerMs > 0 ? cpuCount * scanMs / innerMs * 100 : null;
+        measured = cpuAccountant.sample(counters, cpuClock).map((entry) => ({ ...entry,
+          ...(entry.roles.length ? {} : { rssMb: 0, rssKb: 0, command: "[CPU wait owner for retired product processes]" }),
+          // A supervisor outside the product tree can own a retired Gateway's
+          // wait counters. Preserve those roles without charging its own work.
+          cpuPercent: entry.ownCpuPercent === null ? null :
+            (entry.roles.length ? entry.ownCpuPercent : 0) + (entry.reapedRoles.length ? entry.reapedCpuPercent : 0)
+        }));
+      } catch (error) {
+        if (error instanceof LinuxCpuSnapshotChangedError && attempt < 3) return sample(attempt + 1);
+        samples.push({ timestamp: new Date().toISOString(), elapsedMs: Date.now() - startedAt,
+          rootPid, gatewayPid, collectionStatus: "error", collectionError: error.message, processes: [] });
+        return;
+      }
+    }
     samples.push({
       timestamp: new Date().toISOString(),
       elapsedMs: Date.now() - startedAt,
@@ -120,7 +170,10 @@ export function startResourceSampler(rootPid, options = {}) {
       gatewayPid,
       collectionStatus: "ok",
       collectionError: null,
-      processes: tracked
+      cpuMeasurementContract: cpuAccountant ? "linux-process-interval-v1" : "ps-process-cpu-v1",
+      cpuClock, cpuUncertaintyPercent,
+      ...(cpuAccountant ? { collectionAttempts: attempt } : {}),
+      processes: measured.filter((entry) => entry.roles.length || entry.reapedRoles?.length)
     });
   }
 }
@@ -132,6 +185,7 @@ export function summarizeResourceSamples(samples) {
   const failedSamples = samples.filter((sample) => sample?.collectionStatus === "error");
   let peakTotalRssMb = null;
   let maxTotalCpuPercent = null;
+  let maxTotalCpuPercentLower = null;
   let peakCommandTreeRssMb = null;
   let peakGatewayRssMb = null;
   let peakRssSample = null;
@@ -141,13 +195,19 @@ export function summarizeResourceSamples(samples) {
 
   for (const sample of usableSamples) {
     const totalRssMb = roundNumber(sample.processes.reduce((total, process) => total + process.rssMb, 0));
-    const totalCpuPercent = roundNumber(sample.processes.reduce((total, process) => total + process.cpuPercent, 0));
+    const cpuProcesses = sample.processes.filter((process) => typeof process.cpuPercent === "number");
+    const totalCpu = cpuProcesses.reduce((total, process) => total + process.cpuPercent, 0);
+    const totalCpuPercent = cpuProcesses.length > 0 ? (sample.cpuMeasurementContract === "linux-process-interval-v1" ? Math.ceil(totalCpu * 10) / 10 : roundNumber(totalCpu)) : null;
     const commandTreeRssMb = roleRss(sample.processes, "command-tree");
     const gatewayRssMb = roleRss(sample.processes, "gateway");
     updateRolePeaks(byRole, sample);
 
     peakTotalRssMb = maxNullable(peakTotalRssMb, totalRssMb);
     maxTotalCpuPercent = maxNullable(maxTotalCpuPercent, totalCpuPercent);
+    if (sample.cpuUncertaintyPercent !== null && sample.cpuUncertaintyPercent !== undefined) {
+      const certain = sample.processes.reduce((sum, entry) => sum + (entry.roles.length ? entry.ownCpuPercent ?? 0 : 0), 0);
+      maxTotalCpuPercentLower = maxNullable(maxTotalCpuPercentLower, Math.floor(Math.max(0, certain - sample.cpuUncertaintyPercent) * 10) / 10);
+    }
     peakCommandTreeRssMb = maxNullable(peakCommandTreeRssMb, commandTreeRssMb);
     peakGatewayRssMb = maxNullable(peakGatewayRssMb, gatewayRssMb);
     if (!peakRssSample || totalRssMb > peakRssSample.totalRssMb) {
@@ -158,7 +218,7 @@ export function summarizeResourceSamples(samples) {
         topProcess: sample.processes.toSorted((left, right) => right.rssMb - left.rssMb)[0] ?? null
       };
     }
-    if (!peakCpuSample || totalCpuPercent > peakCpuSample.totalCpuPercent) {
+    if (totalCpuPercent !== null && (!peakCpuSample || totalCpuPercent > peakCpuSample.totalCpuPercent)) {
       peakCpuSample = {
         timestamp: sample.timestamp,
         elapsedMs: sample.elapsedMs,
@@ -168,8 +228,10 @@ export function summarizeResourceSamples(samples) {
     }
 
     for (const process of sample.processes) {
-      const existing = byPid.get(process.pid) ?? {
+      const processIdentity = `${process.pid}:${process.startTicks ?? "legacy"}`;
+      const existing = byPid.get(processIdentity) ?? {
         pid: process.pid,
+        ...(process.startTicks === undefined ? {} : { startTicks: process.startTicks }),
         command: process.command,
         roles: process.roles ?? process.role.split(",").filter(Boolean),
         role: process.role,
@@ -184,7 +246,7 @@ export function summarizeResourceSamples(samples) {
       existing.peakRssMb = Math.max(existing.peakRssMb, process.rssMb);
       existing.maxCpuPercent = Math.max(existing.maxCpuPercent, process.cpuPercent);
       existing.lastSeenMs = sample.elapsedMs;
-      byPid.set(process.pid, existing);
+      byPid.set(processIdentity, existing);
     }
   }
 
@@ -209,6 +271,9 @@ export function summarizeResourceSamples(samples) {
     intervalMs: sampleInterval(usableSamples),
     peakTotalRssMb,
     maxTotalCpuPercent,
+    maxTotalCpuPercentLower,
+    cpuMeasurementContract: usableSamples.find((sample) => sample.cpuMeasurementContract)?.cpuMeasurementContract ?? null,
+    cpuCoverageComplete: usableSamples.some((sample) => sample.processes.some((process) => typeof process.cpuPercent === "number")) && failedSamples.length === 0,
     peakCommandTreeRssMb,
     peakGatewayRssMb,
     byRole: roleSummaries,
@@ -484,7 +549,7 @@ function listProcesses(redactValues = []) {
   const processes = [];
   for (const line of result.stdout.split("\n")) {
     const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\d+)\s+([0-9.]+)\s+(.+)$/);
-    if (!match) {
+    if (!match || Number(match[1]) === result.pid) {
       continue;
     }
     processes.push({
@@ -584,22 +649,31 @@ function lookupGatewayPid(envName, commandEnv) {
 function updateRolePeaks(byRole, sample) {
   const totals = new Map();
   for (const process of sample.processes) {
-    for (const role of process.roles ?? process.role.split(",").filter(Boolean)) {
+    for (const role of new Set([...(process.roles ?? process.role.split(",").filter(Boolean)), ...(process.reapedRoles ?? [])])) {
       const total = totals.get(role) ?? {
         rssMb: 0,
-        cpuPercent: 0,
+        cpuPercent: null,
+        cpuCertainPercent: null,
         processCount: 0,
         topRssProcess: null,
         topCpuProcess: null
       };
-      total.rssMb += process.rssMb;
-      total.cpuPercent += process.cpuPercent;
+      const ownsRole = process.roles?.includes(role) ?? process.role.split(",").includes(role);
+      if (ownsRole) total.rssMb += process.rssMb;
+      if (typeof process.ownCpuPercent === "number") {
+        total.cpuPercent = (total.cpuPercent ?? 0) + (ownsRole ? process.ownCpuPercent : 0) +
+          (process.reapedRoles.includes(role) ? process.reapedCpuPercent : 0);
+        total.cpuCertainPercent = (total.cpuCertainPercent ?? 0) + (ownsRole ? process.ownCpuPercent : 0);
+      } else if (typeof process.cpuPercent === "number") total.cpuPercent = (total.cpuPercent ?? 0) + process.cpuPercent;
       total.processCount += 1;
       if (!total.topRssProcess || process.rssMb > total.topRssProcess.rssMb) {
         total.topRssProcess = process;
       }
-      if (!total.topCpuProcess || process.cpuPercent > total.topCpuProcess.cpuPercent) {
-        total.topCpuProcess = process;
+      const retired = !ownsRole ? process.reapedProcesses?.find((entry) => entry.roles?.includes(role)) : null;
+      const attributed = retired ? { ...process, ...retired, rssMb: 0, role: retired.roles.join(","),
+        cpuPercent: process.reapedCpuPercent, cpuAttribution: "reaped-role-upper-bound", cpuWaitOwnerPid: process.pid } : process;
+      if (!total.topCpuProcess || attributed.cpuPercent > total.topCpuProcess.cpuPercent) {
+        total.topCpuProcess = attributed;
       }
       totals.set(role, total);
     }
@@ -617,14 +691,19 @@ function updateRolePeaks(byRole, sample) {
       peakCpuProcess: null
     };
     const rssMb = roundNumber(total.rssMb);
-    const cpuPercent = roundNumber(total.cpuPercent);
+    const cpuPercent = total.cpuPercent === null ? null :
+      sample.cpuMeasurementContract === "linux-process-interval-v1" ? Math.ceil(total.cpuPercent * 10) / 10 : roundNumber(total.cpuPercent);
     if (existing.peakRssMb === null || rssMb > existing.peakRssMb) {
       existing.peakRssMb = rssMb;
       existing.peakRssAtMs = sample.elapsedMs;
       existing.peakProcessCount = total.processCount;
       existing.peakRssProcess = compactProcess(total.topRssProcess);
     }
-    if (existing.maxCpuPercent === null || cpuPercent > existing.maxCpuPercent) {
+    if (total.cpuCertainPercent !== null) {
+      const lower = Math.floor(Math.max(0, total.cpuCertainPercent - (sample.cpuUncertaintyPercent ?? 0)) * 10) / 10;
+      existing.maxCpuPercentLower = Math.max(existing.maxCpuPercentLower ?? 0, lower);
+    }
+    if (cpuPercent !== null && (existing.maxCpuPercent === null || cpuPercent > existing.maxCpuPercent)) {
       existing.maxCpuPercent = cpuPercent;
       existing.peakCpuAtMs = sample.elapsedMs;
       existing.peakCpuProcess = compactProcess(total.topCpuProcess);
@@ -637,6 +716,7 @@ function finalizeRoleSummary(summary) {
   return {
     peakRssMb: summary.peakRssMb,
     maxCpuPercent: summary.maxCpuPercent,
+    ...(summary.maxCpuPercentLower === undefined ? {} : { maxCpuPercentLower: summary.maxCpuPercentLower }),
     peakRssAtMs: summary.peakRssAtMs,
     peakCpuAtMs: summary.peakCpuAtMs,
     peakProcessCount: summary.peakProcessCount,
@@ -655,7 +735,8 @@ function compactProcess(process) {
     role: process.role,
     rssMb: process.rssMb,
     cpuPercent: process.cpuPercent,
-    command: process.command
+    command: process.command,
+    ...(process.cpuAttribution ? { cpuAttribution: process.cpuAttribution, cpuWaitOwnerPid: process.cpuWaitOwnerPid } : {})
   };
 }
 

--- a/src/commands.mjs
+++ b/src/commands.mjs
@@ -70,11 +70,14 @@ export function runCommand(command, options = {}) {
       childEnv.SHELL = options.shell;
     }
     const accountCpu = process.platform === "linux" && Boolean(options.resourceSample);
+    const accountingEnv = accountCpu ? Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !name.startsWith("NODE_") && name !== "UV_THREADPOOL_SIZE")
+    ) : null;
     const child = spawn(accountCpu ? process.execPath : shell, accountCpu
       ? [fileURLToPath(new URL("../support/resource-command.mjs", import.meta.url)), shell, command]
       : ["-c", command], {
       cwd: repoRoot,
-      env: childEnv,
+      env: accountingEnv ?? childEnv,
       stdio: accountCpu ? ["ignore", "pipe", "pipe", "ipc"] : ["ignore", "pipe", "pipe"],
       detached: process.platform !== "win32"
     });
@@ -94,7 +97,7 @@ export function runCommand(command, options = {}) {
     child.on("message", async (message) => {
       if (message?.type === "ready" && !sampler) {
         sampler = createSampler();
-        child.send({ type: "start" }, () => {});
+        child.send({ type: "start", env: childEnv }, () => {});
       } else if (message?.type === "complete" && !accountedCompletion) {
         clearTimeout(timer);
         accountedCompletion = { ...message, finishedAtEpochMs: Date.now() };

--- a/src/commands.mjs
+++ b/src/commands.mjs
@@ -94,19 +94,18 @@ export function runCommand(command, options = {}) {
     let sampler = accountCpu ? null : createSampler();
     let accountedCompletion;
     let sampledResources;
-    child.on("message", async (message) => {
+    child.on("message", (message) => {
       if (message?.type === "ready" && !sampler) {
         sampler = createSampler();
         child.send({ type: "start", env: childEnv }, () => {});
       } else if (message?.type === "complete" && !accountedCompletion) {
-        clearTimeout(timer);
         accountedCompletion = { ...message, finishedAtEpochMs: Date.now() };
-        try {
-          sampledResources = await sampler?.stop();
-        } catch (error) {
-          sampledResources = { available: false, sampleCount: 0, failedSampleCount: 1,
-            cpuCoverageComplete: false, errors: [error.message] };
-        }
+        // stop() captures the terminal counters synchronously. Persisting the
+        // artifact must not keep the command's wait owner alive after capture.
+        sampledResources = sampler?.stop().catch((error) => ({
+          available: false, sampleCount: 0, failedSampleCount: 1,
+          cpuCoverageComplete: false, errors: [error.message]
+        }));
         if (child.connected) child.send({ type: "sampled" }, () => {});
       }
     });
@@ -175,7 +174,7 @@ export function runCommand(command, options = {}) {
       if (!keepTracking) {
         stopTrackingChild();
       }
-      const finishedAtEpochMs = accountedCompletion?.finishedAtEpochMs ?? Date.now();
+      const finishedAtEpochMs = timedOut ? Date.now() : accountedCompletion?.finishedAtEpochMs ?? Date.now();
       const stdoutResult = stdout.finish();
       const stderrResult = stderr.finish();
       settle({
@@ -201,7 +200,7 @@ export function runCommand(command, options = {}) {
       }
       settled = true;
       if (sampler) {
-        result.resourceSamples = sampledResources ?? await sampler.stop();
+        result.resourceSamples = await (sampledResources ?? sampler.stop());
       }
       resolve(result);
     }

--- a/src/commands.mjs
+++ b/src/commands.mjs
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { StringDecoder } from "node:string_decoder";
 import { startResourceSampler } from "./collectors/resources.mjs";
 import { repoRoot } from "./paths.mjs";
@@ -68,21 +69,44 @@ export function runCommand(command, options = {}) {
     if (options.shell !== undefined && options.env?.SHELL === undefined) {
       childEnv.SHELL = options.shell;
     }
-    const child = spawn(shell, ["-c", command], {
+    const accountCpu = process.platform === "linux" && Boolean(options.resourceSample);
+    const child = spawn(accountCpu ? process.execPath : shell, accountCpu
+      ? [fileURLToPath(new URL("../support/resource-command.mjs", import.meta.url)), shell, command]
+      : ["-c", command], {
       cwd: repoRoot,
       env: childEnv,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: accountCpu ? ["ignore", "pipe", "pipe", "ipc"] : ["ignore", "pipe", "pipe"],
       detached: process.platform !== "win32"
     });
     const stopTrackingChild = trackDetachedChild(child);
 
-    const sampler = options.resourceSample
+    const createSampler = () => options.resourceSample
       ? startResourceSampler(child.pid, {
         ...options.resourceSample,
+        accountingRootPid: accountCpu ? child.pid : undefined,
         rootCommand: command,
         redactValues: options.redactValues ?? []
       })
       : null;
+    let sampler = accountCpu ? null : createSampler();
+    let accountedCompletion;
+    let sampledResources;
+    child.on("message", async (message) => {
+      if (message?.type === "ready" && !sampler) {
+        sampler = createSampler();
+        child.send({ type: "start" }, () => {});
+      } else if (message?.type === "complete" && !accountedCompletion) {
+        clearTimeout(timer);
+        accountedCompletion = { ...message, finishedAtEpochMs: Date.now() };
+        try {
+          sampledResources = await sampler?.stop();
+        } catch (error) {
+          sampledResources = { available: false, sampleCount: 0, failedSampleCount: 1,
+            cpuCoverageComplete: false, errors: [error.message] };
+        }
+        if (child.connected) child.send({ type: "sampled" }, () => {});
+      }
+    });
     const stdout = createBoundedOutputAccumulator({
       limit: maxOutputChars,
       redactValues: options.redactValues
@@ -133,7 +157,7 @@ export function runCommand(command, options = {}) {
         terminationError = await termination;
         reportTerminationError(terminationError);
       }
-      complete(timedOut ? 124 : (status ?? 1), signal, Boolean(terminationError));
+      complete(timedOut ? 124 : (accountedCompletion ? (accountedCompletion.status ?? 1) : (status ?? 1)), accountedCompletion?.signal ?? signal, Boolean(terminationError));
     });
 
     function reportTerminationError(error) {
@@ -148,7 +172,7 @@ export function runCommand(command, options = {}) {
       if (!keepTracking) {
         stopTrackingChild();
       }
-      const finishedAtEpochMs = Date.now();
+      const finishedAtEpochMs = accountedCompletion?.finishedAtEpochMs ?? Date.now();
       const stdoutResult = stdout.finish();
       const stderrResult = stderr.finish();
       settle({
@@ -163,6 +187,7 @@ export function runCommand(command, options = {}) {
         durationMs: finishedAtEpochMs - startedAtEpochMs,
         stdout: stdoutResult.text,
         stderr: stderrResult.text,
+        ...(options.resourceSample ? { resourceSampleExpected: true } : {}),
         outputBudget: outputBudgetSummary(stdoutResult, stderrResult)
       });
     }
@@ -173,7 +198,7 @@ export function runCommand(command, options = {}) {
       }
       settled = true;
       if (sampler) {
-        result.resourceSamples = await sampler.stop();
+        result.resourceSamples = sampledResources ?? await sampler.stop();
       }
       resolve(result);
     }

--- a/src/evaluation/violations.mjs
+++ b/src/evaluation/violations.mjs
@@ -100,31 +100,9 @@ export function checkRoleThresholds(violations, byRole, roleThresholds, options 
         message: `${role} peak process RSS ${peakProcessRssMb} MB exceeded threshold ${thresholds.peakProcessRssMb} MB`
       });
     }
-    const maxCpuThresholdActive = activeFiniteThreshold(
-      violations,
-      `resourceByRole.${role}.maxCpuPercent`,
-      thresholds.maxCpuPercent
-    );
-    if (
-      !skipMaxCpuRoles.has(role) &&
-      maxCpuThresholdActive &&
-      finiteNonNegativeMeasurement(
-        violations,
-        `resourceByRole.${role}.maxCpuPercent`,
-        summary.maxCpuPercent,
-        "measurement"
-      ) &&
-      summary.maxCpuPercent > thresholds.maxCpuPercent
-    ) {
-      violations.push({
-        kind: "resource",
-        metric: `resourceByRole.${role}.maxCpuPercent`,
-        role,
-        expected: `<= ${thresholds.maxCpuPercent}`,
-        actual: summary.maxCpuPercent,
-        message: `${role} max CPU ${summary.maxCpuPercent}% exceeded threshold ${thresholds.maxCpuPercent}%`
-      });
-    }
+    checkCpuThreshold(violations, { kind: "resource", metric: `resourceByRole.${role}.maxCpuPercent`, role,
+      label: `${role} max CPU`, value: summary.maxCpuPercent, lower: summary.maxCpuPercentLower,
+      threshold: thresholds.maxCpuPercent, skipComparison: skipMaxCpuRoles.has(role) });
   }
 }
 
@@ -259,4 +237,20 @@ function describeValue(value) {
   } catch {
     return String(value);
   }
+}
+
+
+export function checkCpuThreshold(violations, { kind, metric, role, label, value, lower, threshold, skipComparison = false }) {
+  if (!activeFiniteThreshold(violations, metric, threshold) || skipComparison ||
+      !finiteNonNegativeMeasurement(violations, metric, value, "measurement") || value <= threshold) return;
+  const uncertain = typeof lower === "number" && lower <= threshold;
+  violations.push({
+    kind: uncertain ? "evidence" : kind, metric, ...(role ? { role } : {}),
+    ...(uncertain ? { failureDomain: "kova-harness" } : {}),
+    expected: `<= ${threshold}`,
+    actual: uncertain ? { lower, upper: value } : value,
+    message: uncertain ? `${label} interval [${lower}%, ${value}%] crosses threshold ${threshold}%; CPU measurement is inconclusive` :
+      typeof lower === "number" ? `${label} at least ${lower}% exceeded threshold ${threshold}% (upper bound ${value}%)` :
+        `${label} ${value}% exceeded threshold ${threshold}%`
+  });
 }

--- a/src/evaluator.mjs
+++ b/src/evaluator.mjs
@@ -44,6 +44,7 @@ import {
   checkDuration,
   checkEvidenceThreshold,
   checkRoleThresholds,
+  checkCpuThreshold,
   checkTurnThreshold
 } from "./evaluation/violations.mjs";
 
@@ -129,7 +130,20 @@ export function evaluateRecord(record, scenario, options = {}) {
   const allResults = collectResults(record);
   const measurementScopeSummary = summarizeMeasurementScopes(record);
   const measuredResults = collectResults(record, { productOnly: true });
-  const gatewayProcessResources = collectGatewayProcessResources(record, { productOnly: true });
+  const intervalCpu = measuredResults.some((result) => result.resourceSamples?.cpuMeasurementContract === "linux-process-interval-v1");
+  const requireCpuContract = options.requireCpuContract === true || intervalCpu ||
+    record.measurements?.resourceHeadlineContract !== undefined;
+  const expectedCpuContract = process.platform === "linux" ? "linux-process-interval-v1" : "ps-process-cpu-v1";
+  for (const result of measuredResults) {
+    const samples = result.resourceSamples;
+    if (samples?.cpuCoverageComplete === false || (requireCpuContract && (options.requireCpuContract === true || samples || result.resourceSampleExpected) &&
+      (samples?.cpuCoverageComplete !== true || samples?.cpuMeasurementContract !== expectedCpuContract))) {
+      violations.push({ kind: "evidence", metric: "resourceCpuCoverage", expected: "complete CPU interval evidence",
+        actual: samples?.errors ?? "missing CPU measurement contract or coverage", failureDomain: "kova-harness",
+        message: "Product CPU interval evidence is incomplete" });
+    }
+  }
+  const gatewayProcessResources = collectGatewayProcessResources(record, { productOnly: true, intervalCpu });
   const resourceSummary = collectResourceSummary(measuredResults, { gatewayProcessResources });
   const channelWorkflowResources = summarizeChannelWorkflowResources(measuredResults);
   const peakTrackedRssMb = maxNullable(gatewayProcessResources?.peakRssMb, resourceSummary.peakTotalRssMb);
@@ -310,15 +324,11 @@ export function evaluateRecord(record, scenario, options = {}) {
     });
   }
 
-  if (cpuPercentThreshold !== null && cpuPercentMax !== null && cpuPercentMax > cpuPercentThreshold) {
-    violations.push({
-      kind: "threshold",
-      metric: "cpuPercentMax",
-      expected: `<= ${cpuPercentThreshold}`,
-      actual: cpuPercentMax,
-      message: `max CPU ${cpuPercentMax}% exceeded threshold ${cpuPercentThreshold}%`
-    });
-  }
+  checkCpuThreshold(violations, {
+    kind: "threshold", metric: "cpuPercentMax", label: "max CPU", value: cpuPercentMax,
+    lower: resourceGate.role ? resourceSummary.byRole[resourceGate.role]?.maxCpuPercentLower : resourceSummary.maxTotalCpuPercentLower,
+    threshold: cpuPercentThreshold ?? undefined
+  });
   checkRoleThresholds(violations, resourceSummary.byRole, roleThresholds, {
     skipPeakRssRoles:
       primaryRoleOwnsResourceGate && typeof thresholds.peakRssMb === "number"
@@ -3855,14 +3865,14 @@ function collectGatewayProcessResources(record, options = {}) {
     if (options.productOnly === true && !measuredProductPhase(phase)) {
       continue;
     }
-    summary = mergeGatewayProcessMetrics(summary, phase.metrics?.process);
+    summary = mergeGatewayProcessMetrics(summary, phase.metrics?.process, options);
   }
-  return mergeGatewayProcessMetrics(summary, record.finalMetrics?.process);
+  return mergeGatewayProcessMetrics(summary, record.finalMetrics?.process, options);
 }
 
-function mergeGatewayProcessMetrics(summary, process) {
+function mergeGatewayProcessMetrics(summary, process, options = {}) {
   const rssMb = typeof process?.rssMb === "number" ? process.rssMb : null;
-  const cpuPercent = typeof process?.cpuPercent === "number" ? process.cpuPercent : null;
+  const cpuPercent = !options.intervalCpu && typeof process?.cpuPercent === "number" ? process.cpuPercent : null;
   if (rssMb === null && cpuPercent === null) {
     return summary;
   }
@@ -3898,6 +3908,7 @@ function collectResourceSummary(results, options = {}) {
   let sampleCount = 0;
   let peakTotalRssMb = null;
   let maxTotalCpuPercent = null;
+  let maxTotalCpuPercentLower = null;
   let peakCommandTreeRssMb = null;
   let peakGatewayRssMb = null;
   let peakRssSample = null;
@@ -3917,6 +3928,7 @@ function collectResourceSummary(results, options = {}) {
     sampleCount += samples.sampleCount ?? 0;
     peakTotalRssMb = maxNullable(peakTotalRssMb, samples.peakTotalRssMb);
     maxTotalCpuPercent = maxNullable(maxTotalCpuPercent, samples.maxTotalCpuPercent);
+    maxTotalCpuPercentLower = maxNullable(maxTotalCpuPercentLower, samples.maxTotalCpuPercentLower);
     peakCommandTreeRssMb = maxNullable(peakCommandTreeRssMb, samples.peakCommandTreeRssMb);
     peakGatewayRssMb = maxNullable(peakGatewayRssMb, samples.peakGatewayRssMb);
     mergeRoleSummaries(byRole, samples.byRole ?? {});
@@ -3929,8 +3941,10 @@ function collectResourceSummary(results, options = {}) {
       artifacts.push(samples.artifactPath);
     }
     for (const process of [...(samples.topByRss ?? []), ...(samples.topByCpu ?? [])]) {
-      const existing = byPid.get(process.pid) ?? {
+      const processIdentity = `${process.pid}:${process.startTicks ?? "legacy"}`;
+      const existing = byPid.get(processIdentity) ?? {
         pid: process.pid,
+        ...(process.startTicks === undefined ? {} : { startTicks: process.startTicks }),
         command: process.command,
         role: process.role,
         peakRssMb: 0,
@@ -3944,7 +3958,7 @@ function collectResourceSummary(results, options = {}) {
       existing.maxCpuPercent = Math.max(existing.maxCpuPercent, process.maxCpuPercent ?? 0);
       existing.firstSeenMs = Math.min(existing.firstSeenMs ?? process.firstSeenMs ?? 0, process.firstSeenMs ?? 0);
       existing.lastSeenMs = Math.max(existing.lastSeenMs ?? process.lastSeenMs ?? 0, process.lastSeenMs ?? 0);
-      byPid.set(process.pid, existing);
+      byPid.set(processIdentity, existing);
     }
   }
 
@@ -3961,6 +3975,7 @@ function collectResourceSummary(results, options = {}) {
     sampleCount,
     peakTotalRssMb,
     maxTotalCpuPercent,
+    maxTotalCpuPercentLower,
     peakCommandTreeRssMb,
     peakGatewayRssMb,
     maxTotalRssGrowthMb,
@@ -4011,6 +4026,7 @@ function mergeRoleSummaries(target, source) {
       existing.peakCpuAtMs = summary.peakCpuAtMs ?? null;
       existing.peakCpuProcess = summary.peakCpuProcess ?? null;
     }
+    if (typeof summary.maxCpuPercentLower === "number") existing.maxCpuPercentLower = Math.max(existing.maxCpuPercentLower ?? 0, summary.maxCpuPercentLower);
     target.set(role, existing);
   }
 }

--- a/src/performance/stats.mjs
+++ b/src/performance/stats.mjs
@@ -2,7 +2,7 @@ import { measurementMetricValue } from "../health.mjs";
 
 export const PERFORMANCE_SCHEMA = "kova.performance.v1";
 export const RESOURCE_MEASUREMENT_SCOPE = "product";
-export const RESOURCE_HEADLINE_CONTRACT = "primary-role-product-scope-v3";
+export const RESOURCE_HEADLINE_CONTRACT = "primary-role-product-scope-v4";
 
 export const PERFORMANCE_METRICS = [
   { id: "readinessHealthReadyMs", title: "Health Ready", unit: "ms", regressionKey: "startupRegressionPercent" },

--- a/src/run/finalize-record.mjs
+++ b/src/run/finalize-record.mjs
@@ -92,6 +92,7 @@ function attachNodeProfileMeasurements(record) {
 
 function evaluatorContext(context, scenario, record) {
   return {
+    requireCpuContract: true,
     surface: context.surfacesById?.[scenario.surface] ?? null,
     targetPlan: context.targetPlan ?? null,
     profile: context.profile ?? null,

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -21998,6 +21998,8 @@ function thresholdPolicyCalibrationCheck() {
             durationMs: 150,
             resourceSamples: {
               schemaVersion: "kova.resourceSamples.v1",
+              cpuCoverageComplete: true,
+              cpuMeasurementContract: process.platform === "linux" ? "linux-process-interval-v1" : "ps-process-cpu-v1",
               sampleCount: 1,
               peakTotalRssMb: 250,
               maxTotalCpuPercent: 80,

--- a/support/resource-command.mjs
+++ b/support/resource-command.mjs
@@ -1,0 +1,32 @@
+import { spawn } from "node:child_process";
+
+// Keep the wait owner alive until the sampler reads its final child CPU counters.
+// Otherwise sub-second commands and the last interval disappear with waitpid.
+let child;
+let completed = false;
+process.on("message", (message) => {
+  if (message?.type === "start" && !child) {
+    child = spawn(process.argv[2], ["-c", process.argv[3]], {
+      stdio: ["ignore", "inherit", "inherit"]
+    });
+    child.once("error", (error) => {
+      process.stderr.write(`${error.message}\n`);
+      finish(127, null);
+    });
+    child.once("close", (status, signal) => finish(status, signal));
+  } else if (message?.type === "sampled" && completed) {
+    process.disconnect();
+  }
+});
+process.on("disconnect", () => {
+  if (child && !completed) {
+    // The command shares this process group; do not orphan it if its owner dies.
+    process.kill(-process.pid, "SIGTERM");
+  }
+});
+function finish(status, signal) {
+  if (completed) return;
+  completed = true;
+  process.send?.({ type: "complete", status, signal });
+}
+process.send?.({ type: "ready" });

--- a/support/resource-command.mjs
+++ b/support/resource-command.mjs
@@ -8,8 +8,12 @@ process.on("message", (message) => {
   if (message?.type === "start" && !child) {
     child = spawn(process.argv[2], ["-c", process.argv[3]], {
       env: message.env,
-      stdio: ["ignore", "inherit", "inherit"]
+      stdio: ["ignore", "pipe", "pipe"]
     });
+    // Keep the wait owner alive until inherited writers close, even when the
+    // direct shell has exited. The parent's watchdog still owns this group.
+    child.stdout.pipe(process.stdout, { end: false });
+    child.stderr.pipe(process.stderr, { end: false });
     child.once("error", (error) => {
       process.stderr.write(`${error.message}\n`);
       finish(127, null);

--- a/support/resource-command.mjs
+++ b/support/resource-command.mjs
@@ -7,6 +7,7 @@ let completed = false;
 process.on("message", (message) => {
   if (message?.type === "start" && !child) {
     child = spawn(process.argv[2], ["-c", process.argv[3]], {
+      env: message.env,
       stdio: ["ignore", "inherit", "inherit"]
     });
     child.once("error", (error) => {

--- a/tests/linux-cpu-accounting.mjs
+++ b/tests/linux-cpu-accounting.mjs
@@ -53,7 +53,7 @@ test("counter regression and a missing historical baseline fail closed", () => {
   assert.throws(() => accountant.sample([processRow(1, 0, 90)], clock(11)), /Regressed/);
   const fresh = createLinuxCpuAccountant();
   fresh.sample([processRow(1, 0, 100)], clock(10));
-  assert.throws(() => fresh.sample([processRow(1, 0, 100), processRow(2, 1, 100)], clock(11)), /Missing CPU baseline/);
+  assert.throws(() => fresh.sample([processRow(1, 0, 100), { ...processRow(2, 1, 100), roles: ["gateway"] }], clock(11)), /Missing CPU baseline/);
 });
 
 
@@ -204,4 +204,50 @@ test("production CPU qualification rejects a completely absent sampler result", 
   evaluateRecord(record, {}, { requireCpuContract: true });
   assert.equal(record.status, "BLOCKED");
   assert.ok(record.violations.some((violation) => violation.metric === "resourceCpuCoverage"));
+});
+
+
+test("unrelated host reparenting is outside the product CPU census", () => {
+  const reads = [];
+  const original = fs.readFileSync;
+  mock.method(fs, "readFileSync", (path, ...args) => {
+    if (!/^\/proc\/[123]\/stat$/.test(path)) return original(path, ...args);
+    reads.push(path);
+    const pid = Number(path.split("/")[2]);
+    const fields = Array(22).fill("0");
+    fields[0] = "S";
+    fields[1] = String(pid === 1 ? 0 : pid === 2 ? 1 : 99);
+    return `${pid} (synthetic) ${fields.join(" ")}`;
+  });
+  syncBuiltinESMExports();
+  try {
+    const rows = readLinuxCpuSnapshot([
+      processRow(1, 0, 0),
+      { ...processRow(2, 1, 0), roles: ["gateway"] },
+      processRow(3, 1, 0)
+    ]);
+    assert.deepEqual(rows.map((entry) => entry.pid), [1, 2]);
+    assert.deepEqual(reads, ["/proc/1/stat", "/proc/2/stat"]);
+  } finally {
+    mock.restoreAll();
+    syncBuiltinESMExports();
+  }
+});
+
+
+test("a new Gateway introduces its existing wait owner without importing host CPU", () => {
+  const accountant = createLinuxCpuAccountant();
+  const command = { ...processRow(1, 0, 0), roles: ["command-tree"] };
+  accountant.sample([command], clock(10));
+  const owner = processRow(2, 0, 5000, 9000);
+  const gateway = { ...processRow(3, 2, 50, 0, 1000), roles: ["gateway"] };
+  const running = accountant.sample([command, owner, gateway], clock(11));
+  assert.equal(running.find((entry) => entry.pid === 2).cpuPercent, 0);
+  assert.equal(running.find((entry) => entry.pid === 3).cpuPercent, 50);
+  assert.ok(accountant.trackedProcessIds().has(2));
+  const completed = accountant.sample([command, { ...owner, childCpuTicks: 9060 }], clock(12));
+  const retired = completed.find((entry) => entry.pid === 2);
+  assert.equal(retired.reapedCpuPercent, 10);
+  assert.deepEqual(retired.reapedRoles, ["gateway"]);
+  assert.equal(accountant.coverageComplete(), true);
 });

--- a/tests/linux-cpu-accounting.mjs
+++ b/tests/linux-cpu-accounting.mjs
@@ -1,0 +1,207 @@
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+import { summarizeResourceSamples } from "../src/collectors/resources.mjs";
+import { checkCpuThreshold } from "../src/evaluation/violations.mjs";
+import { evaluateRecord } from "../src/evaluator.mjs";
+import { createLinuxCpuAccountant, readLinuxCpuSnapshot, LinuxCpuSnapshotChangedError } from "../src/collectors/linux-cpu.mjs";
+
+const clock = (seconds) => ({ hz: 100, ticks: seconds * 100, monotonicMs: seconds * 1000 });
+const processRow = (pid, ppid, cpuTicks, childCpuTicks = 0, startTicks = 0) => ({ pid, ppid, cpuTicks, childCpuTicks, startTicks, rssMb: 0, command: "synthetic", roles: [] });
+const cpu = (rows) => rows.reduce((total, row) => total + (row.cpuPercent ?? 0), 0);
+
+test("serial parent and newborn child use the same CPU interval", () => {
+  const accountant = createLinuxCpuAccountant();
+  accountant.sample([processRow(1, 0, 0)], clock(0));
+  assert.equal(cpu(accountant.sample([processRow(1, 0, 100)], clock(1))), 100);
+  assert.equal(cpu(accountant.sample([processRow(1, 0, 100), processRow(2, 1, 10, 0, 100)], clock(1.1))), 100);
+});
+
+test("real parallel CPU above the unchanged 200% gate remains visible", () => {
+  const accountant = createLinuxCpuAccountant();
+  accountant.sample([processRow(1, 0, 0), processRow(2, 1, 0)], clock(0));
+  assert.equal(cpu(accountant.sample([processRow(1, 0, 150), processRow(2, 1, 150)], clock(1))), 300);
+});
+
+test("wait accounting retains unseen short children and excludes already sampled work", () => {
+  const accountant = createLinuxCpuAccountant({ accountingRootPid: 1 });
+  accountant.sample([processRow(1, 0, 30)], clock(0));
+  assert.equal(cpu(accountant.sample([processRow(1, 0, 40), processRow(2, 1, 60, 0, 0)], clock(1))), 60);
+  // The child did another 20 ticks before being reaped, and a new short child
+  // did 10 ticks entirely between samples. Wrapper work remains harness-only.
+  assert.equal(cpu(accountant.sample([processRow(1, 0, 50, 90)], clock(2))), 30);
+});
+
+test("nested reaping does not count a grandchild twice", () => {
+  const accountant = createLinuxCpuAccountant({ accountingRootPid: 1 });
+  accountant.sample([processRow(1, 0, 0)], clock(0));
+  accountant.sample([processRow(1, 0, 0), processRow(2, 1, 50), processRow(3, 2, 10)], clock(1));
+  assert.equal(cpu(accountant.sample([processRow(1, 0, 0, 90)], clock(2))), 30);
+});
+
+test("a recycled PID begins a new CPU identity", () => {
+  const accountant = createLinuxCpuAccountant({ accountingRootPid: 1 });
+  accountant.sample([processRow(1, 0, 0)], clock(0));
+  accountant.sample([processRow(1, 0, 0), processRow(2, 1, 50)], clock(1));
+  assert.equal(cpu(accountant.sample([processRow(1, 0, 0, 60), processRow(2, 1, 20, 0, 100)], clock(2))), 30);
+});
+
+test("counter regression and a missing historical baseline fail closed", () => {
+  const accountant = createLinuxCpuAccountant();
+  accountant.sample([processRow(1, 0, 100)], clock(10));
+  assert.throws(() => accountant.sample([processRow(1, 0, 90)], clock(11)), /Regressed/);
+  const fresh = createLinuxCpuAccountant();
+  fresh.sample([processRow(1, 0, 100)], clock(10));
+  assert.throws(() => fresh.sample([processRow(1, 0, 100), processRow(2, 1, 100)], clock(11)), /Missing CPU baseline/);
+});
+
+
+
+test("missing CPU counter coverage blocks qualification rather than passing as zero", () => {
+  const record = { status: "PASS", phases: [{ id: "status", measurementScope: "product", results: [{
+    command: "openclaw status", status: 0, stdout: "", stderr: "", durationMs: 10, resourceSamples: { sampleCount: 2, cpuMeasurementContract: process.platform === "linux" ? "linux-process-interval-v1" : "ps-process-cpu-v1", cpuCoverageComplete: false, errors: ["missing CPU baseline"] }
+  }] }] };
+  const complete = structuredClone(record);
+  complete.phases[0].results[0].resourceSamples.cpuCoverageComplete = true;
+  complete.phases[0].results[0].resourceSamples.errors = [];
+  evaluateRecord(complete, {}, {});
+  assert.equal(complete.status, "PASS");
+  evaluateRecord(record, {}, {});
+  assert.equal(record.status, "BLOCKED");
+  assert.ok(record.violations.some((violation) => violation.metric === "resourceCpuCoverage"));
+});
+
+
+test("retired Gateway CPU retains its role when an external supervisor reaps it", () => {
+  const accountant = createLinuxCpuAccountant();
+  const supervisor = processRow(1, 0, 0);
+  const gateway = { ...processRow(2, 1, 0), roles: ["gateway", "gateway-tree"] };
+  accountant.sample([supervisor, gateway], clock(0));
+  accountant.sample([supervisor, { ...gateway, cpuTicks: 100 }], clock(1));
+  const retiring = accountant.sample([supervisor, { ...gateway, cpuTicks: 120, roles: [] }], clock(1.5));
+  assert.deepEqual(retiring.find((entry) => entry.pid === 2).roles, ["gateway", "gateway-tree"]);
+  const processes = accountant.sample([{ ...supervisor, childCpuTicks: 150 }], clock(2));
+  assert.deepEqual(processes[0].reapedRoles, ["gateway", "gateway-tree"]);
+  const summary = summarizeResourceSamples([{ elapsedMs: 2000, collectionStatus: "ok", processes, cpuUncertaintyPercent: 0 }]);
+  assert.equal(summary.byRole.gateway.maxCpuPercent, 60);
+  assert.equal(summary.byRole.gateway.maxCpuPercentLower, 0);
+  assert.equal(summary.byRole.gateway.peakCpuProcess.pid, 2);
+  assert.equal(summary.byRole.gateway.peakCpuProcess.cpuWaitOwnerPid, 1);
+  assert.equal(accountant.coverageComplete(), true);
+});
+
+test("counter scan brackets yield conservative bounds and never an invented CPU failure", () => {
+  const accountant = createLinuxCpuAccountant();
+  accountant.sample([processRow(1, 0, 0)], { ...clock(0), finishedMs: 500 });
+  const measured = accountant.sample([processRow(1, 0, 150)], { ...clock(1), finishedMs: 1500 });
+  assert.equal(cpu(measured), 300);
+  const ambiguous = [];
+  checkCpuThreshold(ambiguous, { kind: "resource", metric: "cpu", label: "CPU", value: 300, lower: 0, threshold: 200 });
+  assert.equal(ambiguous[0].failureDomain, "kova-harness");
+  assert.equal(ambiguous[0].kind, "evidence");
+  const parallel = [];
+  checkCpuThreshold(parallel, { kind: "resource", metric: "cpu", label: "CPU", value: 300, lower: 280, threshold: 200 });
+  assert.equal(parallel[0].kind, "resource");
+  const below = [];
+  checkCpuThreshold(below, { kind: "resource", metric: "cpu", label: "CPU", value: 199, lower: 180, threshold: 200 });
+  assert.deepEqual(below, []);
+});
+
+test("qualification rejects missing and historical CPU contracts", () => {
+  for (const cpuMeasurementContract of [undefined, "ps-process-cpu-legacy"]) {
+    const record = { status: "PASS", phases: [{ id: "status", measurementScope: "product", results: [{
+      command: "openclaw status", status: 0, stdout: "", stderr: "", durationMs: 10,
+      resourceSamples: { sampleCount: 2, cpuCoverageComplete: true, cpuMeasurementContract }
+    }] }] };
+    evaluateRecord(record, {}, { requireCpuContract: true });
+    assert.equal(record.status, "BLOCKED");
+    assert.ok(record.violations.some((violation) => violation.metric === "resourceCpuCoverage"));
+  }
+});
+
+
+test("an unreaped or missing wait owner cannot certify terminal product CPU", () => {
+  const accountant = createLinuxCpuAccountant();
+  accountant.sample([processRow(1, 0, 0), { ...processRow(2, 1, 100), roles: ["gateway"] }], clock(0));
+  accountant.sample([processRow(1, 0, 0)], clock(1));
+  assert.equal(accountant.coverageComplete(), false);
+  accountant.sample([processRow(1, 0, 0, 120)], clock(2));
+  assert.equal(accountant.coverageComplete(), true);
+  const missing = createLinuxCpuAccountant();
+  missing.sample([{ ...processRow(2, 99, 100), roles: ["gateway"] }], clock(0));
+  missing.sample([], clock(1));
+  assert.equal(missing.coverageComplete(), false);
+});
+
+
+test("resource summaries keep recycled PID identities separate", () => {
+  const samples = [0, 100].map((startTicks) => ({ collectionStatus: "ok", elapsedMs: startTicks,
+    processes: [{ ...processRow(2, 1, 0, 0, startTicks), roles: ["command-tree"], role: "command-tree", cpuPercent: 50 }]
+  }));
+  const summary = summarizeResourceSamples(samples);
+  assert.equal(summary.topByCpu.length, 2);
+  assert.deepEqual(summary.topByCpu.map((entry) => entry.startTicks).sort((a, b) => a - b), [0, 100]);
+});
+
+
+test("a child exiting after its wait owner read invalidates the census", () => {
+  const reads = [];
+  const original = fs.readFileSync;
+  mock.method(fs, "readFileSync", (path, ...args) => {
+    if (path !== "/proc/1/stat" && path !== "/proc/2/stat") return original(path, ...args);
+    reads.push(path);
+    if (path === "/proc/2/stat") throw Object.assign(new Error("gone"), { code: "ENOENT" });
+    const fields = Array(22).fill("0"); fields[0] = "S"; fields[13] = "100";
+    return `1 (wait owner) ${fields.join(" ")}`;
+  });
+  syncBuiltinESMExports();
+  try {
+    assert.throws(() => readLinuxCpuSnapshot([
+      { ...processRow(2, 1, 100), roles: ["gateway"] }, processRow(1, 0, 0)
+    ]), LinuxCpuSnapshotChangedError);
+    assert.deepEqual(reads, ["/proc/1/stat", "/proc/2/stat"]);
+    // A restarted Gateway may already have lost its current role, but its
+    // previously measured identity still requires terminal wait accounting.
+    assert.throws(() => readLinuxCpuSnapshot([
+      processRow(2, 1, 100), processRow(1, 0, 0)
+    ], new Set([2])), LinuxCpuSnapshotChangedError);
+  } finally {
+    mock.restoreAll();
+    syncBuiltinESMExports();
+  }
+});
+
+
+test("losing a wait owner cannot erase its outstanding product debt", () => {
+  const accountant = createLinuxCpuAccountant();
+  const init = processRow(99, 0, 0);
+  const owner = processRow(1, 99, 0);
+  accountant.sample([init, owner, { ...processRow(2, 1, 100), roles: ["gateway"] }], clock(0));
+  accountant.sample([init, owner], clock(1));
+  assert.equal(accountant.coverageComplete(), false);
+  accountant.sample([{ ...init, childCpuTicks: 120 }], clock(2));
+  assert.equal(accountant.coverageComplete(), false);
+});
+
+test("a rejected census cannot alter CPU debt or the successful scan bracket", () => {
+  const accountant = createLinuxCpuAccountant();
+  const owner = processRow(1, 0, 10);
+  const gateway = { ...processRow(2, 1, 100), roles: ["gateway"] };
+  const firstClock = { ...clock(0), finishedMs: 100 };
+  accountant.sample([owner, gateway], firstClock);
+  assert.throws(() => accountant.sample([{ ...owner, cpuTicks: 5 }], clock(1)), /Regressed/);
+  assert.equal(accountant.lastSuccessfulClock(), firstClock);
+  accountant.sample([owner, gateway], clock(2));
+  assert.equal(accountant.coverageComplete(), true);
+});
+
+
+test("production CPU qualification rejects a completely absent sampler result", () => {
+  const record = { status: "PASS", phases: [{ id: "status", measurementScope: "product", results: [{
+    command: "openclaw status", status: 0, stdout: "", stderr: "", durationMs: 10
+  }] }] };
+  evaluateRecord(record, {}, { requireCpuContract: true });
+  assert.equal(record.status, "BLOCKED");
+  assert.ok(record.violations.some((violation) => violation.metric === "resourceCpuCoverage"));
+});

--- a/tests/resource-command-accounting.mjs
+++ b/tests/resource-command-accounting.mjs
@@ -23,14 +23,32 @@ test("accounted commands retain output, nonzero exits, and timeout cleanup", { s
 });
 
 
-test("parallel product children can still exceed two CPU cores", { skip: process.platform !== "linux" }, async () => {
-  const script = "const {spawn}=require('node:child_process');for(let i=0;i<4;i++)spawn(process.execPath,['-e','const end=Date.now()+1200;while(Date.now()<end){}'],{stdio:'ignore'});";
-  const command = `${process.execPath} -e ${quoteShell(script)}`;
-  const result = await runCommand(command, { resourceSample: { intervalMs: 250 }, timeoutMs: 10000 });
+test("parallel child CPU is measured against the work actually performed", { skip: process.platform !== "linux" }, async (t) => {
+  const { execFileSync } = await import("node:child_process");
+  const hz = Number(execFileSync("getconf", ["CLK_TCK"], { encoding: "utf8" }).trim());
+  assert.ok(Number.isSafeInteger(hz) && hz > 0);
+  const worker = 'const end=Date.now()+1200;while(Date.now()<end){};console.log(JSON.stringify(process.cpuUsage()));';
+  const script = `const {spawn}=require('node:child_process');Promise.all(Array.from({length:4},()=>new Promise((resolve,reject)=>{const child=spawn(process.execPath,['-e',${JSON.stringify(worker)}],{stdio:['ignore','pipe','inherit']});let text='';child.stdout.on('data',chunk=>text+=chunk);child.on('error',reject);child.on('close',code=>code===0?resolve(JSON.parse(text)):reject(new Error('child failed')));}))).then(rows=>console.log(JSON.stringify(rows))).catch(error=>{console.error(error);process.exitCode=1;});`;
+  const result = await runCommand(`${quoteShell(process.execPath)} -e ${quoteShell(script)}`, { resourceSample: { intervalMs: 250 }, timeoutMs: 10000 });
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.resourceSamples.cpuCoverageComplete, true, JSON.stringify(result.resourceSamples.errors));
-  assert.ok(result.resourceSamples.byRole["command-tree"].maxCpuPercent > 200);
+  const workers = JSON.parse(result.stdout);
+  assert.equal(workers.length, 4);
+  const cpuMicros = workers.reduce((total, row) => total + row.user + row.system, 0);
+  // user and system counters each have one kernel tick of quantization per
+  // worker. The measured peak must cover the independently reported average
+  // work, whether the runner supplies one CPU, a quota, or several CPUs.
+  const quantizationMicros = workers.length * 2 * 1_000_000 / hz;
+  const referenceAverageLower = Math.max(0, cpuMicros - quantizationMicros) / (result.durationMs * 1000) * 100;
+  const measuredPeak = result.resourceSamples.byRole["command-tree"].maxCpuPercent;
+  assert.ok(referenceAverageLower > 0);
+  assert.ok(measuredPeak >= referenceAverageLower, `${measuredPeak}% does not cover ${referenceAverageLower}% of observed child work`);
+  t.diagnostic(JSON.stringify({ case: "parallel-child-cpu", cpuMicros, durationMs: result.durationMs,
+    referenceAverageLower, measuredPeak, productionCpuThreshold: 200,
+    physicallyObservedAboveThreshold: referenceAverageLower > 200,
+    terminalCoverageComplete: result.resourceSamples.cpuCoverageComplete }));
 });
+
 
 test("terminal sampling failures remain visible and do not strand the command owner", { skip: process.platform !== "linux" }, async () => {
   const result = await runCommand("true", { resourceSample: { artifactPath: "/dev/null/not-a-directory/sample.jsonl" }, timeoutMs: 10000 });
@@ -66,4 +84,29 @@ test("command Node preloads and coverage run only in the requested command", { s
   } finally {
     await fs.rm(root, { recursive: true, force: true });
   }
+});
+
+
+test("the command deadline owns inherited output pipes after the shell exits", { skip: process.platform !== "linux" }, async () => {
+  const result = await runCommand("sleep 1.5 & exit 0", { resourceSample: {}, timeoutMs: 250 });
+  assert.equal(result.status, 124);
+  assert.equal(result.timedOut, true);
+  assert.ok(result.durationMs >= 250, "timeout duration must include the inherited-pipe lifetime");
+});
+
+
+test("successful output drain includes descendants without consuming the timeout", { skip: process.platform !== "linux" }, async () => {
+  const result = await runCommand("(sleep 0.1; printf tail >&2) & printf head; exit 0", { resourceSample: {}, timeoutMs: 2000 });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.timedOut, false);
+  assert.equal(result.stdout, "head");
+  assert.equal(result.stderr, "tail");
+});
+
+
+test("the watchdog reaps the owned group when inherited writers ignore TERM", { skip: process.platform !== "linux" }, async () => {
+  const result = await runCommand("(trap '' TERM; sleep 30) & exit 0", { resourceSample: {}, timeoutMs: 250 });
+  assert.equal(result.status, 124);
+  assert.equal(result.timedOut, true);
+  assert.doesNotMatch(result.stderr, /command timeout cleanup failed/);
 });

--- a/tests/resource-command-accounting.mjs
+++ b/tests/resource-command-accounting.mjs
@@ -41,3 +41,29 @@ test("terminal sampling failures remain visible and do not strand the command ow
   assert.equal(signaled.signal, "SIGTERM");
   assert.notEqual(signaled.status, 0);
 });
+
+
+test("command Node preloads and coverage run only in the requested command", { skip: process.platform !== "linux" }, async () => {
+  const fs = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const root = await fs.mkdtemp(join(tmpdir(), "kova-command-node-env-"));
+  try {
+    const modules = join(root, "modules");
+    const coverage = join(root, "coverage");
+    const preload = join(root, "preload.cjs");
+    await fs.mkdir(modules);
+    await fs.writeFile(join(modules, "accounting-preload-marker.js"), 'module.exports = "preload\\n";');
+    await fs.writeFile(preload, 'process.stdout.write(require("accounting-preload-marker"));');
+    const result = await runCommand(`${quoteShell(process.execPath)} -e 'process.stdout.write("target\\n")'`, {
+      env: { NODE_OPTIONS: `--require ${JSON.stringify(preload)}`, NODE_PATH: modules, NODE_V8_COVERAGE: coverage },
+      resourceSample: {}, timeoutMs: 10000
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "preload\ntarget\n");
+    assert.equal((await fs.readdir(coverage)).filter((entry) => entry.endsWith(".json")).length, 1);
+    assert.equal(result.resourceSamples.cpuCoverageComplete, true, JSON.stringify(result.resourceSamples.errors));
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/tests/resource-command-accounting.mjs
+++ b/tests/resource-command-accounting.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runCommand, quoteShell } from "../src/commands.mjs";
+
+test("a final sample measures a sub-second command before its wait owner exits", { skip: process.platform !== "linux" }, async () => {
+  const result = await runCommand(`sleep 0.2; ${process.execPath} -e 'const end=Date.now()+200; while(Date.now()<end){}'`, {
+    resourceSample: {}, timeoutMs: 10000
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(result.resourceSamples.byRole["command-tree"].maxCpuPercent > 20, `sub-second CPU must be measured: ${JSON.stringify(result.resourceSamples)}`);
+  assert.equal(result.resourceSamples.cpuCoverageComplete, true, JSON.stringify(result.resourceSamples.errors));
+  assert.equal(result.resourceSamples.cpuMeasurementContract, "linux-process-interval-v1");
+});
+
+test("accounted commands retain output, nonzero exits, and timeout cleanup", { skip: process.platform !== "linux" }, async () => {
+  const failed = await runCommand("printf output; printf error >&2; exit 7", { resourceSample: {}, timeoutMs: 10000 });
+  assert.equal(failed.status, 7);
+  assert.equal(failed.stdout, "output");
+  assert.equal(failed.stderr, "error");
+  const timeout = await runCommand("sleep 30", { resourceSample: {}, timeoutMs: 200 });
+  assert.equal(timeout.status, 124);
+  assert.equal(timeout.timedOut, true);
+});
+
+
+test("parallel product children can still exceed two CPU cores", { skip: process.platform !== "linux" }, async () => {
+  const script = "const {spawn}=require('node:child_process');for(let i=0;i<4;i++)spawn(process.execPath,['-e','const end=Date.now()+1200;while(Date.now()<end){}'],{stdio:'ignore'});";
+  const command = `${process.execPath} -e ${quoteShell(script)}`;
+  const result = await runCommand(command, { resourceSample: { intervalMs: 250 }, timeoutMs: 10000 });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.resourceSamples.cpuCoverageComplete, true, JSON.stringify(result.resourceSamples.errors));
+  assert.ok(result.resourceSamples.byRole["command-tree"].maxCpuPercent > 200);
+});
+
+test("terminal sampling failures remain visible and do not strand the command owner", { skip: process.platform !== "linux" }, async () => {
+  const result = await runCommand("true", { resourceSample: { artifactPath: "/dev/null/not-a-directory/sample.jsonl" }, timeoutMs: 10000 });
+  assert.equal(result.status, 0);
+  assert.equal(result.resourceSamples.cpuCoverageComplete, false);
+  assert.ok(result.resourceSamples.errors.length > 0);
+  const signaled = await runCommand("kill -TERM $$", { resourceSample: {}, timeoutMs: 10000 });
+  assert.equal(signaled.signal, "SIGTERM");
+  assert.notEqual(signaled.status, 0);
+});

--- a/tests/snapshots/matrix-run-receipt-dry-json.snap
+++ b/tests/snapshots/matrix-run-receipt-dry-json.snap
@@ -36,7 +36,7 @@
     "unstableGroupCount": 0,
     "profiledRunCount": 0,
     "resourceMeasurementScope": "product",
-    "resourceHeadlineContract": "primary-role-product-scope-v3",
+    "resourceHeadlineContract": "primary-role-product-scope-v4",
     "baselineRegressionCount": null,
     "missingBaselineCount": null,
     "skippedMetricCount": null,

--- a/tests/snapshots/matrix-run-receipt-dry.snap
+++ b/tests/snapshots/matrix-run-receipt-dry.snap
@@ -9,7 +9,7 @@
 
 ─── resource contract ──────────────────────────────────────────────────────────
   Scope      product
-  Headline   primary-role-product-scope-v3
+  Headline   primary-role-product-scope-v4
 
 ─── artifacts ──────────────────────────────────────────────────────────────────
   ◆ markdown    <kova-home>/reports/kova-<runId>-smoke.md

--- a/tests/snapshots/run-receipt-dry-json.snap
+++ b/tests/snapshots/run-receipt-dry-json.snap
@@ -21,7 +21,7 @@
     "unstableGroupCount": 0,
     "profiledRunCount": 0,
     "resourceMeasurementScope": "product",
-    "resourceHeadlineContract": "primary-role-product-scope-v3",
+    "resourceHeadlineContract": "primary-role-product-scope-v4",
     "baselineRegressionCount": null,
     "missingBaselineCount": null,
     "skippedMetricCount": null,

--- a/tests/snapshots/run-receipt-dry.snap
+++ b/tests/snapshots/run-receipt-dry.snap
@@ -9,7 +9,7 @@
 
 ─── resource contract ──────────────────────────────────────────────────────────
   Scope      product
-  Headline   primary-role-product-scope-v3
+  Headline   primary-role-product-scope-v4
 
 ─── artifacts ──────────────────────────────────────────────────────────────────
   ◆ markdown    <kova-home>/reports/kova-<runId>.md


### PR DESCRIPTION
Linux CPU sampling added lifetime averages from processes of different ages, producing false status-CLI budget failures and missing short-lived command CPU. This change measures a common interval with PID/start identities and owned command-lifetime accounting, preserving newborn, reaped, and final-interval work.

The 200% gate stays unchanged. Missing or uncertain accounting blocks qualification; the new measurement contract prevents reuse of incompatible old evidence. The collector observes product processes and their required wait-owner ancestry. The accounting helper isolates its Node startup environment while forwarding the untouched command environment to the target.

Rebased onto the current release-preparation base, preserving upstream timeout, process-safety, setup, and dependency fixes. Validation on the final source: 26 Linux CPU/lifecycle tests, 280 self-checks, 21 renderer snapshots, web/release contracts, package build, and packaged CPU smoke passed. The original accounting defect and both review findings have failing-before regressions. Independent P2 review is clean.

This repairs the collector used by OpenClaw full release validation; fresh exact-candidate performance evidence remains required. No version or package publication is included.

The watchdog regression failed on e777: `sleep 1.5 & exit 0` with a 250 ms deadline returned status 0 after about 1,528 ms. The corrected source keeps ownership through inherited-pipe drainage and process-group cleanup, including writers that ignore TERM.

The following bounded synthetic results come from the exact reviewed source e4d865f55f655a77df169a7be01877608c3260b9. CPU peaks are conservative upper bounds. Capacity-test success means the collector covers independently observed child CPU work; it does not label a restricted fixture as passing the 200% release gate merely because its test passes. In particular, the affinity fixture's 297.5% upper bound is not evidence of more than two actual CPUs.

```json
{
  "inheritedPipeTimeout": {
    "command": "sleep 30 & exit 0",
    "timeoutMs": 250,
    "status": 124,
    "timedOut": true,
    "durationMs": 277,
    "ownedGroupExistsAfterReturn": false,
    "terminalCoverageComplete": true,
    "scopedQualification": "FAIL"
  },
  "cpuSmoke": {
    "command": "node -e 'const end=Date.now()+100;while(Date.now()<end){}'",
    "status": 0,
    "durationMs": 131,
    "terminalCoverageComplete": true,
    "commandTreeCpu": 96.5,
    "scopedQualification": "PASS",
    "initialCounters": {
      "cpuTicks": 1,
      "childCpuTicks": 0
    },
    "terminalCounters": {
      "cpuTicks": 1,
      "childCpuTicks": 11
    }
  },
  "capacityChecks": [
    {
      "capacity": {
        "mode": "unconstrained"
      },
      "measurement": {
        "case": "parallel-child-cpu",
        "cpuMicros": 4805102,
        "durationMs": 1258,
        "referenceAverageLower": 375.60429252782194,
        "measuredPeak": 421.5,
        "productionCpuThreshold": 200,
        "physicallyObservedAboveThreshold": true,
        "terminalCoverageComplete": true
      }
    },
    {
      "capacity": {
        "mode": "affinity-1",
        "availableParallelism": 1,
        "cpuMax": "max 100000"
      },
      "measurement": {
        "case": "parallel-child-cpu",
        "cpuMicros": 1212118,
        "durationMs": 1299,
        "referenceAverageLower": 87.15304080061586,
        "measuredPeak": 297.5,
        "productionCpuThreshold": 200,
        "physicallyObservedAboveThreshold": false,
        "terminalCoverageComplete": true
      }
    },
    {
      "capacity": {
        "mode": "quota-1",
        "availableParallelism": 1,
        "cpuMax": "100000 100000"
      },
      "measurement": {
        "case": "parallel-child-cpu",
        "cpuMicros": 1234435,
        "durationMs": 1306,
        "referenceAverageLower": 88.39471669218989,
        "measuredPeak": 113.4,
        "productionCpuThreshold": 200,
        "physicallyObservedAboveThreshold": false,
        "terminalCoverageComplete": true
      }
    }
  ]
}
```

Validation: 26 CPU/lifecycle tests, all 280 self-checks, 21 renderer snapshots, web/release checks, package build and packaged CPU smoke passed. One-CPU affinity and an enforced `cpu.max=100000 100000` quota both ran the live measurement test without skipping it. Fresh P2 review is clean. Production CPU thresholds and command deadlines are unchanged.
