### PR TITLE
fix(cpu): refresh census after gateway discovery

### DIFF
--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -62,7 +62,8 @@ export function startResourceSampler(rootPid, options = {}) {
   }
 
   function sample(attempt = 1) {
-    const processResult = (options.processLister ?? listProcesses)(options.redactValues ?? []);
+    const processLister = options.processLister ?? listProcesses;
+    const processResult = processLister(options.redactValues ?? []);
     if (!processResult.ok) {
       samples.push({
         timestamp: new Date().toISOString(),
@@ -75,7 +76,7 @@ export function startResourceSampler(rootPid, options = {}) {
       });
       return;
     }
-    const allProcesses = processResult.processes;
+    let allProcesses = processResult.processes;
     if (options.envName) {
       const knownGatewayPid = gatewayPid ?? gatewayPidsByEnv.get(options.envName) ?? null;
       gatewayPid = liveGatewayPid(options.envName, gatewayPid, allProcesses);
@@ -83,11 +84,21 @@ export function startResourceSampler(rootPid, options = {}) {
         nextGatewayLookupSample = samples.length;
       }
       if (gatewayPid === null && samples.length >= nextGatewayLookupSample) {
-        gatewayPid = lookupGatewayPid(options.envName, options.commandEnv);
+        gatewayPid = (options.gatewayPidLookup ?? lookupGatewayPid)(options.envName, options.commandEnv);
         // Startup sampling begins before the gateway exists. Retrying on the
         // next sample lets the CPU accountant establish the gateway's zero
         // baseline while its birth still falls inside the current interval.
         nextGatewayLookupSample = samples.length + 1;
+      }
+      // The gateway can be born after the census above but before OCM returns
+      // its PID. Refresh immediately so the CPU accountant records the process
+      // in the same interval in which it was discovered instead of first
+      // observing its already-accumulated lifetime counters a sample later.
+      if (gatewayPid !== null && !allProcesses.some((process) => process.pid === gatewayPid)) {
+        const refreshed = processLister(options.redactValues ?? []);
+        if (refreshed.ok) {
+          allProcesses = refreshed.processes;
+        }
       }
     }
 

--- a/tests/linux-cpu-accounting.mjs
+++ b/tests/linux-cpu-accounting.mjs
@@ -12,6 +12,23 @@ const clock = (seconds) => ({ hz: 100, ticks: seconds * 100, monotonicMs: second
 const processRow = (pid, ppid, cpuTicks, childCpuTicks = 0, startTicks = 0) => ({ pid, ppid, cpuTicks, childCpuTicks, startTicks, rssMb: 0, command: "synthetic", roles: [] });
 const cpu = (rows) => rows.reduce((total, row) => total + (row.cpuPercent ?? 0), 0);
 
+test("gateway discovery refreshes a census that predates gateway birth", async () => {
+  let censusCount = 0;
+  const root = { pid: 1, ppid: 0, rssKb: 1, rssMb: 1, cpuPercent: 0, command: "kova" };
+  const gateway = { pid: 2, ppid: 1, rssKb: 2, rssMb: 2, cpuPercent: 0, command: "openclaw-gateway" };
+  const sampler = startResourceSampler(1, {
+    envName: `gateway-census-refresh-${Date.now()}`,
+    processLister() {
+      censusCount += 1;
+      return { ok: true, processes: censusCount === 1 ? [root] : [root, gateway] };
+    },
+    gatewayPidLookup: () => 2
+  });
+  const summary = await sampler.stop();
+  assert.ok(censusCount >= 2);
+  assert.equal(summary.byRole.gateway.peakRssMb, 2);
+});
+
 test("serial parent and newborn child use the same CPU interval", () => {
   const accountant = createLinuxCpuAccountant();
   accountant.sample([processRow(1, 0, 0)], clock(0));


### PR DESCRIPTION
## Summary
- refresh the process census immediately when OCM discovers a gateway PID that the preceding census did not contain
- keep strict incomplete-history behavior for genuinely late process discovery
- add a regression test for the census/lookup race

## Root cause

Kova #119 retries missing gateway PID lookups at sampling cadence, but each sample took its process census before querying OCM. When the gateway was born between those operations, OCM returned its PID while the stale census omitted it. The accountant first saw the gateway one full sample later with accumulated lifetime CPU, correctly marking history incomplete.

Observed in [OpenClaw proof 34211366482](https://github.com/openclaw/openclaw/actions/runs/34211366482): #119 improved the selected matrix from 12 BLOCKED records to 2, but repeat 3 of `fresh-install/fresh` and `bundled-plugin-startup/fresh` still hit this race. Both had actual gateway CPU below threshold.

## Validation
- `npm run test:cpu-accounting` (26 passed, 9 platform skips)
- `npm run test:assert-command-output`
- `npm run test:selfcheck-isolation`
- `node bin/kova.mjs self-check` (280/280 passed)
