### PR TITLE
chore(release): bump version to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shakkernerd/kova",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shakkernerd/kova",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "cli-truncate": "^6.1.1",
         "json5": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shakkernerd/kova",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "OpenClaw runtime validation lab",
   "type": "module",


### PR DESCRIPTION
## What Problem This Solves

Prepares the version metadata for v0.1.5 through the normal review and CI path.

## Why This Change Was Made

This pull request contains only the package version bump. Squash-merge it so the exact merge commit can pass the main-branch CI gate before the signed release tag is created.

## User Impact

No runtime behavior changes. Release metadata is reviewed and validated before publication.

## Evidence

- Version metadata is limited to `package.json` and `package-lock.json`.
- Pull-request CI is the validation gate.
- After merge, rerun `scripts/release.sh 0.1.5 --remote origin`.
