### PR TITLE
fix: block incomplete CPU evidence after late process discovery

### DIFF
--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -1107,7 +1107,11 @@ current interval, never as a lifetime-average percentage. Its
 bounds. Missing earlier intervals keep `cpuCoverageComplete` false and block
 qualification even if the current upper bound is below the CPU limit; later
 complete samples cannot repair the discovery gap. Existing product processes
-that predate collection still require a historical baseline.
+that predate collection still require a historical baseline. A per-process
+`cpuHistoryComplete: false` marker preserves discovery gaps if a process gains
+its product role later or transfers its counters to a wait owner, without
+discarding known CPU bounds from later intervals. An external wait owner's own
+historical host CPU does not invalidate fully observed product child CPU.
 
 For sampled commands, a Kova wait owner remains alive until the final CPU sample.
 Its own CPU and RSS are harness work and excluded from product measurements;

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -1100,6 +1100,15 @@ terminal wait accounting blocks qualification. CPU percentages may exceed 100% w
 processes execute concurrently. The collector does not sum `ps` lifetime CPU
 averages from processes of different ages.
 
+A product process born during collection but first discovered after an earlier
+sample contributes its lifetime counters as an upper bound over the common
+current interval, never as a lifetime-average percentage. Its
+`cpuIntervalComplete: false` sample excludes that work from total and role lower
+bounds. Missing earlier intervals keep `cpuCoverageComplete` false and block
+qualification even if the current upper bound is below the CPU limit; later
+complete samples cannot repair the discovery gap. Existing product processes
+that predate collection still require a historical baseline.
+
 For sampled commands, a Kova wait owner remains alive until the final CPU sample.
 Its own CPU and RSS are harness work and excluded from product measurements;
 its child accounting retains sub-second commands and the last interval before

--- a/src/collectors/linux-cpu.mjs
+++ b/src/collectors/linux-cpu.mjs
@@ -72,11 +72,12 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
   let previous = new Map();
   let previousClock;
   // A process can be born after collection starts but remain undiscovered
-  // until a later role lookup. Its lifetime counters still provide a complete
-  // baseline for this sampling session.
+  // until a later role lookup. Lifetime counters bound the latest interval's
+  // CPU, but cannot reconstruct the earlier unsampled intervals.
   let initialClock;
   let reapDebt = new Map();
   let missingWaitOwner = false;
