### PR TITLE
fix(perf): inherit release gateway CPU calibration

### DIFF
--- a/profiles/release.json
+++ b/profiles/release.json
@@ -78,6 +78,13 @@
       }
     },
     "surfaces": {
+      "fresh-install": {
+        "roleThresholds": {
+          "gateway": {
+            "maxCpuPercent": 300
+          }
+        }
+      },
       "release-runtime-startup": {
         "thresholds": {
           "gatewayReadyMs": 45000,

--- a/src/selfcheck.mjs
+++ b/src/selfcheck.mjs
@@ -711,6 +711,8 @@ async function runScopedSelfCheck(flags, scope, workspace) {
       assertEqual(releaseProfile?.purpose, "release", "release profile purpose");
       assertEqual((releaseProfile?.calibration?.surfaceCount ?? 0) > 0, true, "release profile calibrated surfaces");
       assertEqual((releaseProfile?.calibration?.roleCount ?? 0) > 0, true, "release profile calibrated roles");
+      const freshSurface = data.surfaces.find((surface) => surface.id === "fresh-install");
+      assertEqual(freshSurface?.roleThresholds?.gateway?.maxCpuPercent, 250, "fresh install retains the default gateway CPU cap");
       const officialSurface = data.surfaces.find((surface) => surface.id === "official-plugin-install");
       assertEqual(Boolean(officialSurface), true, "official plugin surface present");
       assertArrayNotEmpty(officialSurface?.purposes, "official plugin surface purposes");
@@ -21302,15 +21304,27 @@ async function releaseResourceCalibrationCheck() {
       freshSurface,
       gatewaySurface,
       bundledPluginSurface,
-      releaseProfile
+      releaseProfile,
+      smokeProfile
     ] = await Promise.all([
       readSelfCheckJson("scenarios", "fresh-install.json"),
       readSelfCheckJson("scenarios", "gateway-performance.json"),
       readSelfCheckJson("surfaces", "fresh-install.json"),
       readSelfCheckJson("surfaces", "gateway-performance.json"),
       readSelfCheckJson("surfaces", "bundled-plugin-startup.json"),
-      readSelfCheckJson("profiles", "release.json")
+      readSelfCheckJson("profiles", "release.json"),
+      readSelfCheckJson("profiles", "smoke.json")
     ]);
+
+    for (const profile of [null, smokeProfile]) {
+      const policy = resolveThresholdPolicy({
+        profile,
+        surface: freshSurface,
+        scenario: freshScenario,
+        nodeVersion: "v24.19.0"
+      });
+      assertEqual(policy.roleThresholds?.gateway?.maxCpuPercent, 250, "non-release fresh install gateway CPU cap");
+    }
 
     const contracts = [
       {
@@ -21318,6 +21332,7 @@ async function releaseResourceCalibrationCheck() {
         scenario: freshScenario,
         surface: freshSurface,
         primaryRssMb: 1177,
+        gatewayCpuPercent: 300,
         roles: { gateway: 1177, "status-cli": 900, "plugin-cli": 900 }
       },
       {
@@ -21346,6 +21361,9 @@ async function releaseResourceCalibrationCheck() {
       if (contract.primaryRssMb !== null) {
         assertEqual(policy.thresholds?.peakRssMb, contract.primaryRssMb, `${contract.id} resolved primary RSS cap`);
         assertEqual(contract.surface?.thresholds?.peakRssMb?.absoluteCeilingMb, 1200, `${contract.id} absolute primary RSS ceiling`);
+      }
+      if (contract.gatewayCpuPercent !== undefined) {
+        assertEqual(policy.roleThresholds?.gateway?.maxCpuPercent, contract.gatewayCpuPercent, `${contract.id} release-profile gateway CPU cap`);
       }
       for (const [role, peakRssMb] of Object.entries(contract.roles)) {
         assertEqual(contract.surface?.processRoles?.includes(role), true, `${contract.id} declares ${role}`);

--- a/tests/snapshots/plan-json.snap
+++ b/tests/snapshots/plan-json.snap
@@ -17422,7 +17422,7 @@
       "targetKinds": null,
       "diagnostics": null,
       "calibration": {
-        "surfaceCount": 18,
+        "surfaceCount": 19,
         "roleCount": 18
       },
       "gate": {


### PR DESCRIPTION
## Summary

- keep the shared fresh-install gateway CPU ceiling at 250%
- add a release-profile-only 300% override through the existing profile surface calibration
- preserve smoke and unprofiled enforcement

## Root cause

Kova #120 corrected late gateway CPU census undercounting. Two consecutive OpenClaw full validations then each produced one noisy fresh-install sample above 250% while the other two repeats passed. The latest samples were 162.4%, 270%, and 176.7%; the aggregate was classified unstable with a 176.7% median.

The release profile already calibrates general gateway CPU at 300%, but fresh-install's shared 250% surface cap shadowed it. This patch scopes the adjustment through `profiles/release.json`; it does not weaken smoke or unprofiled checks.

## Verification

- failing release evidence: OpenClaw run 34272365769, fresh-install/fresh repeat 2
- same run: 14/15 records passed; health, readiness, RSS, dependencies, plugins, and restarts remained clean
- self-check covers release=300%, smoke=250%, and unprofiled=250%
- `npm run check:full` running after exact-head correction; prior 280/280 self-check green
- autoreview rerun in progress

## LOC

Production/config: +7. Tests/snapshot: +18 net.