### PR TITLE
fix(compat): retain 7.33 calibration with corrected CPU accounting

### DIFF
--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -62,7 +62,8 @@ export function startResourceSampler(rootPid, options = {}) {
   }
 
   function sample(attempt = 1) {
-    const processResult = (options.processLister ?? listProcesses)(options.redactValues ?? []);
+    const processLister = options.processLister ?? listProcesses;
+    const processResult = processLister(options.redactValues ?? []);
     if (!processResult.ok) {
       samples.push({
         timestamp: new Date().toISOString(),
@@ -75,7 +76,7 @@ export function startResourceSampler(rootPid, options = {}) {
       });
       return;
     }
-    const allProcesses = processResult.processes;
+    let allProcesses = processResult.processes;
     if (options.envName) {
       const knownGatewayPid = gatewayPid ?? gatewayPidsByEnv.get(options.envName) ?? null;
       gatewayPid = liveGatewayPid(options.envName, gatewayPid, allProcesses);
@@ -83,11 +84,21 @@ export function startResourceSampler(rootPid, options = {}) {
         nextGatewayLookupSample = samples.length;
       }
       if (gatewayPid === null && samples.length >= nextGatewayLookupSample) {
-        gatewayPid = lookupGatewayPid(options.envName, options.commandEnv);
+        gatewayPid = (options.gatewayPidLookup ?? lookupGatewayPid)(options.envName, options.commandEnv);
         // Startup sampling begins before the gateway exists. Retrying on the
         // next sample lets the CPU accountant establish the gateway's zero
         // baseline while its birth still falls inside the current interval.
         nextGatewayLookupSample = samples.length + 1;
+      }
+      // The gateway can be born after the census above but before OCM returns
+      // its PID. Refresh immediately so the CPU accountant records the process
+      // in the same interval in which it was discovered instead of first
+      // observing its already-accumulated lifetime counters a sample later.
+      if (gatewayPid !== null && !allProcesses.some((process) => process.pid === gatewayPid)) {
+        const refreshed = processLister(options.redactValues ?? []);
+        if (refreshed.ok) {
+          allProcesses = refreshed.processes;
+        }
       }
     }
 

--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -84,7 +84,10 @@ export function startResourceSampler(rootPid, options = {}) {
       }
       if (gatewayPid === null && samples.length >= nextGatewayLookupSample) {
         gatewayPid = lookupGatewayPid(options.envName, options.commandEnv);
-        nextGatewayLookupSample = samples.length + 5;
+        // Startup sampling begins before the gateway exists. Retrying on the
+        // next sample lets the CPU accountant establish the gateway's zero
+        // baseline while its birth still falls inside the current interval.
+        nextGatewayLookupSample = samples.length + 1;
       }
     }
 

--- a/src/collectors/resources.mjs
+++ b/src/collectors/resources.mjs
@@ -62,14 +62,6 @@ export function startResourceSampler(rootPid, options = {}) {
   }
 
   function sample(attempt = 1) {
-    let cpuClock;
-    try {
-      cpuClock = cpuAccountant ? readLinuxCpuClock() : null;
-    } catch (error) {
-      samples.push({ timestamp: new Date().toISOString(), elapsedMs: Date.now() - startedAt,
-        rootPid, gatewayPid, collectionStatus: "error", collectionError: error.message, processes: [] });
-      return;
-    }
     const processResult = (options.processLister ?? listProcesses)(options.redactValues ?? []);
     if (!processResult.ok) {
       samples.push({
@@ -139,9 +131,13 @@ export function startResourceSampler(rootPid, options = {}) {
     }
 
     let measured = tracked;
+    let cpuClock = null;
     let cpuUncertaintyPercent = null;
     if (cpuAccountant) {
       try {
+        // Process discovery is not part of the counter snapshot. Starting the
+        // clock earlier inflates uncertainty with unrelated `ps` latency.
+        cpuClock = readLinuxCpuClock();
         const counters = readLinuxCpuSnapshot(tracked, cpuAccountant.trackedProcessIds());
         cpuClock.finishedMs = performance.now();
         const previousEnd = cpuAccountant.lastSuccessfulClock()?.finishedMs;

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -21604,15 +21604,15 @@ exec /bin/sh -c "$2"
       "live gateway pid reused across samplers"
     );
     assertEqual(
-      lookups.filter((line) => line.includes(missingEnvName)).length,
-      1,
-      "missing gateway pid lookup backs off"
+      lookups.filter((line) => line.includes(missingEnvName)).length >= 3,
+      true,
+      "missing gateway pid lookup retries on the next sample"
     );
     assertEqual(missingSummary.sampleCount >= 3, true, "missing gateway sampler collected repeated samples");
     return {
       id: "resource-gateway-pid-lookups",
       status: "PASS",
-      command: "reuse live gateway pid and back off missing pid lookups",
+      command: "reuse live gateway pid and retry missing pid lookups",
       durationMs: 600
     };
   } catch (error) {

--- a/tests/linux-cpu-accounting.mjs
+++ b/tests/linux-cpu-accounting.mjs
@@ -12,6 +12,23 @@ const clock = (seconds) => ({ hz: 100, ticks: seconds * 100, monotonicMs: second
 const processRow = (pid, ppid, cpuTicks, childCpuTicks = 0, startTicks = 0) => ({ pid, ppid, cpuTicks, childCpuTicks, startTicks, rssMb: 0, command: "synthetic", roles: [] });
 const cpu = (rows) => rows.reduce((total, row) => total + (row.cpuPercent ?? 0), 0);
 
+test("gateway discovery refreshes a census that predates gateway birth", async () => {
+  let censusCount = 0;
+  const root = { pid: 1, ppid: 0, rssKb: 1, rssMb: 1, cpuPercent: 0, command: "kova" };
+  const gateway = { pid: 2, ppid: 1, rssKb: 2, rssMb: 2, cpuPercent: 0, command: "openclaw-gateway" };
+  const sampler = startResourceSampler(1, {
+    envName: `gateway-census-refresh-${Date.now()}`,
+    processLister() {
+      censusCount += 1;
+      return { ok: true, processes: censusCount === 1 ? [root] : [root, gateway] };
+    },
+    gatewayPidLookup: () => 2
+  });
+  const summary = await sampler.stop();
+  assert.ok(censusCount >= 2);
+  assert.equal(summary.byRole.gateway.peakRssMb, 2);
+});
+
 test("serial parent and newborn child use the same CPU interval", () => {
   const accountant = createLinuxCpuAccountant();
   accountant.sample([processRow(1, 0, 0)], clock(0));

--- a/tests/linux-cpu-accounting.mjs
+++ b/tests/linux-cpu-accounting.mjs
@@ -1,8 +1,9 @@
 import fs from "node:fs";
+import childProcess from "node:child_process";
 import { syncBuiltinESMExports } from "node:module";
 import assert from "node:assert/strict";
 import test, { mock } from "node:test";
-import { summarizeResourceSamples } from "../src/collectors/resources.mjs";
+import { startResourceSampler, summarizeResourceSamples } from "../src/collectors/resources.mjs";
 import { checkCpuThreshold } from "../src/evaluation/violations.mjs";
 import { evaluateRecord } from "../src/evaluator.mjs";
 import { createLinuxCpuAccountant, readLinuxCpuSnapshot, LinuxCpuSnapshotChangedError } from "../src/collectors/linux-cpu.mjs";
@@ -216,6 +217,47 @@ test("counter scan brackets yield conservative bounds and never an invented CPU 
   const below = [];
   checkCpuThreshold(below, { kind: "resource", metric: "cpu", label: "CPU", value: 199, lower: 180, threshold: 200 });
   assert.deepEqual(below, []);
+});
+
+test("process census latency stays outside the CPU counter uncertainty window", {
+  skip: process.platform !== "linux"
+}, async () => {
+  let now = 0;
+  let cpuTicks = 0;
+  const originalRead = fs.readFileSync;
+  const originalSpawn = childProcess.spawnSync;
+  mock.method(performance, "now", () => now);
+  mock.method(childProcess, "spawnSync", (command) => {
+    if (command === "getconf") return { status: 0, stdout: "100\n" };
+    if (command === "ps") {
+      now += 100;
+      return { status: 0, pid: 999, stdout: "1 0 1024 0 node\n" };
+    }
+    return originalSpawn(command);
+  });
+  mock.method(fs, "readFileSync", (path, ...args) => {
+    if (path === "/proc/uptime") return `${now / 1000} 0\n`;
+    if (path === "/proc/1/stat") {
+      const fields = Array(22).fill("0");
+      fields[0] = "S";
+      fields[11] = String(cpuTicks);
+      return `1 (node) ${fields.join(" ")}`;
+    }
+    return originalRead(path, ...args);
+  });
+  syncBuiltinESMExports();
+  try {
+    const sampler = startResourceSampler(1);
+    now += 1000;
+    cpuTicks = 100;
+    const summary = await sampler.stop();
+    // The summary rounds the upper bound up and the lower bound down. With no
+    // scan uncertainty, they can therefore differ by at most one tenth.
+    assert.ok(summary.maxTotalCpuPercent - summary.maxTotalCpuPercentLower <= 0.1);
+  } finally {
+    mock.restoreAll();
+    syncBuiltinESMExports();
+  }
 });
 
 test("qualification rejects missing and historical CPU contracts", () => {


### PR DESCRIPTION
## Summary

- preserve the reviewed 250% `status-cli` CPU calibration for OpenClaw 2026.7.33
- backport Kova #118–#120's complete CPU-accounting fixes onto that compatibility lineage
- keep Kova `main` at its normal 200% ceiling

## Why

OpenClaw's 2026.7.33 selector currently has to choose between Kova #116, which owns the historical calibration, and Kova #120, which owns correct process accounting. The exact #120 proof therefore passed 13/15 records but blocked two known status CLI intervals. This compatibility lineage combines both requirements without changing policy for newer OpenClaw releases.

## Validation

- `npm run check` — 280/280 self-checks passed; CPU-accounting suite passed
- exact release-profile proof to follow from the immutable compatibility head

## Worked on by

- Dallin Romney
