### PR TITLE
fix: handle spaces in the CPU accounting test's Node path

### DIFF
--- a/tests/resource-command-accounting.mjs
+++ b/tests/resource-command-accounting.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 import { runCommand, quoteShell } from "../src/commands.mjs";
 
 test("a final sample measures a sub-second command before its wait owner exits", { skip: process.platform !== "linux" }, async () => {
-  const result = await runCommand(`sleep 0.2; ${process.execPath} -e 'const end=Date.now()+200; while(Date.now()<end){}'`, {
+  const result = await runCommand(`sleep 0.2; ${quoteShell(process.execPath)} -e 'const end=Date.now()+200; while(Date.now()<end){}'`, {
     resourceSample: {}, timeoutMs: 10000
   });
   assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
Related: https://github.com/openclaw/Kova/security/code-scanning/3

## What Problem This Solves

Resolves a problem where the CPU-accounting test cannot launch Node when its executable path contains spaces.

## Why This Change Was Made

Quote the fixture's Node executable path with the existing `quoteShell` helper before it reaches the shell. The production runner, accounting wrapper, assertions, timeouts, and platform gates are unchanged.

## User Impact

No production behavior changes. Developers can run the fixture with Node installed in a path containing spaces.

## Evidence

- Real shell-boundary before/after on macOS with the same copied Node executable in a path containing spaces: the original command returned 127 after the shell truncated the path; the quoted command returned 0 with empty stderr.
- `node --test tests/linux-cpu-accounting.mjs tests/resource-command-accounting.mjs`: 18 passed, 8 Linux-only skipped, 0 failed.
- Syntax check and `git diff --check` passed.
- Focused independent review found no actionable P0-P2 findings.
- Local proof used Node 26.7.0 on macOS. It does not prove Linux CPU accounting. The existing Ubuntu Node 24 CI must exercise that flow.
- [Exact-head CI](https://github.com/openclaw/Kova/actions/runs/34130615086) passed the full check suite and package-install smoke on Ubuntu and macOS.
- Ubuntu Node 24.20.0 ran all 26 accounting tests with 0 failures and 0 skips, including the changed fixture and all eight Linux-only cases. This is separate from the local macOS spaces-path proof and local 18-pass/8-skip result above.
- [ClawSweeper's exact-head review](https://github.com/openclaw/Kova/pull/111#issuecomment-5571808190) reported no actionable findings and no before-merge changes.
- The full check/changed gate was not run locally; the complete gate was exercised by hosted CI.
