### PR TITLE
fix(cpu): discover starting gateway on next sample

### DIFF
--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -84,7 +84,10 @@ export function startResourceSampler(rootPid, options = {}) {
       }
       if (gatewayPid === null && samples.length >= nextGatewayLookupSample) {
         gatewayPid = lookupGatewayPid(options.envName, options.commandEnv);
-        nextGatewayLookupSample = samples.length + 5;
+        // Startup sampling begins before the gateway exists. Retrying on the
+        // next sample lets the CPU accountant establish the gateway's zero
+        // baseline while its birth still falls inside the current interval.
+        nextGatewayLookupSample = samples.length + 1;
       }
     }
 

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -21604,15 +21604,15 @@ exec /bin/sh -c "$2"
       "live gateway pid reused across samplers"
     );
     assertEqual(
-      lookups.filter((line) => line.includes(missingEnvName)).length,
-      1,
-      "missing gateway pid lookup backs off"
+      lookups.filter((line) => line.includes(missingEnvName)).length >= 3,
+      true,
+      "missing gateway pid lookup retries on the next sample"
     );
     assertEqual(missingSummary.sampleCount >= 3, true, "missing gateway sampler collected repeated samples");
     return {
       id: "resource-gateway-pid-lookups",
       status: "PASS",
-      command: "reuse live gateway pid and back off missing pid lookups",
+      command: "reuse live gateway pid and retry missing pid lookups",
       durationMs: 600
     };
   } catch (error) {


### PR DESCRIPTION
## Summary
- retry a missing gateway PID on the next resource sample instead of waiting five samples
- preserve cached PID reuse after discovery
- prove missing startup PIDs are retried at sampling cadence

## Root cause

Kova starts CPU sampling before gateway-start/provision commands. The initial OCM lookup therefore sees no gateway, and the five-sample backoff delays discovery until the gateway predates the immediately previous CPU snapshot. Its initial CPU baseline is then irrecoverable, correctly producing BLOCKED evidence.

Retrying on the next sample discovers a newly born gateway while its zero baseline is still provable from the previous snapshot. This fixes evidence production without weakening the release gate.

Observed in [OpenClaw proof 34208309908](https://github.com/openclaw/openclaw/actions/runs/34208309908): 12 BLOCKED records, all caused by late gateway discovery; every CPU lower bound remained below its threshold.

## Validation
- node --test tests/linux-cpu-accounting.mjs (25 passed, 1 platform skip)
- node bin/kova.mjs self-check (280/280 passed)
