### PR TITLE
chore: refresh validation dependencies and prepare 0.1.5 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to Kova are documented in this file.
 
 ## [0.1.5] - Unreleased
 
+**Highlights:** Linux CPU validation now measures process lifetimes without mistaking serial work for parallel load or qualifying incomplete interval evidence.
+
 ### Fixed
 
-- Fix Linux CPU accounting so serial parent/child work is not reported as concurrent CPU, short commands retain final CPU evidence, and incomplete measurements cannot qualify a release.
+- Measure Linux CPU over common intervals so serial parent/child work is not reported as concurrent CPU, short commands retain final CPU evidence, and incomplete measurements cannot qualify a release. (#110)
+- Keep late-discovered process CPU as conservative interval evidence and block qualification when earlier intervals are missing, instead of allowing lifetime averages to hide CPU bursts. Thanks @RomneyDa. (#112)
+- Support Node executable paths containing spaces in the CPU-accounting regression workload. Thanks @vincentkoc. (#111)
+
+### Internal
+
+- Refresh the checksum-verified OCM CI runtime to 0.2.41 and website Node.js types to 26.5.0.
 
 ## [0.1.4] - 2026-09-05
 

--- a/scripts/install-ocm-ci.sh
+++ b/scripts/install-ocm-ci.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="v0.2.38"
+version="v0.2.41"
 case "$(uname -s):$(uname -m)" in
   Linux:x86_64)
     asset="ocm-x86_64-unknown-linux-gnu.tar.gz"
-    expected_sha256="436f1bee1759b39b36a3011bfca273135acde89ac2763052ae14b2e0137ed117"
+    expected_sha256="e57dc642d70310f8bf19096c0fc41aab0325c8fab24b9ed0c6367c60a02b6198"
     ;;
   Darwin:arm64)
     asset="ocm-aarch64-apple-darwin.tar.gz"
-    expected_sha256="354f932b80a2d04afd9315b67fd1ad48e52b4e9466db05c01d1db4c56c794bdb"
+    expected_sha256="99640a65ecc4d8175c76c4336b3b9b3a4c8f9877f40a4b6d9c4ce4c66330b83c"
     ;;
   *)
     echo "unsupported OCM CI platform: $(uname -s) $(uname -m)" >&2

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
-        "@types/node": "^26.4.1",
+        "@types/node": "^26.5.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "npm:@typescript/typescript6@^6.0.2"
       }
@@ -2336,13 +2336,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
-      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~8.9.0"
       }
     },
     "node_modules/@types/unist": {
@@ -5020,9 +5020,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
-    "@types/node": "^26.4.1",
+    "@types/node": "^26.5.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2"
   },


### PR DESCRIPTION
## What Problem This Solves

Refresh the validation toolchain and prepare the complete 0.1.5 patch notes for Linux CPU accounting fixes since v0.1.4.

## Why This Change Was Made

Update the checksum-verified OCM CI runtime from 0.2.38 to 0.2.41 and website Node.js types from 26.4.1 to 26.5.0, including the matching Undici type dependency. Both OCM archive digests were independently verified against the published release assets. CLI dependencies and GitHub Actions pins are current.

## User Impact

Release notes lead with corrected Linux CPU accounting, retain contributor credit, and cover the delayed-discovery repair. This is the final notes PR and must land after #113. No version change, tag, or publication is included.

## Evidence

Website unit tests, Astro checks, and production build passed. Chrome rendered the generated dashboard and matrix and successfully switched the matrix to heatmap view. There is no visual source change.

Validation of `ae1923ec4e4f491a97fffa8e581dff6b15bdf6ea`:

- Downloaded both OCM 0.2.41 archives and independently matched their SHA-256 hashes to the release asset digests: macOS ARM64 `99640a65ecc4d8175c76c4336b3b9b3a4c8f9877f40a4b6d9c4ce4c66330b83c`; Linux x64 `e57dc642d70310f8bf19096c0fc41aab0325c8fab24b9ed0c6367c60a02b6198`.
- With the real OCM 0.2.41 macOS binary on PATH, ran the full Kova checks, then packaged and installed Kova into a disposable prefix outside the checkout. The installed CLI reported 0.1.4, emitted valid plan JSON, passed `setup --ci --json`, and passed all 280 installed self-checks.
- The local release-contract script stalled inside Homebrew Bash 5.3.15's heredoc write, including a retry with a fresh private temp directory. The identical script passed with macOS system Bash 3.2.57. All other full-suite components passed.
- Website: `npm ci --include=dev`, `npm test` (6/6), `npm run check` (0 errors, one existing Zod deprecation hint), and `npm run build` (18 pages) passed. Chrome rendered the production build, navigated to Matrix, and successfully selected Heatmap.
- Codex autoreview of the committed branch against `origin/main` is clean through P2.

Land after #113. The package version remains 0.1.4 until a separately authorized release-preparation step.

CI passed on the exact head, including macOS and Linux full checks plus packaged-install smoke: https://github.com/openclaw/Kova/actions/runs/34178029194.