+  let missingIntervalBaseline = false;
   return {
     lastSuccessfulClock() {
       return previousClock;
@@ -85,12 +86,13 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
       return new Set([...previous.values()].map((entry) => entry.pid));
     },
     coverageComplete() {
-      return !missingWaitOwner && ![...reapDebt.values()].some((debt) => debt.ticks > 0 && debt.processes.some((entry) => entry.roles?.length));
+      return !missingIntervalBaseline && !missingWaitOwner && ![...reapDebt.values()].some((debt) => debt.ticks > 0 && debt.processes.some((entry) => entry.roles?.length));
     },
     sample(processes, clock) {
       initialClock ??= clock;
       const nextDebt = new Map([...reapDebt].map(([key, debt]) => [key, { ...debt, processes: [...debt.processes] }]));
       let nextMissingWaitOwner = missingWaitOwner;
+      let nextMissingIntervalBaseline = missingIntervalBaseline;
       processes = processes.map((entry) => {
         const roles = [...new Set([...(previous.get(identity(entry))?.roles ?? []), ...(entry.roles ?? [])])];
         return { ...entry, roles, role: roles.join(",") };
@@ -134,10 +136,13 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
         let reapedCpuPercent = null;
         let reapedRoles = [];
         let reapedProcesses = [];
+        let cpuIntervalComplete = true;
         if (intervalTicks !== null) {
           const newlyObservedExistingOwner = !before && process.startTicks < Math.floor(previousClock.ticks) - 1;
           const bornDuringSampling = !before && process.startTicks >= Math.floor(initialClock.ticks) - 1;
           const lateSessionProcess = newlyObservedExistingOwner && bornDuringSampling;
+          cpuIntervalComplete = !lateSessionProcess;
+          if (lateSessionProcess && process.roles.length) nextMissingIntervalBaseline = true;
           if (newlyObservedExistingOwner && process.roles.length && !bornDuringSampling) {
             throw new Error(`Missing CPU baseline for process ${process.pid}`);
           }
@@ -148,8 +153,6 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
           const ownTicks = process.cpuTicks - (baseline?.cpuTicks ?? 0);
           const waitedTicks = process.childCpuTicks - (baseline?.childCpuTicks ?? 0);
           if (ownTicks < 0 || waitedTicks < 0) throw new Error(`Regressed CPU counters for process ${process.pid}`);
-          const measuredIntervalTicks = lateSessionProcess ? clock.ticks - process.startTicks : intervalTicks;
-          if (!(measuredIntervalTicks > 0)) throw new Error(`Invalid CPU lifetime interval for process ${process.pid}`);
           const debt = nextDebt.get(key) ?? { ticks: 0, processes: [] };
           const newlyReapedTicks = Math.max(0, waitedTicks - debt.ticks);
           reapedRoles = [...new Set([...(process.roles ?? []), ...debt.processes.flatMap((entry) => entry.roles ?? [])])];
@@ -158,15 +161,16 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
           else nextDebt.delete(key);
           // The accounting wrapper is harness work. Its waited-child counters
           // still contain product work, including children missed by polling.
-          ownCpuPercent = (process.pid === accountingRootPid ? 0 : ownTicks) / measuredIntervalTicks * 100;
-          reapedCpuPercent = newlyReapedTicks / measuredIntervalTicks * 100;
+          ownCpuPercent = (process.pid === accountingRootPid ? 0 : ownTicks) / intervalTicks * 100;
+          reapedCpuPercent = newlyReapedTicks / intervalTicks * 100;
         }
-        measured.push({ ...process, ownCpuPercent, reapedCpuPercent, reapedRoles, reapedProcesses,
+        measured.push({ ...process, ownCpuPercent, reapedCpuPercent, reapedRoles, reapedProcesses, cpuIntervalComplete,
           cpuPercent: ownCpuPercent === null ? null : ownCpuPercent + reapedCpuPercent });
       }
       for (const key of nextDebt.keys()) if (!current.has(key)) nextDebt.delete(key);
       reapDebt = nextDebt;
       missingWaitOwner = nextMissingWaitOwner;
+      missingIntervalBaseline = nextMissingIntervalBaseline;
       previous = current;
       previousClock = clock;
       return measured;

--- a/src/collectors/linux-cpu.mjs
+++ b/src/collectors/linux-cpu.mjs
@@ -98,6 +98,7 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
         return { ...entry, roles, role: roles.join(",") };
       });
       const current = new Map(processes.map((process) => [identity(process), process]));
+      const inheritedIncompleteHistory = new Set();
       const previousByPid = new Map([...previous.values()].map((process) => [process.pid, process]));
       const intervalTicks = previousClock === undefined ? null :
         (clock.monotonicMs - (previousClock.finishedMs ?? previousClock.monotonicMs)) * clock.hz / 1000;
@@ -121,6 +122,7 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
             debt.ticks += process.cpuTicks + process.childCpuTicks;
             debt.processes.push(process);
             nextDebt.set(ancestorKey, debt);
+            if (process.cpuHistoryComplete === false) inheritedIncompleteHistory.add(ancestorKey);
             foundWaitOwner = true;
             break;
           }
@@ -141,8 +143,7 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
           const newlyObservedExistingOwner = !before && process.startTicks < Math.floor(previousClock.ticks) - 1;
           const bornDuringSampling = !before && process.startTicks >= Math.floor(initialClock.ticks) - 1;
           const lateSessionProcess = newlyObservedExistingOwner && bornDuringSampling;
-          cpuIntervalComplete = !lateSessionProcess;
-          if (lateSessionProcess && process.roles.length) nextMissingIntervalBaseline = true;
+          cpuIntervalComplete = !newlyObservedExistingOwner;
           if (newlyObservedExistingOwner && process.roles.length && !bornDuringSampling) {
             throw new Error(`Missing CPU baseline for process ${process.pid}`);
           }
@@ -164,7 +165,11 @@ export function createLinuxCpuAccountant({ accountingRootPid } = {}) {
           ownCpuPercent = (process.pid === accountingRootPid ? 0 : ownTicks) / intervalTicks * 100;
           reapedCpuPercent = newlyReapedTicks / intervalTicks * 100;
         }
-        measured.push({ ...process, ownCpuPercent, reapedCpuPercent, reapedRoles, reapedProcesses, cpuIntervalComplete,
+        const cpuHistoryComplete = before?.cpuHistoryComplete !== false &&
+          !inheritedIncompleteHistory.has(key) && cpuIntervalComplete;
+        current.set(key, { ...process, cpuHistoryComplete });
+        if (!cpuHistoryComplete && process.roles.length) nextMissingIntervalBaseline = true;
+        measured.push({ ...process, ownCpuPercent, reapedCpuPercent, reapedRoles, reapedProcesses, cpuIntervalComplete, cpuHistoryComplete,
           cpuPercent: ownCpuPercent === null ? null : ownCpuPercent + reapedCpuPercent });
       }
       for (const key of nextDebt.keys()) if (!current.has(key)) nextDebt.delete(key);

--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -183,8 +183,10 @@ export function summarizeResourceSamples(samples) {
     sample?.collectionStatus !== "error" && Array.isArray(sample?.processes)
   );
   const failedSamples = samples.filter((sample) => sample?.collectionStatus === "error");
+  // An external wait owner's host history cannot invalidate a fully sampled product child.
   const missingCpuInterval = usableSamples.some((sample) => sample.processes.some((process) =>
-    process.cpuIntervalComplete === false && (process.roles?.length || process.reapedRoles?.length)
+    (process.roles?.length && (process.cpuIntervalComplete === false || process.cpuHistoryComplete === false)) ||
+    (process.reapedRoles?.length && process.cpuIntervalComplete === false)
   ));
   let peakTotalRssMb = null;
   let maxTotalCpuPercent = null;

--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -47,7 +47,7 @@ export function startResourceSampler(rootPid, options = {}) {
     const summary = summarizeResourceSamples(samples);
     if (cpuAccountant && !cpuAccountant.coverageComplete()) {
       summary.cpuCoverageComplete = false;
-      summary.errors.push("Terminal product CPU wait accounting is incomplete");
+      summary.errors.push("Product CPU interval or terminal wait accounting is incomplete");
     }
     if (options.artifactPath) {
       await mkdir(dirname(options.artifactPath), { recursive: true });
@@ -183,6 +183,9 @@ export function summarizeResourceSamples(samples) {
     sample?.collectionStatus !== "error" && Array.isArray(sample?.processes)
   );
   const failedSamples = samples.filter((sample) => sample?.collectionStatus === "error");
+  const missingCpuInterval = usableSamples.some((sample) => sample.processes.some((process) =>
+    process.cpuIntervalComplete === false && (process.roles?.length || process.reapedRoles?.length)
+  ));
   let peakTotalRssMb = null;
   let maxTotalCpuPercent = null;
   let maxTotalCpuPercentLower = null;
@@ -205,7 +208,7 @@ export function summarizeResourceSamples(samples) {
     peakTotalRssMb = maxNullable(peakTotalRssMb, totalRssMb);
     maxTotalCpuPercent = maxNullable(maxTotalCpuPercent, totalCpuPercent);
     if (sample.cpuUncertaintyPercent !== null && sample.cpuUncertaintyPercent !== undefined) {
-      const certain = sample.processes.reduce((sum, entry) => sum + (entry.roles.length ? entry.ownCpuPercent ?? 0 : 0), 0);
+      const certain = sample.processes.reduce((sum, entry) => sum + (entry.roles.length && entry.cpuIntervalComplete !== false ? entry.ownCpuPercent ?? 0 : 0), 0);
       maxTotalCpuPercentLower = maxNullable(maxTotalCpuPercentLower, Math.floor(Math.max(0, certain - sample.cpuUncertaintyPercent) * 10) / 10);
     }
     peakCommandTreeRssMb = maxNullable(peakCommandTreeRssMb, commandTreeRssMb);
@@ -267,13 +270,16 @@ export function summarizeResourceSamples(samples) {
     successfulSampleCount: usableSamples.length,
     failedSampleCount: failedSamples.length,
     available: usableSamples.length > 0,
-    errors: [...new Set(failedSamples.map((sample) => sample.collectionError).filter(Boolean))].slice(0, 5),
+    errors: [...new Set([
+      ...(missingCpuInterval ? ["CPU interval baseline is missing for a late-discovered product process"] : []),
+      ...failedSamples.map((sample) => sample.collectionError).filter(Boolean)
+    ])].slice(0, 5),
     intervalMs: sampleInterval(usableSamples),
     peakTotalRssMb,
     maxTotalCpuPercent,
     maxTotalCpuPercentLower,
     cpuMeasurementContract: usableSamples.find((sample) => sample.cpuMeasurementContract)?.cpuMeasurementContract ?? null,
-    cpuCoverageComplete: usableSamples.some((sample) => sample.processes.some((process) => typeof process.cpuPercent === "number")) && failedSamples.length === 0,
+    cpuCoverageComplete: !missingCpuInterval && usableSamples.some((sample) => sample.processes.some((process) => typeof process.cpuPercent === "number")) && failedSamples.length === 0,
     peakCommandTreeRssMb,
     peakGatewayRssMb,
     byRole: roleSummaries,
@@ -663,7 +669,7 @@ function updateRolePeaks(byRole, sample) {
       if (typeof process.ownCpuPercent === "number") {
         total.cpuPercent = (total.cpuPercent ?? 0) + (ownsRole ? process.ownCpuPercent : 0) +
           (process.reapedRoles.includes(role) ? process.reapedCpuPercent : 0);
-        total.cpuCertainPercent = (total.cpuCertainPercent ?? 0) + (ownsRole ? process.ownCpuPercent : 0);
+        total.cpuCertainPercent = (total.cpuCertainPercent ?? 0) + (ownsRole && process.cpuIntervalComplete !== false ? process.ownCpuPercent : 0);
       } else if (typeof process.cpuPercent === "number") total.cpuPercent = (total.cpuPercent ?? 0) + process.cpuPercent;
       total.processCount += 1;
       if (!total.topRssProcess || process.rssMb > total.topRssProcess.rssMb) {

--- a/tests/linux-cpu-accounting.mjs
+++ b/tests/linux-cpu-accounting.mjs
@@ -131,6 +131,43 @@ test("late discovery of a roleless wait owner does not invalidate product covera
   assert.equal(accountant.coverageComplete(), true);
 });
 
+test("a discovery gap follows an identity when a product role is assigned later", () => {
+  for (const startTicks of [0, 1020]) {
+    const accountant = createLinuxCpuAccountant();
+    accountant.sample([], clock(10));
+    accountant.sample([], clock(11));
+    const owner = processRow(2, 0, 240, 0, startTicks);
+    accountant.sample([owner], clock(15));
+    assert.equal(accountant.coverageComplete(), true);
+    const processes = accountant.sample([{ ...owner, cpuTicks: 260, roles: ["gateway"] }], clock(16));
+    const summary = summarizeResourceSamples([{ processes, collectionStatus: "ok", cpuUncertaintyPercent: 0 }]);
+    assert.equal(summary.byRole.gateway.maxCpuPercent, 20);
+    assert.equal(summary.byRole.gateway.maxCpuPercentLower, 20, "the current interval is known despite the historical gap");
+    assert.equal(summary.cpuCoverageComplete, false);
+    assert.equal(accountant.coverageComplete(), false);
+  }
+});
+
+test("reaping preserves a roleless child's discovery gap for a later product owner", () => {
+  for (const startTicks of [0, 1020]) {
+    for (const roleAtReap of [true, false]) {
+      const accountant = createLinuxCpuAccountant();
+      const owner = processRow(1, 0, 0);
+      accountant.sample([owner], clock(10));
+      accountant.sample([owner], clock(11));
+      accountant.sample([owner, processRow(2, 1, 240, 0, startTicks)], clock(15));
+      let processes = accountant.sample([{ ...owner, childCpuTicks: 260, roles: roleAtReap ? ["gateway"] : [] }], clock(16));
+      if (!roleAtReap) {
+        assert.equal(accountant.coverageComplete(), true);
+        processes = accountant.sample([{ ...owner, cpuTicks: 20, childCpuTicks: 260, roles: ["gateway"] }], clock(17));
+      }
+      const summary = summarizeResourceSamples([{ processes, collectionStatus: "ok", cpuUncertaintyPercent: 0 }]);
+      assert.equal(summary.cpuCoverageComplete, false);
+      assert.equal(accountant.coverageComplete(), false);
+    }
+  }
+});
+
 test("missing CPU counter coverage blocks qualification rather than passing as zero", () => {
   const record = { status: "PASS", phases: [{ id: "status", measurementScope: "product", results: [{
     command: "openclaw status", status: 0, stdout: "", stderr: "", durationMs: 10, resourceSamples: { sampleCount: 2, cpuMeasurementContract: process.platform === "linux" ? "linux-process-interval-v1" : "ps-process-cpu-v1", cpuCoverageComplete: false, errors: ["missing CPU baseline"] }
@@ -323,4 +360,6 @@ test("a new Gateway introduces its existing wait owner without importing host CP
   assert.equal(retired.reapedCpuPercent, 10);
   assert.deepEqual(retired.reapedRoles, ["gateway"]);
   assert.equal(accountant.coverageComplete(), true);
+  const summary = summarizeResourceSamples([{ processes: completed, collectionStatus: "ok", cpuUncertaintyPercent: 0 }]);
+  assert.equal(summary.cpuCoverageComplete, true, "an external owner's historical host CPU does not invalidate a fully sampled product child");
 });

--- a/tests/linux-cpu-accounting.mjs
+++ b/tests/linux-cpu-accounting.mjs
@@ -56,17 +56,80 @@ test("counter regression and a missing historical baseline fail closed", () => {
   assert.throws(() => fresh.sample([processRow(1, 0, 100), { ...processRow(2, 1, 100), roles: ["gateway"] }], clock(11)), /Missing CPU baseline/);
 });
 
-test("a product process born during sampling can be discovered from lifetime counters", () => {
+test("late-discovered product CPU keeps interval bounds and incomplete coverage", () => {
   const accountant = createLinuxCpuAccountant();
   accountant.sample([processRow(1, 0, 100)], clock(10));
   accountant.sample([processRow(1, 0, 100)], clock(11));
   const gateway = { ...processRow(2, 1, 240, 0, 1020), roles: ["gateway"] };
   const measured = accountant.sample([processRow(1, 0, 100), gateway], clock(15));
-  assert.equal(measured.find((entry) => entry.pid === 2).cpuPercent, 50);
+  assert.equal(measured.find((entry) => entry.pid === 2).cpuPercent, 60);
+  assert.equal(accountant.coverageComplete(), false);
+  const summary = summarizeResourceSamples([{ processes: measured, collectionStatus: "ok", cpuUncertaintyPercent: 0 }]);
+  assert.equal(summary.byRole.gateway.maxCpuPercentLower, 0);
+  assert.equal(summary.cpuCoverageComplete, false);
+  const record = { status: "PASS", phases: [{ id: "status", measurementScope: "product", results: [{
+    command: "openclaw status", status: 0, stdout: "", stderr: "", durationMs: 5000, resourceSamples: summary
+  }] }] };
+  evaluateRecord(record, {}, {});
+  assert.equal(record.status, "BLOCKED", "unobserved earlier bursts cannot qualify even when the latest upper bound is small");
+  assert.ok(record.violations.some((violation) => violation.metric === "resourceCpuCoverage"));
+  accountant.sample([processRow(1, 0, 100), { ...gateway, cpuTicks: 260 }], clock(16));
+  assert.equal(accountant.coverageComplete(), false, "later intervals cannot repair an earlier discovery gap");
+});
+
+test("late discovery cannot average a 225% CPU burst into a passing lifetime value", () => {
+  const accountant = createLinuxCpuAccountant();
+  accountant.sample([], clock(10));
+  accountant.sample([], clock(11));
+  const processes = accountant.sample([{ ...processRow(2, 0, 900, 0, 1020), roles: ["gateway"] }], clock(15));
+  const summary = summarizeResourceSamples([{ processes, collectionStatus: "ok", cpuUncertaintyPercent: 0 }]);
+  assert.equal(summary.byRole.gateway.maxCpuPercent, 225);
+  assert.equal(summary.byRole.gateway.maxCpuPercentLower, 0);
+  const violations = [];
+  checkCpuThreshold(violations, { kind: "resource", metric: "cpu", label: "CPU", value: summary.byRole.gateway.maxCpuPercent,
+    lower: summary.byRole.gateway.maxCpuPercentLower, threshold: 200 });
+  assert.equal(violations[0]?.kind, "evidence");
+  assert.equal(violations[0]?.failureDomain, "kova-harness");
+});
+
+test("mixed discovery times do not import uncertain CPU into total or role lower bounds", () => {
+  const accountant = createLinuxCpuAccountant();
+  const known = { ...processRow(1, 0, 0), roles: ["gateway"] };
+  accountant.sample([known], clock(10));
+  accountant.sample([known], clock(11));
+  const processes = accountant.sample([{ ...known, cpuTicks: 400 },
+    { ...processRow(2, 0, 900, 0, 1020), roles: ["gateway"] }], clock(15));
+  const summary = summarizeResourceSamples([{ processes, collectionStatus: "ok", cpuUncertaintyPercent: 0 }]);
+  assert.equal(summary.maxTotalCpuPercent, 325);
+  assert.equal(summary.maxTotalCpuPercentLower, 100);
+  assert.equal(summary.byRole.gateway.maxCpuPercent, 325);
+  assert.equal(summary.byRole.gateway.maxCpuPercentLower, 100);
+  assert.equal(summary.cpuCoverageComplete, false);
+});
+
+test("a rejected late-discovery census cannot poison interval coverage", () => {
+  const accountant = createLinuxCpuAccountant();
+  const known = { ...processRow(1, 0, 100), roles: ["gateway"] };
+  accountant.sample([known], clock(10));
+  accountant.sample([known], clock(11));
+  assert.throws(() => accountant.sample([
+    { ...processRow(2, 0, 240, 0, 1020), roles: ["gateway"] }, { ...known, cpuTicks: 90 }
+  ], clock(15)), /Regressed/);
+  accountant.sample([{ ...known, cpuTicks: 200 }], clock(16));
   assert.equal(accountant.coverageComplete(), true);
 });
 
-
+test("late discovery of a roleless wait owner does not invalidate product coverage", () => {
+  const accountant = createLinuxCpuAccountant();
+  const known = { ...processRow(1, 0, 0), roles: ["gateway"] };
+  accountant.sample([known], clock(10));
+  accountant.sample([known], clock(11));
+  const processes = accountant.sample([{ ...known, cpuTicks: 100 }, processRow(2, 0, 0, 0, 1020)], clock(15));
+  const summary = summarizeResourceSamples([{ processes, collectionStatus: "ok", cpuUncertaintyPercent: 0 }]);
+  assert.equal(summary.cpuCoverageComplete, true);
+  assert.deepEqual(summary.errors, []);
+  assert.equal(accountant.coverageComplete(), true);
+});
 
 test("missing CPU counter coverage blocks qualification rather than passing as zero", () => {
   const record = { status: "PASS", phases: [{ id: "status", measurementScope: "product", results: [{


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Linux release validation could qualify CPU evidence after discovering a product process several samples late. A 225% burst in the latest interval could be reported as a passing 187.5% lifetime average.

Related: #112 and its interval-accounting review finding.

## Why This Change Was Made

Keep the session-birth detection introduced by @RomneyDa, but divide its counters by the common sample interval to obtain a conservative upper bound. Exclude temporally uncertain work from both total and per-role lower bounds. Missing earlier intervals remain incomplete evidence and block qualification even when the current upper bound is below the CPU limit; later samples cannot reconstruct that gap. Existing historical-process baseline rejection and CPU thresholds are preserved.

## User Impact

Delayed Gateway discovery can no longer silently qualify an unobserved CPU burst or turn uncertain CPU into a product failure. Reports retain the useful upper-bound measurements and explain why a fresh, complete run is required.

## Evidence

The pre-fix reproduction reports 187.5%, complete coverage, and no violation for a 225% interval. Regression coverage exercises that burst, mixed process discovery times, missing earlier intervals below the limit, rejected-census rollback, and roleless wait owners.

Changelog and release notes are intentionally collected in a separate final notes PR.

Validation of `ec413bc38f86964ca2636eb2caedf94eb7349b36` (remote source SHA-256 values matched the committed collector and regression-test files):

- Linux: `npm run test:cpu-accounting` passed 33/33 with no skips, including real command processes, short-lived children, parallel CPU, timeouts, inherited output pipes, and the new discovery-history regressions.
- Four live CPU workers independently consumed at least 364.9% CPU; the collector measured a 440.8% peak with complete terminal coverage. The production threshold remains 200%.
- Real Linux counter comparison using the same live process: main reported `PASS`, complete coverage, and 20.6% CPU; the fixed accountant reported `BLOCKED`, incomplete coverage, and a conservative 26.7% upper bound with a zero lower bound.
- Exercised production `startResourceSampler` with actual `ps` discovery and `/proc` counters. Only the OCM PID lookup was a controlled discovery fixture; the CPU workload and collection were real. A process created after collection began was returned at the normal later lookup: 10 samples, `BLOCKED`, coverage false, 70% upper bound. A fresh sampler observing the same process from its first census collected 5 samples and returned `PASS`, coverage true, 59.8% CPU, with no errors.
- The deterministic 225% burst regression no longer becomes a passing 187.5% lifetime average. Tests also cover later role assignment, pre-existing roleless processes, counter transfer to wait owners, rejected-census rollback, and fully observed product children of external supervisors.
- Packaged and installed the exact source into a disposable Linux prefix outside the checkout. The installed CLI reported 0.1.4, emitted valid plan JSON, passed `setup --ci --json`, and passed all 280 installed self-checks.
- Full check suites passed during development on Linux and macOS. On this Mac, the release-contract script required system Bash 3.2.57 after Homebrew Bash 5.3.15 stalled in a heredoc write; the same script passed unchanged.

The follow-up commit preserves discovery gaps through later product attribution and reaping. An external supervisor's unrelated historical host CPU does not invalidate a fully observed product child. Release notes and contributor credit are collected in #114.

Final gates: committed-branch Codex autoreview against `origin/main` is clean through P2 with full collector context. CI passed on this exact head, including macOS/Linux full checks and packaged-install smoke: https://github.com/openclaw/Kova/actions/runs/34178652555. The isolated Linux proof machine was released after validation.
