### PR TITLE
fix(cpu): account late-discovered session processes

### DIFF
--- a/src/collectors/linux-cpu.mjs
+++ b/src/collectors/linux-cpu.mjs
@@ -71,6 +71,10 @@ const identity = (process) => `${process.pid}:${process.startTicks}`;
 export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
   let previous = new Map();
   let previousClock;
+  // A process can be born after collection starts but remain undiscovered
+  // until a later role lookup. Its lifetime counters still provide a complete
+  // baseline for this sampling session.
+  let initialClock;
   let reapDebt = new Map();
   let missingWaitOwner = false;
   return {
@@ -84,6 +88,7 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
       return !missingWaitOwner && ![...reapDebt.values()].some((debt) => debt.ticks > 0 && debt.processes.some((entry) => entry.roles?.length));
     },
     sample(processes, clock) {
+      initialClock ??= clock;
       const nextDebt = new Map([...reapDebt].map(([key, debt]) => [key, { ...debt, processes: [...debt.processes] }]));
       let nextMissingWaitOwner = missingWaitOwner;
       processes = processes.map((entry) => {
@@ -131,16 +136,20 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
         let reapedProcesses = [];
         if (intervalTicks !== null) {
           const newlyObservedExistingOwner = !before && process.startTicks < Math.floor(previousClock.ticks) - 1;
-          if (newlyObservedExistingOwner && process.roles.length) {
+          const bornDuringSampling = !before && process.startTicks >= Math.floor(initialClock.ticks) - 1;
+          const lateSessionProcess = newlyObservedExistingOwner && bornDuringSampling;
+          if (newlyObservedExistingOwner && process.roles.length && !bornDuringSampling) {
             throw new Error(`Missing CPU baseline for process ${process.pid}`);
           }
           // A new product process can introduce an existing external wait owner.
           // Its historical host work is not product CPU; establish its baseline
           // before the child can be reaped in a later parent-first census.
-          const baseline = before ?? (newlyObservedExistingOwner ? process : null);
+          const baseline = before ?? (newlyObservedExistingOwner && !lateSessionProcess ? process : null);
           const ownTicks = process.cpuTicks - (baseline?.cpuTicks ?? 0);
           const waitedTicks = process.childCpuTicks - (baseline?.childCpuTicks ?? 0);
           if (ownTicks < 0 || waitedTicks < 0) throw new Error(`Regressed CPU counters for process ${process.pid}`);
+          const measuredIntervalTicks = lateSessionProcess ? clock.ticks - process.startTicks : intervalTicks;
+          if (!(measuredIntervalTicks > 0)) throw new Error(`Invalid CPU lifetime interval for process ${process.pid}`);
           const debt = nextDebt.get(key) ?? { ticks: 0, processes: [] };
           const newlyReapedTicks = Math.max(0, waitedTicks - debt.ticks);
           reapedRoles = [...new Set([...(process.roles ?? []), ...debt.processes.flatMap((entry) => entry.roles ?? [])])];
@@ -149,8 +158,8 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
           else nextDebt.delete(key);
           // The accounting wrapper is harness work. Its waited-child counters
           // still contain product work, including children missed by polling.
-          ownCpuPercent = (process.pid === accountingRootPid ? 0 : ownTicks) / intervalTicks * 100;
-          reapedCpuPercent = newlyReapedTicks / intervalTicks * 100;
+          ownCpuPercent = (process.pid === accountingRootPid ? 0 : ownTicks) / measuredIntervalTicks * 100;
+          reapedCpuPercent = newlyReapedTicks / measuredIntervalTicks * 100;
         }
         measured.push({ ...process, ownCpuPercent, reapedCpuPercent, reapedRoles, reapedProcesses,
           cpuPercent: ownCpuPercent === null ? null : ownCpuPercent + reapedCpuPercent });

--- a/tests/linux-cpu-accounting.mjs
+++ b/tests/linux-cpu-accounting.mjs
@@ -56,6 +56,16 @@ test("counter regression and a missing historical baseline fail closed", () => {
   assert.throws(() => fresh.sample([processRow(1, 0, 100), { ...processRow(2, 1, 100), roles: ["gateway"] }], clock(11)), /Missing CPU baseline/);
 });
 
+test("a product process born during sampling can be discovered from lifetime counters", () => {
+  const accountant = createLinuxCpuAccountant();
+  accountant.sample([processRow(1, 0, 100)], clock(10));
+  accountant.sample([processRow(1, 0, 100)], clock(11));
+  const gateway = { ...processRow(2, 1, 240, 0, 1020), roles: ["gateway"] };
+  const measured = accountant.sample([processRow(1, 0, 100), gateway], clock(15));
+  assert.equal(measured.find((entry) => entry.pid === 2).cpuPercent, 50);
+  assert.equal(accountant.coverageComplete(), true);
+});
+
 
 
 test("missing CPU counter coverage blocks qualification rather than passing as zero", () => {


### PR DESCRIPTION
## Summary

- distinguish product processes that predate a measurement session from processes born during it
- use complete Linux lifetime counters for a session-born process discovered after a later role lookup
- preserve fail-closed behavior for truly preexisting product processes without a baseline

## Why

OpenClaw 2026.7.33 performance validation twice produced a single blocked repeat while all product CPU/RSS budgets passed. The resource sampler began before `ocm service start`, but the Gateway PID became discoverable several samples later. `/proc/<pid>/stat` proved the Gateway was born after the sampler's initial Linux clock, yet the accountant rejected it as an unbaselined historical process.

For a process born after the session baseline, its cumulative Linux CPU counters cover its complete lifetime inside the measurement session. Dividing those counters by its measured lifetime gives valid evidence without importing pre-session work.

## Validation

- `npm run test:cpu-accounting` — 19 passed, 8 platform skips
- `npm run check:full` advanced through all CPU-accounting tests; the subsequent self-check isolation test hit an unrelated local JSON timeout on Node 24.15.0
- `git diff --check`

## Release evidence

- exact candidate: `f9e17bacb91b85d28456df15c504ea324c96859c`
- isolated rerun: https://github.com/openclaw/openclaw/actions/runs/34170676923
- two repeats passed; one repeat was blocked only by `Missing CPU baseline for process 32164`
- all three rerun CPU maxima were 170–174%, below the 200% threshold; RSS stayed below 1200 MB
