### PR TITLE
fix(perf): restore status CLI CPU ceiling

### DIFF
--- a/surfaces/cross-platform-smoke.json
+++ b/surfaces/cross-platform-smoke.json
@@ -19,7 +19,7 @@
     },
     "status-cli": {
       "peakRssMb": 500,
-      "maxCpuPercent": 250
+      "maxCpuPercent": 200
     }
   },
   "diagnostics": {

--- a/surfaces/fresh-install.json
+++ b/surfaces/fresh-install.json
@@ -31,7 +31,7 @@
     },
     "status-cli": {
       "peakRssMb": 900,
-      "maxCpuPercent": 250
+      "maxCpuPercent": 200
     },
     "plugin-cli": {
       "peakRssMb": 900,

--- a/surfaces/gateway-performance.json
+++ b/surfaces/gateway-performance.json
@@ -36,7 +36,7 @@
     },
     "status-cli": {
       "peakRssMb": 900,
-      "maxCpuPercent": 250
+      "maxCpuPercent": 200
     },
     "plugin-cli": {
       "peakRssMb": 950,

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -712,7 +712,7 @@
         },
         "status-cli": {
           "peakRssMb": 500,
-          "maxCpuPercent": 250
+          "maxCpuPercent": 200
         }
       },
       "diagnostics": {
@@ -1086,7 +1086,7 @@
         },
         "status-cli": {
           "peakRssMb": 900,
-          "maxCpuPercent": 250
+          "maxCpuPercent": 200
         },
         "plugin-cli": {
           "peakRssMb": 900,
@@ -1184,7 +1184,7 @@
         },
         "status-cli": {
           "peakRssMb": 900,
-          "maxCpuPercent": 250
+          "maxCpuPercent": 200
         },
         "plugin-cli": {
           "peakRssMb": 950,


### PR DESCRIPTION
Related: #116
Companion OpenClaw fix: openclaw/openclaw#141935

## What Problem This Solves

Fixes an issue where Kova's shared status CLI CPU policy was loosened globally to accommodate a single historical OpenClaw release candidate.

## Why This Change Was Made

Restores the three status CLI ceilings and their plan snapshots from 250% to the normal 200%. The exceptional allowance belongs in the OpenClaw release-validation workflow that selects the affected target.

## User Impact

Kova again enforces the calibrated 200% status CLI CPU ceiling for current and future targets.

## Evidence

- Kova self-check: 280/280 passed
- Snapshot suite: 21/21 passed with an isolated HOME (avoids local path wrapping)
- Web payload and release-contract checks passed
- `git diff --check` passed
