### PR TITLE
fix(cpu): exclude process census from scan uncertainty

### DIFF
--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -62,14 +62,6 @@ export function startResourceSampler(rootPid, options = {}) {
   }
 
   function sample(attempt = 1) {
-    let cpuClock;
-    try {
-      cpuClock = cpuAccountant ? readLinuxCpuClock() : null;
-    } catch (error) {
-      samples.push({ timestamp: new Date().toISOString(), elapsedMs: Date.now() - startedAt,
-        rootPid, gatewayPid, collectionStatus: "error", collectionError: error.message, processes: [] });
-      return;
-    }
     const processResult = (options.processLister ?? listProcesses)(options.redactValues ?? []);
     if (!processResult.ok) {
       samples.push({
@@ -139,9 +131,13 @@ export function startResourceSampler(rootPid, options = {}) {
     }
 
     let measured = tracked;
+    let cpuClock = null;
     let cpuUncertaintyPercent = null;
     if (cpuAccountant) {
       try {
+        // Process discovery is not part of the counter snapshot. Starting the
+        // clock earlier inflates uncertainty with unrelated `ps` latency.
+        cpuClock = readLinuxCpuClock();
         const counters = readLinuxCpuSnapshot(tracked, cpuAccountant.trackedProcessIds());
         cpuClock.finishedMs = performance.now();
         const previousEnd = cpuAccountant.lastSuccessfulClock()?.finishedMs;

--- a/tests/linux-cpu-accounting.mjs
+++ b/tests/linux-cpu-accounting.mjs
@@ -251,7 +251,9 @@ test("process census latency stays outside the CPU counter uncertainty window", 
     now += 1000;
     cpuTicks = 100;
     const summary = await sampler.stop();
-    assert.equal(summary.maxTotalCpuPercentLower, summary.maxTotalCpuPercent);
+    // The summary rounds the upper bound up and the lower bound down. With no
+    // scan uncertainty, they can therefore differ by at most one tenth.
+    assert.ok(summary.maxTotalCpuPercent - summary.maxTotalCpuPercentLower <= 0.1);
   } finally {
     mock.restoreAll();
     syncBuiltinESMExports();

--- a/tests/linux-cpu-accounting.mjs
+++ b/tests/linux-cpu-accounting.mjs
@@ -1,8 +1,9 @@
 import fs from "node:fs";
+import childProcess from "node:child_process";
 import { syncBuiltinESMExports } from "node:module";
 import assert from "node:assert/strict";
 import test, { mock } from "node:test";
-import { summarizeResourceSamples } from "../src/collectors/resources.mjs";
+import { startResourceSampler, summarizeResourceSamples } from "../src/collectors/resources.mjs";
 import { checkCpuThreshold } from "../src/evaluation/violations.mjs";
 import { evaluateRecord } from "../src/evaluator.mjs";
 import { createLinuxCpuAccountant, readLinuxCpuSnapshot, LinuxCpuSnapshotChangedError } from "../src/collectors/linux-cpu.mjs";
@@ -216,6 +217,45 @@ test("counter scan brackets yield conservative bounds and never an invented CPU 
   const below = [];
   checkCpuThreshold(below, { kind: "resource", metric: "cpu", label: "CPU", value: 199, lower: 180, threshold: 200 });
   assert.deepEqual(below, []);
+});
+
+test("process census latency stays outside the CPU counter uncertainty window", {
+  skip: process.platform !== "linux"
+}, async () => {
+  let now = 0;
+  let cpuTicks = 0;
+  const originalRead = fs.readFileSync;
+  const originalSpawn = childProcess.spawnSync;
+  mock.method(performance, "now", () => now);
+  mock.method(childProcess, "spawnSync", (command) => {
+    if (command === "getconf") return { status: 0, stdout: "100\n" };
+    if (command === "ps") {
+      now += 100;
+      return { status: 0, pid: 999, stdout: "1 0 1024 0 node\n" };
+    }
+    return originalSpawn(command);
+  });
+  mock.method(fs, "readFileSync", (path, ...args) => {
+    if (path === "/proc/uptime") return `${now / 1000} 0\n`;
+    if (path === "/proc/1/stat") {
+      const fields = Array(22).fill("0");
+      fields[0] = "S";
+      fields[11] = String(cpuTicks);
+      return `1 (node) ${fields.join(" ")}`;
+    }
+    return originalRead(path, ...args);
+  });
+  syncBuiltinESMExports();
+  try {
+    const sampler = startResourceSampler(1);
+    now += 1000;
+    cpuTicks = 100;
+    const summary = await sampler.stop();
+    assert.equal(summary.maxTotalCpuPercentLower, summary.maxTotalCpuPercent);
+  } finally {
+    mock.restoreAll();
+    syncBuiltinESMExports();
+  }
 });
 
 test("qualification rejects missing and historical CPU contracts", () => {


### PR DESCRIPTION
## Summary

- start the Linux CPU snapshot clock after process discovery
- keep the clock bracketing only the `/proc` counter census it bounds
- prove 100ms of process-list latency does not reduce the measured CPU lower bound

## Root cause

`startResourceSampler` read the CPU clock before invoking `ps`. The uncertainty calculation therefore charged the process census to the `/proc` counter scan. In OpenClaw release validation this widened a gateway observation from a 308.1% upper bound down to a 229.4% lower bound—about 79 percentage points of uncertainty—and made Kova return `BLOCKED`.

Kova is correct to block inconclusive evidence; the measurement window was wrong. This fixes the producer rather than teaching OpenClaw to accept a blocked gate.

## Verification

- `npm run test:cpu-accounting` (25 passed locally; Linux-only regression runs in CI)
- `npm run check` reached the unrelated existing selfcheck-isolation timeout fixture after focused suites passed
- production `+4/-8` (net -4); tests `+41/-1`
